### PR TITLE
Add configurable floor events

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ Progress is automatically saved whenever you clear a floor. On the next launch y
 - Floors grow in size and feature unique enemy and boss sets.
 - Battle through 18 floors of escalating challenge.
 
+## Floor Events
+
+Some floors can trigger a random special event:
+
+- **Merchant** – a travelling trader who opens the shop.
+- **Puzzle** – answer a riddle correctly to gain 50 gold.
+- **Trap** – a hidden device springs and harms the player.
+
+Events are configured per floor through `FLOOR_CONFIGS` and one is
+selected at random when the floor is reached.
+
 ## Example
 
 The game can also be driven programmatically:

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from .constants import SAVE_FILE, SCORE_FILE, ANNOUNCER_LINES, RIDDLES
 from .entities import Player, Enemy, Companion
 from .items import Item, Weapon
+from .events import EVENT_TYPES
 
 # ---------------------------------------------------------------------------
 # Data loading utilities
@@ -92,6 +93,7 @@ FLOOR_CONFIGS = {
         "enemies": ["Basilisk", "Gargoyle", "Troll", "Lich"],
         "bosses": ["Void Serpent", "Ember Lord", "Glacier Fiend"],
         "places": {"Trap": 4, "Treasure": 4, "Enchantment": 2, "Sanctuary": 2, "Blacksmith": 1},
+        "events": ["Merchant", "Puzzle", "Trap"],
     },
     5: {
         "size": (12, 12),
@@ -938,6 +940,13 @@ class DungeonBase:
     # Floor-specific events keep gameplay varied without hardcoding logic in
     # play_game. Additional floors can be added here easily.
     def trigger_floor_event(self, floor):
+        config = FLOOR_CONFIGS.get(floor, {})
+        if "events" in config:
+            event_name = random.choice(config["events"])
+            event_cls = EVENT_TYPES[event_name]
+            event = event_cls()
+            event.trigger(self)
+            return
         events = {
             1: self._floor_one_event,
             2: self._floor_two_event,

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -1,0 +1,62 @@
+"""Event classes used by the dungeon crawler game.
+
+The events encapsulate special encounters that may occur when
+descending to new floors. Each event exposes a :meth:`trigger` method
+that operates on the :class:`~dungeoncrawler.dungeon.DungeonBase`
+instance passed to it.
+"""
+
+from __future__ import annotations
+
+import random
+
+from .constants import RIDDLES
+
+
+class BaseEvent:
+    """Base class for floor events."""
+
+    name = "base"
+
+    def trigger(self, dungeon: "DungeonBase") -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class MerchantEvent(BaseEvent):
+    """A travelling merchant appears and opens a shop."""
+
+    name = "Merchant"
+
+    def trigger(self, dungeon: "DungeonBase") -> None:
+        dungeon.shop()
+
+
+class PuzzleEvent(BaseEvent):
+    """A riddle challenge that rewards gold if answered correctly."""
+
+    name = "Puzzle"
+
+    def trigger(self, dungeon: "DungeonBase") -> None:
+        riddle = random.choice(RIDDLES)
+        print(riddle["question"])
+        response = input("Answer: ").strip().lower()
+        if response == riddle["answer"]:
+            reward = 50
+            print(f"Correct! You receive {reward} gold.")
+            dungeon.player.gold += reward
+        else:
+            print("Incorrect! The puzzle resets.")
+
+
+class TrapEvent(BaseEvent):
+    """A simple trap that harms the player."""
+
+    name = "Trap"
+
+    def trigger(self, dungeon: "DungeonBase") -> None:
+        damage = 10
+        print(f"A hidden trap springs! You take {damage} damage.")
+        dungeon.player.take_damage(damage)
+
+
+EVENT_TYPES = {cls.name: cls for cls in (MerchantEvent, PuzzleEvent, TrapEvent)}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,40 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+
+
+def setup_dungeon():
+    dungeon = DungeonBase(5, 5)
+    dungeon.player = Player("hero")
+    return dungeon
+
+
+def test_merchant_event_calls_shop():
+    dungeon = setup_dungeon()
+    with patch("dungeoncrawler.dungeon.random.choice", return_value="Merchant"), \
+         patch.object(DungeonBase, "shop") as mock_shop:
+        dungeon.trigger_floor_event(4)
+        assert mock_shop.called
+
+
+def test_puzzle_event_rewards_gold():
+    dungeon = setup_dungeon()
+    riddle = {"question": "What has keys but can't open locks?", "answer": "piano"}
+    with patch("dungeoncrawler.dungeon.random.choice", side_effect=["Puzzle", riddle]), \
+         patch("builtins.input", return_value="piano"):
+        gold_before = dungeon.player.gold
+        dungeon.trigger_floor_event(4)
+        assert dungeon.player.gold == gold_before + 50
+
+
+def test_trap_event_deals_damage():
+    dungeon = setup_dungeon()
+    with patch("dungeoncrawler.dungeon.random.choice", return_value="Trap"):
+        health_before = dungeon.player.health
+        dungeon.trigger_floor_event(4)
+        assert dungeon.player.health == health_before - 10


### PR DESCRIPTION
## Summary
- add MerchantEvent, PuzzleEvent and TrapEvent classes
- register floor events in configs with random selection
- document new event types and test their behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a59c895a08326bc34bc7b75e7be54