### PR TITLE
Add CI workflow with testing and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint
+        run: python -m flake8 --max-line-length=200 --extend-ignore=E231,E302,E402
+      - name: Test
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dungeon Crawler
 
+[![CI](https://github.com/OWNER/Dungeon-Crawler/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/Dungeon-Crawler/actions/workflows/ci.yml)
+
 Dungeon Crawler is a small text-based adventure that borrows the core ideas of the *Dungeon Crawler Carl* novels while toning down the humor. Guide your hero through procedurally generated floors filled with monsters, treasure, and meaningful character choices.
 
 ## Installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flake8
+pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running flake8 and pytest on Python 3.10 and 3.11
- cache pip dependencies for faster builds
- show workflow status badge in README

## Testing
- `python -m flake8 --max-line-length=200 --extend-ignore=E231,E302,E402`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a59c256c08326953a47ce91aefd42