### PR TITLE
Add Sphinx docs and GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: docs
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install sphinx
+      - name: Build docs
+        run: sphinx-build -b html docs docs/_build/html
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4
+

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ scores.json
 # OS generated files
 .DS_Store
 Thumbs.db
+
+# Sphinx build output
+docs/_build/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Dungeon Crawler is a small text-based adventure that borrows the core ideas of the *Dungeon Crawler Carl* novels while toning down the humor. Guide your hero through procedurally generated floors filled with monsters, treasure, and meaningful character choices.
 
+## Quickstart
+
+Clone the repository and start the game with Python 3:
+
+```bash
+git clone https://github.com/yourname/Dungeon-Crawler.git
+cd Dungeon-Crawler
+python -m dungeoncrawler
+```
+
+For full installation instructions, gameplay tips, API reference, and contributing guidelines, see the [documentation](https://<username>.github.io/Dungeon-Crawler/).
+
 ## Installation
 
 The game only requires Python 3. Run it directly using the main module:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -1,0 +1,13 @@
+API Reference
+=============
+
+.. automodule:: dungeoncrawler
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: dungeon_crawler
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,37 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+# Adding the project root to ``sys.path`` allows Sphinx to locate the
+# application's modules for autodoc generation.
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Dungeon Crawler'
+copyright = '2025, Dungeon Crawler Contributors'
+author = 'Dungeon Crawler Contributors'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,7 @@
+Contributing
+============
+
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+Make sure to run the test suite with ``pytest`` and update documentation as needed.
+

--- a/docs/gameplay_guide.rst
+++ b/docs/gameplay_guide.rst
@@ -1,0 +1,9 @@
+Gameplay Guide
+==============
+
+Use the numbered menu to explore rooms, fight monsters, visit shops, and descend deeper into the dungeon.
+
+At any time choose **8. Show Map** to display the dungeon grid. The map marks your location with ``@``, visited rooms with ``.``, and unexplored or blocked rooms with ``#``.
+
+Progress is automatically saved whenever you clear a floor.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,17 @@
+.. Dungeon Crawler documentation master file, created by
+   sphinx-quickstart on Mon Aug 11 21:01:54 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Dungeon Crawler Documentation
+=============================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   installation
+   gameplay_guide
+   api_reference
+   contributing
+

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,11 @@
+Installation
+============
+
+Install the game by cloning the repository and running it with Python 3.
+
+.. code-block:: bash
+
+   git clone https://github.com/yourname/Dungeon-Crawler.git
+   cd Dungeon-Crawler
+   python -m dungeoncrawler
+

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd


### PR DESCRIPTION
## Summary
- initialize Sphinx docs and enable autodoc
- document installation, gameplay, API reference and contributing
- add GitHub Pages workflow and README quickstart

## Testing
- `sphinx-build -b html docs docs/_build/html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a59d204c88326b5d525be3bc0a291