### PR TITLE
Award boss loot to player

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -830,6 +830,12 @@ class DungeonBase:
 
         if not enemy.is_alive():
             self.announce(f"{enemy.name} has been defeated!")
+            # Award boss-specific loot directly to the player
+            if enemy.name in BOSS_LOOT:
+                loot = random.choice(BOSS_LOOT[enemy.name])
+                self.player.collect_item(loot)
+                print(f"The {enemy.name} dropped {loot.name}!")
+                self.announce(f"{self.player.name} obtains {loot.name}!")
 
     def audience_gift(self):
         if random.random() < 0.1:

--- a/tests/test_boss_loot.py
+++ b/tests/test_boss_loot.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import random
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.dungeon import DungeonBase, BOSS_LOOT
+from dungeoncrawler.entities import Player, Enemy
+
+
+def test_boss_drops_loot(monkeypatch):
+    game = DungeonBase(1, 1)
+    game.player = Player("Hero")
+    boss_name = next(iter(BOSS_LOOT))
+    enemy = Enemy(boss_name, 1, 0, 0, 0)
+
+    monkeypatch.setattr('builtins.input', lambda _: '1')
+    monkeypatch.setattr(random, 'choice', lambda seq: seq[0])
+
+    game.battle(enemy)
+
+    assert BOSS_LOOT[boss_name][0] in game.player.inventory


### PR DESCRIPTION
## Summary
- Grant players a random loot drop when defeating bosses, adding the item directly to inventory with announcer callouts.
- Add test ensuring boss defeats award the appropriate loot item.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a4f0e99c48326b2498f564f795605