### PR TITLE
Add project packaging and release instructions

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,0 +1,1 @@
+"""JSON asset files for Dungeon Crawler."""

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,22 @@
+# Releasing
+
+Follow these steps to publish a new version of *Dungeon Crawler* to PyPI.
+
+1. Ensure the version number in `pyproject.toml` is updated.
+2. Install required build tools:
+   ```bash
+   python -m pip install --upgrade build twine
+   ```
+3. Build the distribution archives:
+   ```bash
+   python -m build
+   ```
+4. Upload the artifacts to PyPI:
+   ```bash
+   twine upload dist/*
+   ```
+5. Tag the release in git and push the tag:
+   ```bash
+   git tag vX.Y.Z
+   git push --tags
+   ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dungeon-crawler"
+version = "0.1.0"
+description = "A text-based adventure inspired by the Dungeon Crawler Carl novels."
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "Dungeon Crawler Contributors"}]
+dependencies = []
+
+[project.scripts]
+dungeon-crawler = "dungeoncrawler.main:main"
+
+[tool.setuptools.packages.find]
+include = ["dungeoncrawler", "data"]
+
+[tool.setuptools.package-data]
+"data" = ["*.json"]


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with metadata, dependencies and console script entry
- package JSON assets and add a `data` module
- document release process for publishing to PyPI

## Testing
- `pip install -e .`
- `dungeon-crawler <<'EOF'
n
Test
^C
EOF`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a59d137148326a7186f7f5091ac74