### PR TITLE
Add skills for new classes

### DIFF
--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -144,6 +144,13 @@ class Player(Entity):
                 self.status_effects['freeze'] -= 1
             if self.status_effects['freeze'] <= 0:
                 del self.status_effects['freeze']
+        if 'inspire' in self.status_effects:
+            if self.status_effects['inspire'] == 3:
+                self.attack_power += 3
+            self.status_effects['inspire'] -= 1
+            if self.status_effects['inspire'] <= 0:
+                self.attack_power -= 3
+                del self.status_effects['inspire']
 
     def decrement_cooldowns(self):
         if self.skill_cooldown > 0:
@@ -167,6 +174,21 @@ class Player(Entity):
             damage = self.attack_power + random.randint(5, 10)
             print(f"You perform a sneaky Backstab for {damage} damage!")
             enemy.take_damage(damage)
+        elif self.class_type == "Cleric":
+            heal = min(20, self.max_health - self.health)
+            self.health += heal
+            print(f"You invoke Healing Light and recover {heal} health!")
+        elif self.class_type == "Paladin":
+            damage = self.attack_power + random.randint(5, 12)
+            print(f"You smite the {enemy.name} for {damage} holy damage!")
+            enemy.take_damage(damage)
+            heal = min(10, self.max_health - self.health)
+            if heal:
+                self.health += heal
+                print(f"Divine power heals you for {heal} HP!")
+        elif self.class_type == "Bard":
+            print("You play an inspiring tune, bolstering your spirit!")
+            self.status_effects['inspire'] = 3
         else:
             print("You don't have a special skill.")
             return

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,42 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.entities import Player, Enemy
+
+class DummyEnemy(Enemy):
+    def __init__(self):
+        super().__init__("Dummy", 100, 10, 0, 0)
+
+
+def test_cleric_skill_heals():
+    player = Player("test", "Cleric")
+    player.health = player.health - 20
+    enemy = DummyEnemy()
+    player.use_skill(enemy)
+    assert player.health > player.max_health - 20
+    assert player.skill_cooldown > 0
+
+
+def test_paladin_skill_damage_and_heal():
+    player = Player("pal", "Paladin")
+    player.health -= 5
+    enemy = DummyEnemy()
+    enemy_hp = enemy.health
+    player.use_skill(enemy)
+    assert enemy.health < enemy_hp
+    assert player.health > player.max_health - 5
+
+
+def test_bard_inspire_buff():
+    player = Player("bard", "Bard")
+    enemy = DummyEnemy()
+    base_attack = player.attack_power
+    player.use_skill(enemy)
+    assert "inspire" in player.status_effects
+    player.apply_status_effects()
+    assert player.attack_power == base_attack + 3
+    player.apply_status_effects()
+    player.apply_status_effects()
+    assert "inspire" not in player.status_effects
+    assert player.attack_power == base_attack


### PR DESCRIPTION
## Summary
- add `inspire` status for Bard and corresponding player effects
- implement unique class skills for Cleric, Paladin and Bard
- include regression tests for new skills

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688378db3e508326adf20af21a8e638a