### PR TITLE
Enhance announcer and gameplay flavor

### DIFF
--- a/dungeoncrawler/constants.py
+++ b/dungeoncrawler/constants.py
@@ -5,4 +5,21 @@ ANNOUNCER_LINES = [
     "You fight with determination.",
     "Your skill improves.",
     "You press the attack.",
+    "The crowd goes wild!",
+    "Fans cheer from across the stars.",
+    "Viewers gasp in suspense.",
+    "Our ratings just spiked!",
+    "Another thrilling moment for our contestant.",
+]
+
+# Simple riddles used for trap rooms. Answer correctly to avoid damage.
+RIDDLES = [
+    (
+        "What walks on four legs in the morning, two legs at noon, and three legs in the evening?",
+        "human",
+    ),
+    (
+        "I speak without a mouth and hear without ears. I have nobody, but I come alive with wind. What am I?",
+        "echo",
+    ),
 ]


### PR DESCRIPTION
## Summary
- expand announcer lines and add simple riddles
- record the floor reached on the leaderboard
- provide puzzle-based traps with announcer praise
- drop audience gifts randomly during exploration
- add announcer commentary for attacks, treasures and items

## Testing
- `python3 -m py_compile dungeoncrawler/*.py`
- `python3 -m dungeoncrawler.main <<'EOF'
TestPlayer
1
7
EOF`


------
https://chatgpt.com/codex/tasks/task_e_688343f334fc83268c26d35caa0b6b9c