### PR TITLE
Add plugin system for mod support

### DIFF
--- a/docs/modding.md
+++ b/docs/modding.md
@@ -1,0 +1,49 @@
+# Modding the Dungeon Crawler
+
+The game now supports lightweight plug-ins that can extend enemies and items.
+Mods live inside the top level `mods/` package.  Each mod is a normal Python
+package placed in its own subdirectory, e.g. `mods/my_mod/`.
+
+```
+mods/
+└── my_mod/
+    ├── __init__.py
+    └── data/
+        ├── enemies.json  # optional
+        └── items.json    # optional
+```
+
+## Plugin hooks
+
+A mod can expose two optional functions in its `__init__` module:
+
+```python
+# mods/my_mod/__init__.py
+from dungeoncrawler.items import Weapon
+
+def register_enemies(enemy_stats, enemy_abilities):
+    enemy_stats["Gelatinous Cube"] = (30, 5, 8, 12, 2)
+    enemy_abilities["Gelatinous Cube"] = "dissolve"
+
+def register_items(shop_items):
+    shop_items.append(Weapon("Rusty Pike", "Barely holds together", 3, 6, 5))
+```
+
+`register_enemies` receives the global enemy dictionaries and can add new
+entries.  `register_items` is handed the list of shop items used when the game
+starts.
+
+## Supplying JSON data
+
+Instead of using Python hooks, mods may ship JSON files.  Place them in a
+`data` directory inside the mod:
+
+- `enemies.json` follows the same schema as the built-in `data/enemies.json`.
+- `items.json` can contain two lists: `weapons` and `items`, each with the
+  appropriate fields for `Weapon` or `Item` objects.
+
+These files are automatically discovered and merged into the game's data during
+initialisation.
+
+After creating your mod, launch the game normally and it will automatically
+load any modules found under `mods/`.

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from .constants import SAVE_FILE, SCORE_FILE, ANNOUNCER_LINES, RIDDLES
 from .entities import Player, Enemy, Companion
 from .items import Item, Weapon
+from .plugins import apply_enemy_plugins, apply_item_plugins
 
 # ---------------------------------------------------------------------------
 # Data loading utilities
@@ -67,6 +68,7 @@ def load_bosses():
 
 ENEMY_STATS, ENEMY_ABILITIES = load_enemies()
 BOSS_STATS, BOSS_LOOT = load_bosses()
+apply_enemy_plugins(ENEMY_STATS, ENEMY_ABILITIES)
 # Floor specific configuration
 FLOOR_CONFIGS = {
     1: {
@@ -213,6 +215,7 @@ class DungeonBase:
             Weapon("Dwarven Waraxe", "Forged in the deep halls.", 12, 20, 0),
             Item("Shadow Cloak", "Grants an air of mystery")
         ]
+        apply_item_plugins(self.shop_items)
 
     def announce(self, msg):
         print(f"[Announcer] {random.choice(ANNOUNCER_LINES)} {msg}")

--- a/dungeoncrawler/plugins.py
+++ b/dungeoncrawler/plugins.py
@@ -1,0 +1,47 @@
+import importlib
+import pkgutil
+from pathlib import Path
+import json
+
+from .items import Item, Weapon
+
+MODS_DIR = Path(__file__).resolve().parent.parent / "mods"
+
+def discover_plugins():
+    """Return imported plugin modules found under :mod:`mods` package."""
+    if not MODS_DIR.exists():
+        return []
+    return [importlib.import_module(f"mods.{m.name}") for m in pkgutil.iter_modules([str(MODS_DIR)])]
+
+def _load_json_from_mod(mod, filename):
+    mod_path = Path(mod.__file__).parent
+    json_path = mod_path / "data" / filename
+    if json_path.exists():
+        with open(json_path) as f:
+            return json.load(f)
+    return None
+
+def apply_enemy_plugins(enemy_stats, enemy_abilities):
+    """Augment enemy dictionaries with contributions from mods."""
+    for mod in discover_plugins():
+        data = _load_json_from_mod(mod, "enemies.json")
+        if data:
+            for name, cfg in data.items():
+                enemy_stats[name] = tuple(cfg["stats"])
+                ability = cfg.get("ability")
+                if ability:
+                    enemy_abilities[name] = ability
+        if hasattr(mod, "register_enemies"):
+            mod.register_enemies(enemy_stats, enemy_abilities)
+
+def apply_item_plugins(shop_items):
+    """Append new items to ``shop_items`` list via JSON or hooks."""
+    for mod in discover_plugins():
+        data = _load_json_from_mod(mod, "items.json")
+        if data:
+            for cfg in data.get("weapons", []):
+                shop_items.append(Weapon(**cfg))
+            for cfg in data.get("items", []):
+                shop_items.append(Item(**cfg))
+        if hasattr(mod, "register_items"):
+            mod.register_items(shop_items)

--- a/mods/__init__.py
+++ b/mods/__init__.py
@@ -1,0 +1,5 @@
+"""Package containing user-created mods.
+
+Mods are discovered at runtime by :mod:`dungeoncrawler.plugins`.
+Each submodule can contribute additional content to the game.
+"""


### PR DESCRIPTION
## Summary
- add plugin discovery under `mods/` using `pkgutil`
- provide hooks for mods to register enemies and items
- load extra JSON from mods and document modding workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a59ccc64c8326a713d1affaa4e0ed