### PR TITLE
Load riddles from JSON and expand trap puzzles

### DIFF
--- a/data/riddles.json
+++ b/data/riddles.json
@@ -1,0 +1,42 @@
+[
+  {
+    "question": "What walks on four legs in the morning, two legs at noon, and three legs in the evening?",
+    "answer": "human"
+  },
+  {
+    "question": "I speak without a mouth and hear without ears. I have nobody, but I come alive with wind. What am I?",
+    "answer": "echo"
+  },
+  {
+    "question": "What has keys but can't open locks?",
+    "answer": "piano"
+  },
+  {
+    "question": "What has hands but cannot clap?",
+    "answer": "clock"
+  },
+  {
+    "question": "What has a heart that doesn't beat?",
+    "answer": "artichoke"
+  },
+  {
+    "question": "What can travel around the world while staying in a corner?",
+    "answer": "stamp"
+  },
+  {
+    "question": "What has one eye but cannot see?",
+    "answer": "needle"
+  },
+  {
+    "question": "The more of this there is, the less you see. What is it?",
+    "answer": "darkness"
+  },
+  {
+    "question": "What gets wetter the more it dries?",
+    "answer": "towel"
+  },
+  {
+    "question": "What building has the most stories?",
+    "answer": "library"
+  }
+]

--- a/dungeoncrawler/constants.py
+++ b/dungeoncrawler/constants.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+import json
+
 SAVE_FILE = "savegame.json"
 SCORE_FILE = "scores.json"
 ANNOUNCER_LINES = [
@@ -12,14 +15,24 @@ ANNOUNCER_LINES = [
     "Another thrilling moment for our contestant.",
 ]
 
+
+def load_riddles():
+    """Load riddles from the JSON data file.
+
+    The file is expected to contain a list of objects with ``question`` and
+    ``answer`` fields.  Answers are stored in lower case for easy
+    comparisons during gameplay.
+    """
+
+    data_dir = Path(__file__).resolve().parent.parent / "data"
+    path = data_dir / "riddles.json"
+    with open(path) as f:
+        riddles = json.load(f)
+    # Normalise answers for case-insensitive comparison
+    for r in riddles:
+        r["answer"] = r["answer"].lower()
+    return riddles
+
+
 # Simple riddles used for trap rooms. Answer correctly to avoid damage.
-RIDDLES = [
-    (
-        "What walks on four legs in the morning, two legs at noon, and three legs in the evening?",
-        "human",
-    ),
-    (
-        "I speak without a mouth and hear without ears. I have nobody, but I come alive with wind. What am I?",
-        "echo",
-    ),
-]
+RIDDLES = load_riddles()

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -666,11 +666,11 @@ class DungeonBase:
             self.room_names[y][x] = "Sacred Sanctuary"
 
         elif room == "Trap":
-            riddle, answer = random.choice(RIDDLES)
+            riddle = random.choice(RIDDLES)
             print("A trap springs! Solve this riddle to escape unharmed:")
-            print(riddle)
+            print(riddle["question"])
             response = input("Answer: ").strip().lower()
-            if response == answer:
+            if response == riddle["answer"].lower():
                 print("The mechanism clicks harmlessly. You solved it!")
                 self.announce("Brilliant puzzle solving!")
             else:

--- a/tests/test_riddles.py
+++ b/tests/test_riddles.py
@@ -1,0 +1,28 @@
+import builtins
+
+from dungeoncrawler import constants
+from dungeoncrawler import dungeon as dungeon_module
+from dungeoncrawler.entities import Player
+
+
+def test_riddles_loaded_and_used(monkeypatch, capsys):
+    # Ensure riddles were loaded from the data file and contain many entries
+    assert isinstance(constants.RIDDLES, list)
+    assert len(constants.RIDDLES) >= 5
+
+    chosen = constants.RIDDLES[-1]
+    # Restrict the riddles list in the dungeon module so the trap must use our chosen riddle
+    monkeypatch.setattr(dungeon_module, "RIDDLES", [chosen])
+    monkeypatch.setattr(builtins, "input", lambda _: chosen["answer"])
+
+    dungeon = dungeon_module.DungeonBase(2, 1)
+    dungeon.player = Player("Hero")
+    # Position the player and a trap in the dungeon
+    dungeon.rooms[0][0] = "Trap"
+    dungeon.rooms[0][1] = dungeon.player
+    dungeon.player.x = 1
+    dungeon.player.y = 0
+
+    dungeon.handle_room(0, 0)
+    out = capsys.readouterr().out
+    assert chosen["question"] in out


### PR DESCRIPTION
## Summary
- Load riddles from `data/riddles.json` via new helper in `constants`
- Update trap rooms to use question/answer objects
- Add larger riddle dataset and unit test for trap selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a56d13d508326ad893991dfc19cc6