### PR TITLE
Add interactive tutorial with persistence

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -213,6 +213,7 @@ class DungeonBase:
             Weapon("Dwarven Waraxe", "Forged in the deep halls.", 12, 20, 0),
             Item("Shadow Cloak", "Grants an air of mystery")
         ]
+        self.tutorial_complete = False
 
     def announce(self, msg):
         print(f"[Announcer] {random.choice(ANNOUNCER_LINES)} {msg}")
@@ -235,6 +236,7 @@ class DungeonBase:
 
         data = {
             "floor": floor,
+            "tutorial_complete": self.tutorial_complete,
             "player": {
                 "name": self.player.name,
                 "level": self.player.level,
@@ -303,6 +305,7 @@ class DungeonBase:
                     Companion(comp_data["name"], comp_data["effect"])
                 )
 
+            self.tutorial_complete = data.get("tutorial_complete", False)
             return data.get("floor", 1)
         return 1
 

--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -4,10 +4,15 @@ Character creation now mirrors the progression seen in the source
 material: when starting a new run the player only chooses a name.  Class,
 race and guild selections are deferred to later floors and offered by the
 ``DungeonBase`` floor events.
+
+This module also wires up the optional tutorial which introduces basic
+gameplay concepts before the first adventure.
 """
 
 from .dungeon import DungeonBase
 from .entities import Player
+from .tutorial import run_tutorial
+import argparse
 
 
 def build_character():
@@ -29,11 +34,31 @@ def build_character():
     return player
 
 
-def main():
+def main(args=None):
+    """Launch the game optionally running the tutorial.
+
+    Parameters
+    ----------
+    args: list[str] | None
+        Optional list of arguments. When ``None`` the values from
+        ``sys.argv`` are used.
+    """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--skip-tutorial",
+        action="store_true",
+        help="Skip the introductory tutorial",
+    )
+    opts = parser.parse_args(args)
+
     game = DungeonBase(10, 10)
     cont = input("Load existing save? (y/n): ").strip().lower()
     if cont != "y":
         game.player = build_character()
+        if not opts.skip_tutorial:
+            run_tutorial(game.player)
+        game.tutorial_complete = True
     game.play_game()
 
 

--- a/dungeoncrawler/tutorial.py
+++ b/dungeoncrawler/tutorial.py
@@ -1,0 +1,15 @@
+"""Simple interactive tutorial for basic gameplay concepts."""
+
+
+def run_tutorial(player):
+    """Guide the player through movement, combat and inventory basics."""
+    print("--- Tutorial: Movement ---")
+    input("Use WASD keys to move your character. Press Enter to continue...")
+
+    print("--- Tutorial: Combat ---")
+    input("Combat is turn-based. Press Enter to strike at your foe...")
+
+    print("--- Tutorial: Inventory ---")
+    input("Open your inventory with 'i'. Press Enter once you've looked around...")
+
+    print("You're ready to begin your adventure, brave {}!".format(player.name))

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler import main as main_module
+from dungeoncrawler import constants
+from dungeoncrawler import dungeon as dungeon_module
+
+
+def test_tutorial_runs_only_once(tmp_path, monkeypatch):
+    save_path = tmp_path / "save.json"
+    monkeypatch.setattr(constants, 'SAVE_FILE', str(save_path))
+    monkeypatch.setattr(dungeon_module, 'SAVE_FILE', str(save_path))
+
+    # First run: new game
+    inputs = iter(['n', 'Hero'])
+    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+
+    calls = []
+
+    def fake_tutorial(player):
+        calls.append(player.name)
+
+    monkeypatch.setattr(main_module, 'run_tutorial', fake_tutorial)
+
+    def fake_play_game(self):
+        if self.player is None:
+            self.load_game()
+        self.save_game(1)
+
+    monkeypatch.setattr(main_module.DungeonBase, 'play_game', fake_play_game)
+
+    main_module.main(args=[])
+
+    assert calls == ['Hero']
+    with open(save_path) as f:
+        data = json.load(f)
+    assert data.get('tutorial_complete') is True
+
+    # Second run: load existing save, tutorial should not run
+    inputs2 = iter(['y'])
+    monkeypatch.setattr('builtins.input', lambda _: next(inputs2))
+    calls.clear()
+
+    main_module.main(args=[])
+
+    assert calls == []


### PR DESCRIPTION
## Summary
- Introduce interactive tutorial guiding movement, combat and inventory use
- Hook tutorial after character creation with CLI flag to skip and track completion
- Persist tutorial completion in save files and test that it runs only once per save

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a59cb811c832686925652793c1dc4