### PR TITLE
Introduce configurable settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ profile_default/
 # Temporary Save Files
 savegame.json
 scores.json
+config.json
 
 # OS generated files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ python3 -m dungeoncrawler
 
 Make sure the file is executable if you wish to launch it with `./dungeon_crawler.py`.
 
+## Configuration
+
+Game settings are loaded from `config.json` if present. Copy the provided
+`config.example.json` and adjust values as needed:
+
+```bash
+cp config.example.json config.json
+```
+
+The defaults mirror previous hard-coded values so the game will run even if
+no custom configuration is supplied.
+
 ## Running the Game
 
 When launching the game you start by entering a name. Your class is chosen on

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,7 @@
+{
+  "save_file": "savegame.json",
+  "score_file": "scores.json",
+  "max_floors": 18,
+  "screen_width": 10,
+  "screen_height": 10
+}

--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.json"
+
+
+@dataclass
+class Config:
+    """Game configuration loaded from ``config.json``.
+
+    Defaults mirror the previous hard-coded constants so the game remains
+    playable even if no configuration file is provided.
+    """
+
+    save_file: str = "savegame.json"
+    score_file: str = "scores.json"
+    max_floors: int = 18
+    screen_width: int = 10
+    screen_height: int = 10
+
+
+def load_config(path: Path = CONFIG_PATH) -> Config:
+    """Load configuration from ``path`` if it exists.
+
+    Parameters
+    ----------
+    path:
+        Location of the JSON configuration file.  Defaults to
+        ``config.json`` in the project root.
+
+    Returns
+    -------
+    Config
+        A :class:`Config` instance populated with values from the JSON file or
+        falling back to defaults when the file or specific keys are missing.
+    """
+
+    cfg = Config()
+    if path.exists():
+        try:
+            data: dict[str, Any] = json.loads(path.read_text())
+        except json.JSONDecodeError:
+            return cfg
+        for key, value in data.items():
+            if hasattr(cfg, key):
+                setattr(cfg, key, value)
+    return cfg
+
+
+# Load configuration at import so other modules can simply import ``config``.
+config = load_config()

--- a/dungeoncrawler/constants.py
+++ b/dungeoncrawler/constants.py
@@ -1,8 +1,14 @@
 from pathlib import Path
 import json
 
-SAVE_FILE = "savegame.json"
-SCORE_FILE = "scores.json"
+from .config import config
+
+# Configuration-driven values
+SAVE_FILE = config.save_file
+SCORE_FILE = config.score_file
+MAX_FLOORS = config.max_floors
+SCREEN_WIDTH = config.screen_width
+SCREEN_HEIGHT = config.screen_height
 ANNOUNCER_LINES = [
     "A decisive blow!",
     "You fight with determination.",

--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -8,6 +8,7 @@ race and guild selections are deferred to later floors and offered by the
 
 from .dungeon import DungeonBase
 from .entities import Player
+from .config import load_config
 
 
 def build_character():
@@ -30,7 +31,8 @@ def build_character():
 
 
 def main():
-    game = DungeonBase(10, 10)
+    cfg = load_config()
+    game = DungeonBase(cfg.screen_width, cfg.screen_height)
     cont = input("Load existing save? (y/n): ").strip().lower()
     if cont != "y":
         game.player = build_character()


### PR DESCRIPTION
## Summary
- add `Config` dataclass that loads game settings from `config.json`
- drive save, score, and size constants from configuration
- document `config.example.json` for user customization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a59c5d0e48326b7020311e653d74b