### PR TITLE
Add status effects and enemy AI

### DIFF
--- a/dungeoncrawler/ai.py
+++ b/dungeoncrawler/ai.py
@@ -1,0 +1,14 @@
+class AggressiveAI:
+    """Simple AI that always chooses to attack."""
+
+    def choose_action(self, enemy, player):
+        return "attack"
+
+
+class DefensiveAI:
+    """AI that prioritizes defense when health is low."""
+
+    def choose_action(self, enemy, player):
+        if enemy.health <= enemy.max_health // 2 and 'shield' not in enemy.status_effects:
+            return "defend"
+        return "attack"

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -749,18 +749,16 @@ class DungeonBase:
         print(f"You encountered a {enemy.name}! {enemy.ability.capitalize() if enemy.ability else ''} Boss incoming!")
         self.announce(f"{self.player.name} engages {enemy.name}!")
         while self.player.is_alive() and enemy.is_alive():
-            self.player.apply_status_effects()
+            skip_player = self.player.apply_status_effects()
             for companion in getattr(self.player, 'companions', []):
                 companion.assist(self.player, enemy)
             if not enemy.is_alive():
                 break
-            if 'freeze' in self.player.status_effects:
-                print("\u2744\ufe0f You are frozen and skip this turn!")
-                self.player.status_effects['freeze'] -= 1
-                if self.player.status_effects['freeze'] <= 0:
-                    del self.player.status_effects['freeze']
+            if skip_player:
                 if enemy.is_alive():
-                    enemy.attack(self.player)
+                    skip = enemy.apply_status_effects()
+                    if enemy.is_alive() and not skip:
+                        enemy.take_turn(self.player)
                 continue
 
             print(f"Player Health: {self.player.health}")
@@ -773,26 +771,26 @@ class DungeonBase:
                 if enemy.is_alive():
                     skip = enemy.apply_status_effects()
                     if enemy.is_alive() and not skip:
-                        enemy.attack(self.player)
+                        enemy.take_turn(self.player)
             elif choice == "2":
                 self.player.defend(enemy)
                 if enemy.is_alive():
                     skip = enemy.apply_status_effects()
                     if enemy.is_alive() and not skip:
-                        enemy.attack(self.player)
+                        enemy.take_turn(self.player)
             elif choice == "3":
                 self.player.use_health_potion()
                 if enemy.is_alive():
                     skip = enemy.apply_status_effects()
                     if enemy.is_alive() and not skip:
-                        enemy.attack(self.player)
+                        enemy.take_turn(self.player)
             elif choice == "4":
                 self.player.use_skill(enemy)
                 self.announce("Special skill unleashed!")
                 if enemy.is_alive():
                     skip = enemy.apply_status_effects()
                     if enemy.is_alive() and not skip:
-                        enemy.attack(self.player)
+                        enemy.take_turn(self.player)
             else:
                 print("Invalid choice!")
             self.player.decrement_cooldowns()

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -1,11 +1,13 @@
 import os
 import sys
 import random
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import pytest
 
 from dungeoncrawler.entities import Player, Enemy, Weapon
+from dungeoncrawler.ai import AggressiveAI, DefensiveAI
 
 
 @pytest.fixture
@@ -46,3 +48,42 @@ def test_status_effects_tick():
     p.apply_status_effects()
     assert p.health == 47
     assert p.status_effects['poison'] == 1
+
+
+def test_bleed_effect():
+    p = Player("Hero")
+    p.health = 30
+    p.status_effects['bleed'] = 2
+    p.apply_status_effects()
+    assert p.health == 28
+    assert p.status_effects['bleed'] == 1
+
+
+def test_stun_effect_skips_enemy_turn():
+    e = Enemy("Orc", 20, 5, 0, 5)
+    e.status_effects['stun'] = 1
+    skip = e.apply_status_effects()
+    assert skip is True
+    assert 'stun' not in e.status_effects
+
+
+def test_shield_reduces_damage():
+    e = Enemy("Orc", 20, 10, 0, 0)
+    e.status_effects['shield'] = 1
+    e.take_damage(10)
+    assert e.health == 15
+
+
+def test_aggressive_ai_attacks(player):
+    enemy = Enemy("Goblin", 20, 6, 0, 0, ai=AggressiveAI())
+    initial = player.health
+    random.seed(0)
+    enemy.take_turn(player)
+    assert player.health < initial
+
+
+def test_defensive_ai_defends(player):
+    enemy = Enemy("Goblin", 20, 6, 0, 0, ai=DefensiveAI())
+    enemy.health = 5
+    enemy.take_turn(player)
+    assert 'shield' in enemy.status_effects


### PR DESCRIPTION
## Summary
- Add support for bleed, stun and shield effects on players and enemies
- Introduce AggressiveAI and DefensiveAI for enemy decision making
- Integrate AI-driven turns into the combat loop
- Expand combat tests for new effects and AI behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a59c9734083268f893e794ec9d5ab