### PR TITLE
Add companion assist mechanics with battle integration and tests

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -699,6 +699,10 @@ class DungeonBase:
         self.announce(f"{self.player.name} engages {enemy.name}!")
         while self.player.is_alive() and enemy.is_alive():
             self.player.apply_status_effects()
+            for companion in getattr(self.player, 'companions', []):
+                companion.assist(self.player, enemy)
+            if not enemy.is_alive():
+                break
             if 'freeze' in self.player.status_effects:
                 print("\u2744\ufe0f You are frozen and skip this turn!")
                 self.player.status_effects['freeze'] -= 1

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -431,8 +431,38 @@ class Enemy(Entity):
         print(f"The {self.name} attacked you and dealt {damage} damage.")
 
 class Companion(Entity):
-    """NPC ally that grants a minor permanent bonus when recruited."""
+    """NPC ally that can aid the player during combat.
 
-    def __init__(self, name, effect):
+    Companions may be offensive or supportive.  Attack-oriented
+    companions deal a small amount of damage to the enemy each round,
+    while healer companions restore a bit of the player's health.  The
+    previously existing ``effect`` attribute remains for future use
+    (e.g. passive bonuses) but is optional.
+    """
+
+    def __init__(self, name, effect=None, attack_power=0, heal_amount=0):
         super().__init__(name, "A loyal companion")
         self.effect = effect
+        self.attack_power = attack_power
+        self.heal_amount = heal_amount
+
+    def assist(self, player, enemy):
+        """Perform the companion's action for the round.
+
+        Parameters
+        ----------
+        player : :class:`Player`
+            The player being assisted.
+        enemy : :class:`Enemy`
+            The current enemy, if any.
+        """
+
+        if self.attack_power and enemy.is_alive():
+            dmg = random.randint(max(1, self.attack_power // 2), self.attack_power)
+            enemy.take_damage(dmg)
+            print(f"{self.name} strikes {enemy.name} for {dmg} damage!")
+        if self.heal_amount and player.is_alive():
+            heal = min(self.heal_amount, player.max_health - player.health)
+            if heal > 0:
+                player.health += heal
+                print(f"{self.name} heals {player.name} for {heal} HP!")

--- a/tests/test_companions.py
+++ b/tests/test_companions.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import random
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player, Enemy, Companion
+
+
+def test_attack_companion_deals_damage(monkeypatch):
+    game = DungeonBase(1, 1)
+    game.player = Player("Hero")
+    enemy = Enemy("Goblin", 5, 0, 0, 0)
+    wolf = Companion("Wolf", attack_power=5)
+    game.player.companions.append(wolf)
+
+    monkeypatch.setattr('builtins.input', lambda _: '2')  # defend
+    monkeypatch.setattr(random, 'randint', lambda a, b: b)
+
+    game.battle(enemy)
+
+    assert enemy.health == 0
+
+
+def test_healer_companion_restores_health(monkeypatch):
+    game = DungeonBase(1, 1)
+    game.player = Player("Hero")
+    game.player.health = 50
+    enemy = Enemy("Goblin", 1, 0, 0, 0)
+    healer = Companion("Cleric", heal_amount=10)
+    game.player.companions.append(healer)
+
+    monkeypatch.setattr('builtins.input', lambda _: '1')  # attack
+    monkeypatch.setattr(random, 'randint', lambda a, b: b)
+
+    game.battle(enemy)
+
+    assert game.player.health == 60


### PR DESCRIPTION
## Summary
- Extend `Companion` with attack and healing capabilities and an `assist` method
- Invoke companion assistance each battle round so allies can attack or heal
- Add tests covering offensive and healing companion behaviors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a56c2b724832686b4db694e6c57b9