### PR TITLE
Use curses renderer with map legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,16 @@ floor one, a guild becomes available on floor two, and races are unlocked on
 floor three. Use the number menu to explore rooms, fight monsters, visit
 shops, and descend deeper into the dungeon.
 
-At any time you may choose **8. Show Map** to display a grid of the dungeon. The map marks your location with `@`, rooms you've visited with `.`, and unexplored or blocked rooms with `#`.
+At any time you may choose **8. Show Map** to display a grid of the dungeon.
+The map is rendered using ``curses`` with coloured symbols:
+
+- `@` – your current position (cyan)
+- `.` – rooms you have visited (white)
+- `#` – unexplored or blocked rooms (grey)
+- `E` – the exit to the next floor (magenta)
+
+While viewing the map press `?` to toggle a legend describing these symbols.
+Press `q` (or `ESC`) to exit the map view and return to the game.
 
 Progress is automatically saved whenever you clear a floor. On the next launch you will be asked if you want to continue.
 

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -606,17 +606,16 @@ class DungeonBase:
             print("You can't move that way.")
 
     def render_map(self):
-        for y in range(self.height):
-            row = ""
-            for x in range(self.width):
-                pos = (x, y)
-                if pos == (self.player.x, self.player.y):
-                    row += "@"
-                elif pos in self.visited_rooms or pos == self.exit_coords:
-                    row += "."
-                else:
-                    row += "#"
-            print(row)
+        """Display a coloured map using :mod:`curses`.
+
+        This delegates to :class:`dungeoncrawler.map.MapRenderer` which
+        handles colour output and the optional legend that can be toggled by
+        pressing ``?``.  Press ``q`` or ``ESC`` to exit the map view.
+        """
+
+        from .map import MapRenderer
+
+        MapRenderer(self).run()
 
     def handle_room(self, x, y):
         room = self.rooms[y][x]

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -1,0 +1,170 @@
+"""Utility for rendering the dungeon map.
+
+This module provides a :class:`MapRenderer` that can draw the current
+state of a :class:`~dungeoncrawler.dungeon.DungeonBase` instance using the
+`curses` library.  The renderer colours different tile types and supports
+displaying a small legend that explains the symbols.  The legend can be
+toggle at runtime by pressing ``?`` when the map is displayed.
+
+The renderer also exposes :meth:`MapRenderer.render_to_string` which
+generates the coloured map as a plain string.  This is used by the unit
+tests to perform snapshot style assertions without requiring a real
+terminal environment.
+"""
+
+from __future__ import annotations
+
+import curses
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Colour and symbol configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TileAppearance:
+    symbol: str
+    colour_name: str
+
+
+TILES: Dict[str, TileAppearance] = {
+    "player": TileAppearance("@", "player"),
+    "visited": TileAppearance(".", "visited"),
+    "unseen": TileAppearance("#", "unseen"),
+    "exit": TileAppearance("E", "exit"),
+}
+
+
+COLOUR_PAIRS = {
+    "player": 1,
+    "visited": 2,
+    "unseen": 3,
+    "exit": 4,
+}
+
+# ANSI colour codes used for ``render_to_string``.  These mirror the curses
+# colours but allow tests to easily assert the output of the renderer.
+ANSI_COLOURS = {
+    "player": 36,  # cyan
+    "visited": 37,  # white
+    "unseen": 90,  # bright black / grey
+    "exit": 35,  # magenta
+}
+
+LEGEND = {
+    TILES["player"].symbol: "Player",
+    TILES["visited"].symbol: "Visited",
+    TILES["unseen"].symbol: "Unseen",
+    TILES["exit"].symbol: "Exit",
+}
+
+
+class MapRenderer:
+    """Render a dungeon map using curses or plain strings."""
+
+    def __init__(self, dungeon: "DungeonBase"):
+        self.dungeon = dungeon
+        self.show_legend = False
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def _tile_at(self, x: int, y: int) -> TileAppearance:
+        pos = (x, y)
+        if pos == (self.dungeon.player.x, self.dungeon.player.y):
+            key = "player"
+        elif pos == getattr(self.dungeon, "exit_coords", None):
+            key = "exit"
+        elif pos in getattr(self.dungeon, "visited_rooms", set()):
+            key = "visited"
+        else:
+            key = "unseen"
+        return TILES[key]
+
+    def _colourise(self, symbol: str, colour_name: str) -> str:
+        code = ANSI_COLOURS[colour_name]
+        return f"\x1b[{code}m{symbol}\x1b[0m"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def render_to_string(self, show_legend: bool = False) -> str:
+        """Return the map as a colourised string.
+
+        Parameters
+        ----------
+        show_legend:
+            If ``True`` a legend describing the map symbols will be appended
+            to the returned string.
+        """
+
+        lines = []
+        for y in range(self.dungeon.height):
+            row_symbols = []
+            for x in range(self.dungeon.width):
+                tile = self._tile_at(x, y)
+                row_symbols.append(self._colourise(tile.symbol, tile.colour_name))
+            lines.append("".join(row_symbols))
+
+        if show_legend:
+            lines.append("")
+            for sym, desc in LEGEND.items():
+                colour = TILES[[k for k, v in TILES.items() if v.symbol == sym][0]].colour_name
+                lines.append(f"{self._colourise(sym, colour)} - {desc}")
+
+        return "\n".join(lines)
+
+    # Curses based rendering ------------------------------------------------
+    def _init_colours(self) -> None:
+        curses.start_color()
+        curses.use_default_colors()
+        curses.init_pair(COLOUR_PAIRS["player"], curses.COLOR_CYAN, -1)
+        curses.init_pair(COLOUR_PAIRS["visited"], curses.COLOR_WHITE, -1)
+        curses.init_pair(COLOUR_PAIRS["unseen"], curses.COLOR_BLACK, -1)
+        curses.init_pair(COLOUR_PAIRS["exit"], curses.COLOR_MAGENTA, -1)
+
+    def _draw(self, stdscr) -> None:
+        stdscr.clear()
+        for y in range(self.dungeon.height):
+            for x in range(self.dungeon.width):
+                tile = self._tile_at(x, y)
+                colour = curses.color_pair(COLOUR_PAIRS[tile.colour_name])
+                stdscr.addstr(y, x, tile.symbol, colour)
+
+        if self.show_legend:
+            offset = self.dungeon.height + 1
+            for i, (sym, desc) in enumerate(LEGEND.items()):
+                colour_name = TILES[[k for k, v in TILES.items() if v.symbol == sym][0]].colour_name
+                colour = curses.color_pair(COLOUR_PAIRS[colour_name])
+                stdscr.addstr(offset + i, 0, sym, colour)
+                stdscr.addstr(offset + i, 2, f"- {desc}")
+
+        stdscr.refresh()
+
+    def _curses_loop(self, stdscr) -> None:
+        self._init_colours()
+        curses.curs_set(0)
+        self._draw(stdscr)
+        while True:
+            key = stdscr.getch()
+            if key == ord('?'):
+                self.show_legend = not self.show_legend
+                self._draw(stdscr)
+            elif key in (ord('q'), 27):
+                break
+
+    def run(self) -> None:
+        """Display the map using curses.
+
+        The user can press ``?`` to toggle the legend or ``q``/``ESC`` to
+        exit the map view.
+        """
+
+        curses.wrapper(self._curses_loop)
+
+
+__all__ = ["MapRenderer"]
+

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,0 +1,53 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+from dungeoncrawler.map import MapRenderer
+
+
+def build_sample_dungeon():
+    dungeon = DungeonBase(3, 3)
+    dungeon.rooms = [["Empty" for _ in range(3)] for _ in range(3)]
+    dungeon.player = Player("Tester")
+    dungeon.player.x = 1
+    dungeon.player.y = 1
+    dungeon.rooms[1][1] = dungeon.player
+    dungeon.visited_rooms = {(1, 1), (1, 2)}
+    dungeon.exit_coords = (2, 2)
+    return dungeon
+
+
+def test_render_map_string_snapshot():
+    dungeon = build_sample_dungeon()
+    renderer = MapRenderer(dungeon)
+    rendered = renderer.render_to_string()
+
+    expected = (
+        "\x1b[90m#\x1b[0m\x1b[90m#\x1b[0m\x1b[90m#\x1b[0m\n"
+        "\x1b[90m#\x1b[0m\x1b[36m@\x1b[0m\x1b[90m#\x1b[0m\n"
+        "\x1b[90m#\x1b[0m\x1b[37m.\x1b[0m\x1b[35mE\x1b[0m"
+    )
+
+    assert rendered == expected
+
+
+def test_render_map_with_legend_snapshot():
+    dungeon = build_sample_dungeon()
+    renderer = MapRenderer(dungeon)
+    rendered = renderer.render_to_string(show_legend=True)
+
+    expected = (
+        "\x1b[90m#\x1b[0m\x1b[90m#\x1b[0m\x1b[90m#\x1b[0m\n"
+        "\x1b[90m#\x1b[0m\x1b[36m@\x1b[0m\x1b[90m#\x1b[0m\n"
+        "\x1b[90m#\x1b[0m\x1b[37m.\x1b[0m\x1b[35mE\x1b[0m\n\n"
+        "\x1b[36m@\x1b[0m - Player\n"
+        "\x1b[37m.\x1b[0m - Visited\n"
+        "\x1b[90m#\x1b[0m - Unseen\n"
+        "\x1b[35mE\x1b[0m - Exit"
+    )
+
+    assert rendered == expected
+


### PR DESCRIPTION
## Summary
- Add `MapRenderer` for colored map output using curses
- Support `?` legend toggle and integrate with `DungeonBase.render_map`
- Document map legend and key bindings
- Snapshot tests for map rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a59cac8948326ae5427eeb118d403