### PR TITLE
Add selling option to shop

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -771,9 +771,12 @@ class DungeonBase:
         for i, item in enumerate(self.shop_items, 1):
             price = item.price if isinstance(item, Weapon) else 10
             print(f"{i}. {item.name} - {price} Gold")
-        print(f"{len(self.shop_items)+1}. Exit")
+        sell_option = len(self.shop_items) + 1
+        exit_option = sell_option + 1
+        print(f"{sell_option}. Sell Items")
+        print(f"{exit_option}. Exit")
 
-        choice = input("Buy what?")
+        choice = input("Choose an option:")
         if choice.isdigit():
             choice = int(choice)
             if 1 <= choice <= len(self.shop_items):
@@ -785,8 +788,55 @@ class DungeonBase:
                     print(f"You bought {item.name}.")
                 else:
                     print("Not enough gold.")
-            elif choice == len(self.shop_items) + 1:
+            elif choice == sell_option:
+                self.sell_items()
+            elif choice == exit_option:
                 print("Leaving the shop.")
+            else:
+                print("Invalid choice.")
+        else:
+            print("Invalid input.")
+
+    def get_sale_price(self, item):
+        if isinstance(item, Weapon):
+            price = getattr(item, "price", 0)
+            if price > 0:
+                return price // 2
+            return None
+        if isinstance(item, Item):
+            return 5
+        return None
+
+    def sell_items(self):
+        if not self.player.inventory:
+            print("You have nothing to sell.")
+            return
+
+        print("Your Items:")
+        for i, item in enumerate(self.player.inventory, 1):
+            sale_price = self.get_sale_price(item)
+            if sale_price is None:
+                print(f"{i}. {item.name} - Cannot sell")
+            else:
+                print(f"{i}. {item.name} - {sale_price} Gold")
+        print(f"{len(self.player.inventory)+1}. Back")
+
+        choice = input("Sell what?")
+        if choice.isdigit():
+            choice = int(choice)
+            if 1 <= choice <= len(self.player.inventory):
+                item = self.player.inventory[choice - 1]
+                sale_price = self.get_sale_price(item)
+                if sale_price is None:
+                    print("You can't sell that item.")
+                    return
+                confirm = input(f"Sell {item.name} for {sale_price} gold? (y/n) ")
+                if confirm.lower() == 'y':
+                    self.player.inventory.pop(choice - 1)
+                    self.player.gold += sale_price
+                    print(f"You sold {item.name}.")
+            elif choice == len(self.player.inventory) + 1:
+                return
             else:
                 print("Invalid choice.")
         else:

--- a/tests/test_shop.py
+++ b/tests/test_shop.py
@@ -4,6 +4,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from dungeoncrawler.dungeon import DungeonBase
 from dungeoncrawler.entities import Player
+from dungeoncrawler.items import Item, Weapon
 
 
 def test_shop_purchase(monkeypatch):
@@ -14,3 +15,38 @@ def test_shop_purchase(monkeypatch):
     dungeon.shop()
     assert dungeon.player.gold == 10
     assert any(item.name == 'Health Potion' for item in dungeon.player.inventory)
+
+
+def test_sell_weapon(monkeypatch):
+    dungeon = DungeonBase(1, 1)
+    dungeon.player = Player("Seller")
+    weapon = Weapon("Sword", "A sharp sword", 10, 15, 40)
+    dungeon.player.collect_item(weapon)
+    inputs = iter(['1', 'y'])
+    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+    dungeon.sell_items()
+    assert dungeon.player.gold == 20
+    assert weapon not in dungeon.player.inventory
+
+
+def test_sell_item(monkeypatch):
+    dungeon = DungeonBase(1, 1)
+    dungeon.player = Player("Seller")
+    potion = Item("Health Potion", "Restores 20 health")
+    dungeon.player.collect_item(potion)
+    inputs = iter(['1', 'y'])
+    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+    dungeon.sell_items()
+    assert dungeon.player.gold == 5
+    assert potion not in dungeon.player.inventory
+
+
+def test_sell_unsellable(monkeypatch):
+    dungeon = DungeonBase(1, 1)
+    dungeon.player = Player("Seller")
+    rare_weapon = Weapon("Elven Longbow", "Bow", 15, 25, 0)
+    dungeon.player.collect_item(rare_weapon)
+    monkeypatch.setattr('builtins.input', lambda _: '1')
+    dungeon.sell_items()
+    assert dungeon.player.gold == 0
+    assert rare_weapon in dungeon.player.inventory


### PR DESCRIPTION
## Summary
- extend shop with "Sell Items" option and selling workflow
- add tests for selling weapons, items, and unsellable loot

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a56c4a7188326aface9cb02d12068