### PR TITLE
Format code and enforce linting checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503, E402, E501

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Lint
-        run: python -m flake8 --max-line-length=200 --extend-ignore=E231,E302,E402
+        run: |
+          black --check dungeoncrawler tests
+          isort --profile black --check-only dungeoncrawler tests
+          flake8
       - name: Test
         run: pytest

--- a/dungeoncrawler/ai.py
+++ b/dungeoncrawler/ai.py
@@ -9,6 +9,9 @@ class DefensiveAI:
     """AI that prioritizes defense when health is low."""
 
     def choose_action(self, enemy, player):
-        if enemy.health <= enemy.max_health // 2 and 'shield' not in enemy.status_effects:
+        if (
+            enemy.health <= enemy.max_health // 2
+            and "shield" not in enemy.status_effects
+        ):
             return "defend"
         return "attack"

--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.json"
 

--- a/dungeoncrawler/constants.py
+++ b/dungeoncrawler/constants.py
@@ -1,6 +1,6 @@
-from pathlib import Path
 import json
 from functools import lru_cache
+from pathlib import Path
 
 from .config import config
 

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -4,8 +4,8 @@ import random
 from functools import lru_cache
 from pathlib import Path
 
-from .constants import SAVE_FILE, SCORE_FILE, ANNOUNCER_LINES, RIDDLES
-from .entities import Player, Enemy, Companion
+from .constants import ANNOUNCER_LINES, RIDDLES, SAVE_FILE, SCORE_FILE
+from .entities import Companion, Enemy, Player
 from .items import Item, Weapon
 from .plugins import apply_enemy_plugins, apply_item_plugins
 
@@ -115,109 +115,217 @@ FLOOR_CONFIGS = {
         "size": (8, 8),
         "enemies": ["Goblin", "Skeleton", "Bandit"],
         "bosses": ["Bone Tyrant"],
-        "places": {"Trap": 2, "Treasure": 2, "Enchantment": 1, "Sanctuary": 1, "Blacksmith": 1},
+        "places": {
+            "Trap": 2,
+            "Treasure": 2,
+            "Enchantment": 1,
+            "Sanctuary": 1,
+            "Blacksmith": 1,
+        },
     },
     2: {
         "size": (9, 9),
         "enemies": ["Orc", "Cultist", "Ghoul", "Bandit"],
         "bosses": ["Inferno Golem", "Frost Warden"],
-        "places": {"Trap": 3, "Treasure": 3, "Enchantment": 1, "Sanctuary": 1, "Blacksmith": 1},
+        "places": {
+            "Trap": 3,
+            "Treasure": 3,
+            "Enchantment": 1,
+            "Sanctuary": 1,
+            "Blacksmith": 1,
+        },
     },
     3: {
         "size": (10, 10),
         "enemies": ["Vampire", "Warlock", "Wraith", "Werewolf"],
         "bosses": ["Shadow Reaver", "Doom Bringer"],
-        "places": {"Trap": 3, "Treasure": 4, "Enchantment": 2, "Sanctuary": 2, "Blacksmith": 1},
+        "places": {
+            "Trap": 3,
+            "Treasure": 4,
+            "Enchantment": 2,
+            "Sanctuary": 2,
+            "Blacksmith": 1,
+        },
     },
     4: {
         "size": (11, 11),
         "enemies": ["Basilisk", "Gargoyle", "Troll", "Lich"],
         "bosses": ["Void Serpent", "Ember Lord", "Glacier Fiend"],
-        "places": {"Trap": 4, "Treasure": 4, "Enchantment": 2, "Sanctuary": 2, "Blacksmith": 1},
+        "places": {
+            "Trap": 4,
+            "Treasure": 4,
+            "Enchantment": 2,
+            "Sanctuary": 2,
+            "Blacksmith": 1,
+        },
     },
     5: {
         "size": (12, 12),
         "enemies": ["Phoenix", "Hydra", "Revenant", "Beholder"],
         "bosses": ["Grave Monarch", "Storm Reaper"],
-        "places": {"Trap": 4, "Treasure": 5, "Enchantment": 2, "Sanctuary": 2, "Blacksmith": 1},
+        "places": {
+            "Trap": 4,
+            "Treasure": 5,
+            "Enchantment": 2,
+            "Sanctuary": 2,
+            "Blacksmith": 1,
+        },
     },
     6: {
         "size": (13, 13),
         "enemies": ["Minotaur", "Demon", "Harpy", "Shade"],
         "bosses": ["Bone Tyrant", "Inferno Golem"],
-        "places": {"Trap": 5, "Treasure": 5, "Enchantment": 2, "Sanctuary": 2, "Blacksmith": 1},
+        "places": {
+            "Trap": 5,
+            "Treasure": 5,
+            "Enchantment": 2,
+            "Sanctuary": 2,
+            "Blacksmith": 1,
+        },
     },
     7: {
         "size": (14, 14),
         "enemies": ["Giant Spider", "Slime King", "Zombie", "Gargoyle"],
         "bosses": ["Frost Warden", "Shadow Reaver"],
-        "places": {"Trap": 5, "Treasure": 6, "Enchantment": 2, "Sanctuary": 2, "Blacksmith": 1},
+        "places": {
+            "Trap": 5,
+            "Treasure": 6,
+            "Enchantment": 2,
+            "Sanctuary": 2,
+            "Blacksmith": 1,
+        },
     },
     8: {
         "size": (15, 15),
         "enemies": ["Dark Knight", "Cyclops", "Basilisk", "Werewolf"],
         "bosses": ["Doom Bringer", "Void Serpent"],
-        "places": {"Trap": 5, "Treasure": 6, "Enchantment": 3, "Sanctuary": 2, "Blacksmith": 1},
+        "places": {
+            "Trap": 5,
+            "Treasure": 6,
+            "Enchantment": 3,
+            "Sanctuary": 2,
+            "Blacksmith": 1,
+        },
     },
     9: {
         "size": (15, 15),
         "enemies": ["Hydra", "Beholder", "Revenant", "Warlock"],
         "bosses": ["Ember Lord", "Glacier Fiend"],
-        "places": {"Trap": 6, "Treasure": 6, "Enchantment": 3, "Sanctuary": 2, "Blacksmith": 1},
+        "places": {
+            "Trap": 6,
+            "Treasure": 6,
+            "Enchantment": 3,
+            "Sanctuary": 2,
+            "Blacksmith": 1,
+        },
     },
     10: {
         "size": (15, 15),
         "enemies": ["Phoenix", "Dark Knight", "Cyclops", "Minotaur"],
         "bosses": ["Grave Monarch", "Storm Reaper"],
-        "places": {"Trap": 6, "Treasure": 7, "Enchantment": 3, "Sanctuary": 3, "Blacksmith": 1},
+        "places": {
+            "Trap": 6,
+            "Treasure": 7,
+            "Enchantment": 3,
+            "Sanctuary": 3,
+            "Blacksmith": 1,
+        },
     },
     11: {
         "size": (15, 15),
         "enemies": ["Astral Dragon", "Demon", "Harpy", "Shade"],
         "bosses": ["Bone Tyrant", "Inferno Golem", "Frost Warden"],
-        "places": {"Trap": 7, "Treasure": 7, "Enchantment": 3, "Sanctuary": 3, "Blacksmith": 1},
+        "places": {
+            "Trap": 7,
+            "Treasure": 7,
+            "Enchantment": 3,
+            "Sanctuary": 3,
+            "Blacksmith": 1,
+        },
     },
     12: {
         "size": (15, 15),
         "enemies": ["Giant Spider", "Slime King", "Zombie", "Warlock"],
         "bosses": ["Shadow Reaver", "Doom Bringer", "Void Serpent"],
-        "places": {"Trap": 7, "Treasure": 8, "Enchantment": 4, "Sanctuary": 3, "Blacksmith": 1},
+        "places": {
+            "Trap": 7,
+            "Treasure": 8,
+            "Enchantment": 4,
+            "Sanctuary": 3,
+            "Blacksmith": 1,
+        },
     },
     13: {
         "size": (15, 15),
         "enemies": ["Basilisk", "Gargoyle", "Troll", "Lich"],
         "bosses": ["Ember Lord", "Glacier Fiend", "Grave Monarch"],
-        "places": {"Trap": 8, "Treasure": 8, "Enchantment": 4, "Sanctuary": 3, "Blacksmith": 1},
+        "places": {
+            "Trap": 8,
+            "Treasure": 8,
+            "Enchantment": 4,
+            "Sanctuary": 3,
+            "Blacksmith": 1,
+        },
     },
     14: {
         "size": (15, 15),
         "enemies": ["Hydra", "Beholder", "Revenant", "Dark Knight"],
         "bosses": ["Storm Reaper"],
-        "places": {"Trap": 8, "Treasure": 9, "Enchantment": 4, "Sanctuary": 3, "Blacksmith": 1},
+        "places": {
+            "Trap": 8,
+            "Treasure": 9,
+            "Enchantment": 4,
+            "Sanctuary": 3,
+            "Blacksmith": 1,
+        },
     },
     15: {
         "size": (15, 15),
         "enemies": ["Cyclops", "Astral Dragon", "Phoenix", "Minotaur"],
         "bosses": ["Doom Bringer", "Void Serpent"],
-        "places": {"Trap": 9, "Treasure": 9, "Enchantment": 5, "Sanctuary": 3, "Blacksmith": 1},
+        "places": {
+            "Trap": 9,
+            "Treasure": 9,
+            "Enchantment": 5,
+            "Sanctuary": 3,
+            "Blacksmith": 1,
+        },
     },
     16: {
         "size": (15, 15),
         "enemies": ["Demon", "Harpy", "Shade", "Giant Spider"],
         "bosses": ["Ember Lord", "Glacier Fiend"],
-        "places": {"Trap": 9, "Treasure": 10, "Enchantment": 5, "Sanctuary": 3, "Blacksmith": 1},
+        "places": {
+            "Trap": 9,
+            "Treasure": 10,
+            "Enchantment": 5,
+            "Sanctuary": 3,
+            "Blacksmith": 1,
+        },
     },
     17: {
         "size": (15, 15),
         "enemies": ["Slime King", "Zombie", "Gargoyle", "Warlock"],
         "bosses": ["Grave Monarch", "Storm Reaper"],
-        "places": {"Trap": 9, "Treasure": 10, "Enchantment": 5, "Sanctuary": 4, "Blacksmith": 1},
+        "places": {
+            "Trap": 9,
+            "Treasure": 10,
+            "Enchantment": 5,
+            "Sanctuary": 4,
+            "Blacksmith": 1,
+        },
     },
     18: {
         "size": (15, 15),
         "enemies": ["Hydra", "Beholder", "Astral Dragon", "Dark Knight"],
         "bosses": ["Bone Tyrant", "Doom Bringer", "Void Serpent"],
-        "places": {"Trap": 10, "Treasure": 10, "Enchantment": 6, "Sanctuary": 4, "Blacksmith": 1},
+        "places": {
+            "Trap": 10,
+            "Treasure": 10,
+            "Enchantment": 6,
+            "Sanctuary": 4,
+            "Blacksmith": 1,
+        },
     },
 }
 
@@ -231,11 +339,14 @@ class DungeonBase:
     flow of a game session while utility helpers handle saving progress and
     shop interactions.
     """
+
     def __init__(self, width, height):
         self.width = width
         self.height = height
         self.rooms = [[None for _ in range(width)] for _ in range(height)]
-        self.room_names = [[self.generate_room_name() for _ in range(width)] for _ in range(height)]
+        self.room_names = [
+            [self.generate_room_name() for _ in range(width)] for _ in range(height)
+        ]
         self.visited_rooms = set()
         self.player = None
         self.exit_coords = None
@@ -247,13 +358,13 @@ class DungeonBase:
             Weapon("Warhammer", "Crushes armor and bone", 14, 22, 85),
             Weapon("Rapier", "A slender, piercing blade", 9, 17, 50),
             Weapon("Flame Blade", "Glows with searing heat", 13, 20, 95),
-            Weapon("Crossbow", "Ranged attack with bolts", 11, 19, 60)
+            Weapon("Crossbow", "Ranged attack with bolts", 11, 19, 60),
         ]
         self.rare_loot = [
             Weapon("Elven Longbow", "Bow of unmatched accuracy.", 15, 25, 0),
             Item("Blessed Charm", "Said to bring good fortune."),
             Weapon("Dwarven Waraxe", "Forged in the deep halls.", 12, 20, 0),
-            Item("Shadow Cloak", "Grants an air of mystery")
+            Item("Shadow Cloak", "Grants an air of mystery"),
         ]
         apply_item_plugins(self.shop_items)
 
@@ -304,7 +415,9 @@ class DungeonBase:
         if os.path.exists(SAVE_FILE):
             with open(SAVE_FILE) as f:
                 data = json.load(f)
-            self.player = Player(data["player"]["name"], data["player"].get("class", "Novice"))
+            self.player = Player(
+                data["player"]["name"], data["player"].get("class", "Novice")
+            )
             p = data["player"]
             self.player.level = p["level"]
             self.player.health = p["health"]
@@ -354,7 +467,9 @@ class DungeonBase:
         if os.path.exists(SCORE_FILE):
             with open(SCORE_FILE) as f:
                 records = json.load(f)
-        records.append({"name": self.player.name, "score": self.player.get_score(), "floor": floor})
+        records.append(
+            {"name": self.player.name, "score": self.player.get_score(), "floor": floor}
+        )
         records = sorted(records, key=lambda x: x["score"], reverse=True)[:10]
         with open(SCORE_FILE, "w") as f:
             json.dump(records, f, indent=2)
@@ -449,14 +564,35 @@ class DungeonBase:
 
     def generate_room_name(self, room_type=None):
         lore = {
-            "Treasure": ("Glittering Vault", "The air shimmers with unseen magic. Ancient riches may lie within."),
-            "Trap": ("Booby-Trapped Passage", "This corridor is riddled with pressure plates and crumbled bones."),
-            "Enemy": ("Cursed Hall", "The shadows shift... something watches from the dark."),
-            "Exit": ("Sealed Gate", "Massive stone doors sealed by arcane runes. It might be the only way out."),
-            "Key": ("Hidden Niche", "A hollow carved into the wall, forgotten by time. Something valuable glints inside."),
-            "Sanctuary": ("Sacred Sanctuary", "A calm aura fills this room, soothing your wounds."),
-            "Empty": ("Silent Chamber", "Dust covers everything. It appears long abandoned."),
-            "default": (None, None)
+            "Treasure": (
+                "Glittering Vault",
+                "The air shimmers with unseen magic. Ancient riches may lie within.",
+            ),
+            "Trap": (
+                "Booby-Trapped Passage",
+                "This corridor is riddled with pressure plates and crumbled bones.",
+            ),
+            "Enemy": (
+                "Cursed Hall",
+                "The shadows shift... something watches from the dark.",
+            ),
+            "Exit": (
+                "Sealed Gate",
+                "Massive stone doors sealed by arcane runes. It might be the only way out.",
+            ),
+            "Key": (
+                "Hidden Niche",
+                "A hollow carved into the wall, forgotten by time. Something valuable glints inside.",
+            ),
+            "Sanctuary": (
+                "Sacred Sanctuary",
+                "A calm aura fills this room, soothing your wounds.",
+            ),
+            "Empty": (
+                "Silent Chamber",
+                "Dust covers everything. It appears long abandoned.",
+            ),
+            "default": (None, None),
         }
 
         if room_type in lore:
@@ -471,7 +607,10 @@ class DungeonBase:
         size = cfg.get("size", (min(15, 8 + floor), min(15, 8 + floor)))
         self.width, self.height = size
         self.rooms = [[None for _ in range(self.width)] for _ in range(self.height)]
-        self.room_names = [[self.generate_room_name() for _ in range(self.width)] for _ in range(self.height)]
+        self.room_names = [
+            [self.generate_room_name() for _ in range(self.width)]
+            for _ in range(self.height)
+        ]
         visited = set()
         path = []
         x, y = self.width // 2, self.height // 2
@@ -480,7 +619,7 @@ class DungeonBase:
         path.append(start)
 
         while len(visited) < (self.width * self.height) // 2:
-            direction = random.choice([(1,0), (-1,0), (0,1), (0,-1)])
+            direction = random.choice([(1, 0), (-1, 0), (0, 1), (0, -1)])
             nx, ny = x + direction[0], y + direction[1]
             if 0 <= nx < self.width and 0 <= ny < self.height:
                 if (nx, ny) not in visited:
@@ -488,7 +627,7 @@ class DungeonBase:
                     path.append((nx, ny))
                 x, y = nx, ny
 
-        for (x, y) in visited:
+        for x, y in visited:
             self.rooms[y][x] = "Empty"
 
         if self.player is None:
@@ -521,7 +660,9 @@ class DungeonBase:
 
             defense = max(1, defense + floor // 3)
 
-            health = random.randint(hp_min + floor * hp_scale, hp_max + floor * hp_scale)
+            health = random.randint(
+                hp_min + floor * hp_scale, hp_max + floor * hp_scale
+            )
             attack = random.randint(
                 atk_min + floor * atk_scale,
                 atk_max + floor * atk_scale,
@@ -538,7 +679,14 @@ class DungeonBase:
         name = random.choice(boss_names)
         hp, atk, dfs, gold, ability = BOSS_STATS[name]
         print(f"A powerful boss guards this floor! The {name} lurks nearby...")
-        boss = Enemy(name, hp + floor * 10, atk + floor, dfs + floor // 2, gold + floor * 5, ability=ability)
+        boss = Enemy(
+            name,
+            hp + floor * 10,
+            atk + floor,
+            dfs + floor // 2,
+            gold + floor * 5,
+            ability=ability,
+        )
         place(boss)
         boss_drop = BOSS_LOOT.get(name, [])
         if boss_drop and random.random() < 0.5:
@@ -552,7 +700,13 @@ class DungeonBase:
             Companion("Hired Blade", "attack"),
         ]
         place(random.choice(companion_options))
-        default_places = {"Trap": 3, "Treasure": 3, "Enchantment": 2, "Sanctuary": 2, "Blacksmith": 1}
+        default_places = {
+            "Trap": 3,
+            "Treasure": 3,
+            "Enchantment": 2,
+            "Sanctuary": 2,
+            "Blacksmith": 1,
+        }
         place_counts = default_places.copy()
         place_counts.update(cfg.get("places", {}))
         for pname, count in place_counts.items():
@@ -581,13 +735,19 @@ class DungeonBase:
             self.trigger_floor_event(floor)
 
             while self.player.is_alive():
-                print(f"Position: ({self.player.x}, {self.player.y}) - {self.room_names[self.player.y][self.player.x]}")
-                print(f"Health: {self.player.health} | XP: {self.player.xp} | Gold: {self.player.gold} | Level: {self.player.level} | Floor: {floor} | Skill CD: {self.player.skill_cooldown}")
+                print(
+                    f"Position: ({self.player.x}, {self.player.y}) - {self.room_names[self.player.y][self.player.x]}"
+                )
+                print(
+                    f"Health: {self.player.health} | XP: {self.player.xp} | Gold: {self.player.gold} | Level: {self.player.level} | Floor: {floor} | Skill CD: {self.player.skill_cooldown}"
+                )
                 if self.player.guild:
                     print(f"Guild: {self.player.guild}")
                 if self.player.race:
                     print(f"Race: {self.player.race}")
-                print("1. Move Left 2. Move Right 3. Move Up 4. Move Down 5. Visit Shop 6. Inventory 7. Quit 8. Show Map")
+                print(
+                    "1. Move Left 2. Move Right 3. Move Up 4. Move Down 5. Visit Shop 6. Inventory 7. Quit 8. Show Map"
+                )
                 choice = input("Action: ")
 
                 if choice == "1":
@@ -610,12 +770,21 @@ class DungeonBase:
                 else:
                     print("Invalid choice!")
 
-                if self.player.level >= 5 and self.player.health < self.player.max_health:
+                if (
+                    self.player.level >= 5
+                    and self.player.health < self.player.max_health
+                ):
                     self.player.health += 1
 
-                if self.player.x == self.exit_coords[0] and self.player.y == self.exit_coords[1] and self.player.has_item("Key"):
+                if (
+                    self.player.x == self.exit_coords[0]
+                    and self.player.y == self.exit_coords[1]
+                    and self.player.has_item("Key")
+                ):
                     print("You reach the Sealed Gate.")
-                    proceed = input("Would you like to descend to the next floor? (y/n): ").lower()
+                    proceed = input(
+                        "Would you like to descend to the next floor? (y/n): "
+                    ).lower()
                     if proceed == "y":
                         floor += 1
                         self.save_game(floor)
@@ -635,9 +804,15 @@ class DungeonBase:
             os.remove(SAVE_FILE)
 
     def move_player(self, direction):
-        dx, dy = {"left": (-1,0), "right": (1,0), "up": (0,-1), "down": (0,1)}.get(direction, (0,0))
+        dx, dy = {"left": (-1, 0), "right": (1, 0), "up": (0, -1), "down": (0, 1)}.get(
+            direction, (0, 0)
+        )
         x, y = self.player.x + dx, self.player.y + dy
-        if 0 <= x < self.width and 0 <= y < self.height and self.rooms[y][x] is not None:
+        if (
+            0 <= x < self.width
+            and 0 <= y < self.height
+            and self.rooms[y][x] is not None
+        ):
             self.handle_room(x, y)
         else:
             print("You can't move that way.")
@@ -665,7 +840,7 @@ class DungeonBase:
             "Sealed Gate": "Massive stone doors sealed by arcane runes. It might be the only way out.",
             "Hidden Niche": "A hollow carved into the wall, forgotten by time. Something valuable glints inside.",
             "Silent Chamber": "Dust covers everything. It appears long abandoned.",
-            "Sacred Sanctuary": "A peaceful place that heals weary adventurers."
+            "Sacred Sanctuary": "A peaceful place that heals weary adventurers.",
         }
         if name in lore:
             print(f"{lore[name]}")
@@ -712,7 +887,9 @@ class DungeonBase:
                 print("1. Poison  2. Burn  3. Freeze  4. Cancel")
                 choice = input("Choose enchantment: ")
                 if self.player.weapon.effect:
-                    print("Your weapon is already enchanted! You can't add another enchantment.")
+                    print(
+                        "Your weapon is already enchanted! You can't add another enchantment."
+                    )
                 elif self.player.gold >= 30 and choice in ["1", "2", "3"]:
                     effect = {"1": "poison", "2": "burn", "3": "freeze"}[choice]
                     self.player.weapon.description += f" (Enchanted: {effect})"
@@ -730,8 +907,12 @@ class DungeonBase:
         elif room == "Blacksmith":
             print("You meet a grizzled blacksmith hammering at a forge.")
             if self.player.weapon:
-                print(f"Your weapon: {self.player.weapon.name} ({self.player.weapon.min_damage}-{self.player.weapon.max_damage})")
-                print("Would you like to upgrade your weapon for 50 gold? +3 min/max damage")
+                print(
+                    f"Your weapon: {self.player.weapon.name} ({self.player.weapon.min_damage}-{self.player.weapon.max_damage})"
+                )
+                print(
+                    "Would you like to upgrade your weapon for 50 gold? +3 min/max damage"
+                )
                 confirm = input("Upgrade? (y/n): ")
                 if confirm.lower() == "y" and self.player.gold >= 50:
                     self.player.weapon.min_damage += 3
@@ -743,7 +924,9 @@ class DungeonBase:
                 else:
                     print("Maybe next time.")
             else:
-                print("The blacksmith scoffs. 'No weapon? Come back when you have something worth forging.'")
+                print(
+                    "The blacksmith scoffs. 'No weapon? Come back when you have something worth forging.'"
+                )
             self.rooms[y][x] = None
             self.room_names[y][x] = "Blacksmith Forge"
 
@@ -783,11 +966,13 @@ class DungeonBase:
         self.audience_gift()
 
     def battle(self, enemy):
-        print(f"You encountered a {enemy.name}! {enemy.ability.capitalize() if enemy.ability else ''} Boss incoming!")
+        print(
+            f"You encountered a {enemy.name}! {enemy.ability.capitalize() if enemy.ability else ''} Boss incoming!"
+        )
         self.announce(f"{self.player.name} engages {enemy.name}!")
         while self.player.is_alive() and enemy.is_alive():
             skip_player = self.player.apply_status_effects()
-            for companion in getattr(self.player, 'companions', []):
+            for companion in getattr(self.player, "companions", []):
                 companion.assist(self.player, enemy)
             if not enemy.is_alive():
                 break
@@ -925,7 +1110,7 @@ class DungeonBase:
                     print("You can't sell that item.")
                     return
                 confirm = input(f"Sell {item.name} for {sale_price} gold? (y/n) ")
-                if confirm.lower() == 'y':
+                if confirm.lower() == "y":
                     self.player.inventory.pop(choice - 1)
                     self.player.gold += sale_price
                     print(f"You sold {item.name}.")

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import random
-from .items import Item, Weapon
+
 from .constants import ANNOUNCER_LINES
+from .items import Item, Weapon
 
 
 class Entity:
@@ -89,7 +90,14 @@ class Player(Entity):
         return any(item.name == name for item in self.inventory)
 
     def use_health_potion(self):
-        potion = next((item for item in self.inventory if isinstance(item, Item) and item.name == "Health Potion"), None)
+        potion = next(
+            (
+                item
+                for item in self.inventory
+                if isinstance(item, Item) and item.name == "Health Potion"
+            ),
+            None,
+        )
         if potion:
             self.inventory.remove(potion)
             healed_amount = min(20, self.max_health - self.health)
@@ -144,65 +152,65 @@ class Player(Entity):
         print(f"The {enemy.name} attacked you and dealt {damage} damage.")
 
     def take_damage(self, damage):
-        if 'shield' in self.status_effects:
+        if "shield" in self.status_effects:
             damage = max(0, damage - 5)
             print("Your shield absorbs 5 damage!")
         self.health = max(0, self.health - damage)
 
     def apply_status_effects(self):
         skip_turn = False
-        if 'poison' in self.status_effects:
-            poison_turns = self.status_effects['poison']
+        if "poison" in self.status_effects:
+            poison_turns = self.status_effects["poison"]
             if poison_turns > 0:
                 self.health -= 3
                 print("You take 3 poison damage!")
-                self.status_effects['poison'] -= 1
-            if self.status_effects['poison'] <= 0:
-                del self.status_effects['poison']
-        if 'burn' in self.status_effects:
-            burn_turns = self.status_effects['burn']
+                self.status_effects["poison"] -= 1
+            if self.status_effects["poison"] <= 0:
+                del self.status_effects["poison"]
+        if "burn" in self.status_effects:
+            burn_turns = self.status_effects["burn"]
             if burn_turns > 0:
                 self.health -= 4
                 print("You suffer 4 burn damage!")
-                self.status_effects['burn'] -= 1
-            if self.status_effects['burn'] <= 0:
-                del self.status_effects['burn']
-        if 'bleed' in self.status_effects:
-            bleed_turns = self.status_effects['bleed']
+                self.status_effects["burn"] -= 1
+            if self.status_effects["burn"] <= 0:
+                del self.status_effects["burn"]
+        if "bleed" in self.status_effects:
+            bleed_turns = self.status_effects["bleed"]
             if bleed_turns > 0:
                 self.health -= 2
                 print("You bleed for 2 damage!")
-                self.status_effects['bleed'] -= 1
-            if self.status_effects['bleed'] <= 0:
-                del self.status_effects['bleed']
-        if 'freeze' in self.status_effects:
-            freeze_turns = self.status_effects['freeze']
+                self.status_effects["bleed"] -= 1
+            if self.status_effects["bleed"] <= 0:
+                del self.status_effects["bleed"]
+        if "freeze" in self.status_effects:
+            freeze_turns = self.status_effects["freeze"]
             if freeze_turns > 0:
                 print("You're frozen and lose your turn!")
-                self.status_effects['freeze'] -= 1
+                self.status_effects["freeze"] -= 1
                 skip_turn = True
-            if self.status_effects['freeze'] <= 0:
-                del self.status_effects['freeze']
-        if 'stun' in self.status_effects:
-            stun_turns = self.status_effects['stun']
+            if self.status_effects["freeze"] <= 0:
+                del self.status_effects["freeze"]
+        if "stun" in self.status_effects:
+            stun_turns = self.status_effects["stun"]
             if stun_turns > 0:
                 print("You're stunned and can't move!")
-                self.status_effects['stun'] -= 1
+                self.status_effects["stun"] -= 1
                 skip_turn = True
-            if self.status_effects['stun'] <= 0:
-                del self.status_effects['stun']
-        if 'shield' in self.status_effects:
-            self.status_effects['shield'] -= 1
-            if self.status_effects['shield'] <= 0:
+            if self.status_effects["stun"] <= 0:
+                del self.status_effects["stun"]
+        if "shield" in self.status_effects:
+            self.status_effects["shield"] -= 1
+            if self.status_effects["shield"] <= 0:
                 print("Your shield fades.")
-                del self.status_effects['shield']
-        if 'inspire' in self.status_effects:
-            if self.status_effects['inspire'] == 3:
+                del self.status_effects["shield"]
+        if "inspire" in self.status_effects:
+            if self.status_effects["inspire"] == 3:
                 self.attack_power += 3
-            self.status_effects['inspire'] -= 1
-            if self.status_effects['inspire'] <= 0:
+            self.status_effects["inspire"] -= 1
+            if self.status_effects["inspire"] <= 0:
                 self.attack_power -= 3
-                del self.status_effects['inspire']
+                del self.status_effects["inspire"]
         return skip_turn
 
     def decrement_cooldowns(self):
@@ -221,8 +229,8 @@ class Player(Entity):
             damage = self.attack_power + random.randint(10, 15)
             print(f"You cast Fireball dealing {damage} damage!")
             enemy.take_damage(damage)
-            enemy.status_effects = getattr(enemy, 'status_effects', {})
-            enemy.status_effects['burn'] = 3
+            enemy.status_effects = getattr(enemy, "status_effects", {})
+            enemy.status_effects["burn"] = 3
         elif self.class_type == "Rogue":
             damage = self.attack_power + random.randint(5, 10)
             print(f"You perform a sneaky Backstab for {damage} damage!")
@@ -241,7 +249,7 @@ class Player(Entity):
                 print(f"Divine power heals you for {heal} HP!")
         elif self.class_type == "Bard":
             print("You play an inspiring tune, bolstering your spirit!")
-            self.status_effects['inspire'] = 3
+            self.status_effects["inspire"] = 3
         elif self.class_type == "Barbarian":
             damage = self.attack_power + random.randint(8, 12)
             enemy.take_damage(damage)
@@ -251,19 +259,19 @@ class Player(Entity):
         elif self.class_type == "Druid":
             damage = self.attack_power + random.randint(5, 10)
             enemy.take_damage(damage)
-            enemy.status_effects['freeze'] = 1
+            enemy.status_effects["freeze"] = 1
             heal = min(5, self.max_health - self.health)
             self.health += heal
             print(f"Nature's wrath deals {damage} damage and restores {heal} health!")
         elif self.class_type == "Ranger":
             damage = self.attack_power + random.randint(6, 12)
             enemy.take_damage(damage)
-            enemy.status_effects['poison'] = 3
+            enemy.status_effects["poison"] = 3
             print(f"A volley of arrows hits for {damage} damage and poisons the foe!")
         elif self.class_type == "Sorcerer":
             damage = self.attack_power + random.randint(12, 18)
             enemy.take_damage(damage)
-            enemy.status_effects['burn'] = 3
+            enemy.status_effects["burn"] = 3
             print(f"You unleash Arcane Blast for {damage} damage!")
         elif self.class_type == "Monk":
             damage = self.attack_power + random.randint(4, 8)
@@ -291,8 +299,10 @@ class Player(Entity):
         elif self.class_type == "Alchemist":
             damage = self.attack_power + random.randint(8, 12)
             enemy.take_damage(damage)
-            enemy.status_effects['burn'] = 3
-            print(f"An explosive flask bursts for {damage} damage and sets the foe ablaze!")
+            enemy.status_effects["burn"] = 3
+            print(
+                f"An explosive flask bursts for {damage} damage and sets the foe ablaze!"
+            )
         else:
             print("You don't have a special skill.")
             return
@@ -400,6 +410,7 @@ class Player(Entity):
     def get_score(self):
         return self.level * 100 + len(self.inventory) * 10 + self.gold
 
+
 class Enemy(Entity):
     """Adversary encountered within the dungeon.
 
@@ -407,7 +418,9 @@ class Enemy(Entity):
     :meth:`attack` method applies damage and effects to the player.
     """
 
-    def __init__(self, name, health, attack_power, defense, gold, ability=None, ai=None):
+    def __init__(
+        self, name, health, attack_power, defense, gold, ability=None, ai=None
+    ):
         super().__init__(name, "")
         self.health = health
         self.max_health = health
@@ -423,7 +436,7 @@ class Enemy(Entity):
         return self.health > 0
 
     def take_damage(self, damage):
-        if 'shield' in self.status_effects:
+        if "shield" in self.status_effects:
             damage = max(0, damage - 5)
             print(f"The {self.name}'s shield absorbs 5 damage!")
         self.health = max(0, self.health - damage)
@@ -434,57 +447,57 @@ class Enemy(Entity):
     def apply_status_effects(self):
         """Apply ongoing status effects and decrement their duration."""
         skip_turn = False
-        if 'poison' in self.status_effects:
-            if self.status_effects['poison'] > 0:
+        if "poison" in self.status_effects:
+            if self.status_effects["poison"] > 0:
                 self.health -= 3
                 print(f"The {self.name} takes 3 poison damage!")
-                self.status_effects['poison'] -= 1
-            if self.status_effects['poison'] <= 0:
-                del self.status_effects['poison']
-        if 'burn' in self.status_effects:
-            if self.status_effects['burn'] > 0:
+                self.status_effects["poison"] -= 1
+            if self.status_effects["poison"] <= 0:
+                del self.status_effects["poison"]
+        if "burn" in self.status_effects:
+            if self.status_effects["burn"] > 0:
                 self.health -= 4
                 print(f"The {self.name} suffers 4 burn damage!")
-                self.status_effects['burn'] -= 1
-            if self.status_effects['burn'] <= 0:
-                del self.status_effects['burn']
-        if 'bleed' in self.status_effects:
-            if self.status_effects['bleed'] > 0:
+                self.status_effects["burn"] -= 1
+            if self.status_effects["burn"] <= 0:
+                del self.status_effects["burn"]
+        if "bleed" in self.status_effects:
+            if self.status_effects["bleed"] > 0:
                 self.health -= 2
                 print(f"The {self.name} bleeds for 2 damage!")
-                self.status_effects['bleed'] -= 1
-            if self.status_effects['bleed'] <= 0:
-                del self.status_effects['bleed']
-        if 'freeze' in self.status_effects:
-            if self.status_effects['freeze'] > 0:
+                self.status_effects["bleed"] -= 1
+            if self.status_effects["bleed"] <= 0:
+                del self.status_effects["bleed"]
+        if "freeze" in self.status_effects:
+            if self.status_effects["freeze"] > 0:
                 print(f"The {self.name} is frozen and can't move!")
-                self.status_effects['freeze'] -= 1
+                self.status_effects["freeze"] -= 1
                 skip_turn = True
-            if self.status_effects['freeze'] <= 0:
-                del self.status_effects['freeze']
-        if 'stun' in self.status_effects:
-            if self.status_effects['stun'] > 0:
+            if self.status_effects["freeze"] <= 0:
+                del self.status_effects["freeze"]
+        if "stun" in self.status_effects:
+            if self.status_effects["stun"] > 0:
                 print(f"The {self.name} is stunned and can't move!")
-                self.status_effects['stun'] -= 1
+                self.status_effects["stun"] -= 1
                 skip_turn = True
-            if self.status_effects['stun'] <= 0:
-                del self.status_effects['stun']
-        if 'shield' in self.status_effects:
-            self.status_effects['shield'] -= 1
-            if self.status_effects['shield'] <= 0:
+            if self.status_effects["stun"] <= 0:
+                del self.status_effects["stun"]
+        if "shield" in self.status_effects:
+            self.status_effects["shield"] -= 1
+            if self.status_effects["shield"] <= 0:
                 print(f"The {self.name}'s shield fades.")
-                del self.status_effects['shield']
+                del self.status_effects["shield"]
         return skip_turn
 
     def defend(self):
-        self.status_effects['shield'] = 1
+        self.status_effects["shield"] = 1
         print(f"The {self.name} raises its guard!")
 
     def take_turn(self, player):
-        action = 'attack'
+        action = "attack"
         if self.ai:
             action = self.ai.choose_action(self, player)
-        if action == 'defend':
+        if action == "defend":
             self.defend()
         else:
             self.attack(player)
@@ -495,22 +508,23 @@ class Enemy(Entity):
             self.health += damage // 3
             print(f"The {self.name} drains life and heals for {damage // 3}!")
         elif self.ability == "poison":
-            player.status_effects['poison'] = 3
+            player.status_effects["poison"] = 3
         elif self.ability == "burn":
-            player.status_effects['burn'] = 3
+            player.status_effects["burn"] = 3
         elif self.ability == "stun":
-            player.status_effects['stun'] = 1
+            player.status_effects["stun"] = 1
             print(f"The {self.name} stuns you!")
         elif self.ability == "bleed":
-            player.status_effects['bleed'] = 3
+            player.status_effects["bleed"] = 3
         elif self.ability == "freeze":
-            player.status_effects['freeze'] = 1
+            player.status_effects["freeze"] = 1
             print(f"The {self.name} freezes you for 1 turns!")
         elif self.ability == "double_strike" and random.random() < 0.25:
             print(f"The {self.name} strikes twice!")
             player.take_damage(damage)
         player.take_damage(damage)
         print(f"The {self.name} attacked you and dealt {damage} damage.")
+
 
 class Companion(Entity):
     """NPC ally that can aid the player during combat.

--- a/dungeoncrawler/items.py
+++ b/dungeoncrawler/items.py
@@ -3,6 +3,7 @@ class Item:
         self.name = name
         self.description = description
 
+
 class Weapon(Item):
     def __init__(self, name, description, min_damage, max_damage, price=50):
         super().__init__(name, description)

--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -6,9 +6,9 @@ race and guild selections are deferred to later floors and offered by the
 ``DungeonBase`` floor events.
 """
 
+from .config import load_config
 from .dungeon import DungeonBase
 from .entities import Player
-from .config import load_config
 
 
 def build_character():

--- a/dungeoncrawler/plugins.py
+++ b/dungeoncrawler/plugins.py
@@ -1,17 +1,22 @@
 import importlib
+import json
 import pkgutil
 from pathlib import Path
-import json
 
 from .items import Item, Weapon
 
 MODS_DIR = Path(__file__).resolve().parent.parent / "mods"
 
+
 def discover_plugins():
     """Return imported plugin modules found under :mod:`mods` package."""
     if not MODS_DIR.exists():
         return []
-    return [importlib.import_module(f"mods.{m.name}") for m in pkgutil.iter_modules([str(MODS_DIR)])]
+    return [
+        importlib.import_module(f"mods.{m.name}")
+        for m in pkgutil.iter_modules([str(MODS_DIR)])
+    ]
+
 
 def _load_json_from_mod(mod, filename):
     mod_path = Path(mod.__file__).parent
@@ -20,6 +25,7 @@ def _load_json_from_mod(mod, filename):
         with open(json_path) as f:
             return json.load(f)
     return None
+
 
 def apply_enemy_plugins(enemy_stats, enemy_abilities):
     """Augment enemy dictionaries with contributions from mods."""
@@ -33,6 +39,7 @@ def apply_enemy_plugins(enemy_stats, enemy_abilities):
                     enemy_abilities[name] = ability
         if hasattr(mod, "register_enemies"):
             mod.register_enemies(enemy_stats, enemy_abilities)
+
 
 def apply_item_plugins(shop_items):
     """Append new items to ``shop_items`` list via JSON or hooks."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+black
 flake8
+isort
 pytest

--- a/tests/test_boss_loot.py
+++ b/tests/test_boss_loot.py
@@ -1,11 +1,11 @@
 import os
-import sys
 import random
+import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from dungeoncrawler.dungeon import DungeonBase, BOSS_LOOT
-from dungeoncrawler.entities import Player, Enemy
+from dungeoncrawler.dungeon import BOSS_LOOT, DungeonBase
+from dungeoncrawler.entities import Enemy, Player
 
 
 def test_boss_drops_loot(monkeypatch):
@@ -14,8 +14,8 @@ def test_boss_drops_loot(monkeypatch):
     boss_name = next(iter(BOSS_LOOT))
     enemy = Enemy(boss_name, 1, 0, 0, 0)
 
-    monkeypatch.setattr('builtins.input', lambda _: '1')
-    monkeypatch.setattr(random, 'choice', lambda seq: seq[0])
+    monkeypatch.setattr("builtins.input", lambda _: "1")
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
     game.battle(enemy)
 

--- a/tests/test_build_character.py
+++ b/tests/test_build_character.py
@@ -1,16 +1,20 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from dungeoncrawler.entities import Enemy, Player
 from dungeoncrawler.main import build_character
-from dungeoncrawler.entities import Player, Enemy
 
 
 def test_build_character(monkeypatch):
-    inputs = iter([
-        "", "Alice",  # name (invalid then valid)
-    ])
-    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+    inputs = iter(
+        [
+            "",
+            "Alice",  # name (invalid then valid)
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
 
     player = build_character()
     assert isinstance(player, Player)
@@ -34,7 +38,7 @@ def test_warlock_skill_lifesteal(monkeypatch):
     enemy = Enemy("Dummy", 100, 5, 0, 0)
     player.health = 70
 
-    monkeypatch.setattr('random.randint', lambda a, b: 10)
+    monkeypatch.setattr("random.randint", lambda a, b: 10)
     player.use_skill(enemy)
     expected_damage = player.attack_power + 10
     assert enemy.health == 100 - expected_damage

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -1,13 +1,13 @@
 import os
-import sys
 import random
+import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import pytest
 
-from dungeoncrawler.entities import Player, Enemy, Weapon
 from dungeoncrawler.ai import AggressiveAI, DefensiveAI
+from dungeoncrawler.entities import Enemy, Player, Weapon
 
 
 @pytest.fixture
@@ -44,32 +44,32 @@ def test_enemy_attack_applies_status(player):
 def test_status_effects_tick():
     p = Player("Hero")
     p.health = 50
-    p.status_effects['poison'] = 2
+    p.status_effects["poison"] = 2
     p.apply_status_effects()
     assert p.health == 47
-    assert p.status_effects['poison'] == 1
+    assert p.status_effects["poison"] == 1
 
 
 def test_bleed_effect():
     p = Player("Hero")
     p.health = 30
-    p.status_effects['bleed'] = 2
+    p.status_effects["bleed"] = 2
     p.apply_status_effects()
     assert p.health == 28
-    assert p.status_effects['bleed'] == 1
+    assert p.status_effects["bleed"] == 1
 
 
 def test_stun_effect_skips_enemy_turn():
     e = Enemy("Orc", 20, 5, 0, 5)
-    e.status_effects['stun'] = 1
+    e.status_effects["stun"] = 1
     skip = e.apply_status_effects()
     assert skip is True
-    assert 'stun' not in e.status_effects
+    assert "stun" not in e.status_effects
 
 
 def test_shield_reduces_damage():
     e = Enemy("Orc", 20, 10, 0, 0)
-    e.status_effects['shield'] = 1
+    e.status_effects["shield"] = 1
     e.take_damage(10)
     assert e.health == 15
 
@@ -86,4 +86,4 @@ def test_defensive_ai_defends(player):
     enemy = Enemy("Goblin", 20, 6, 0, 0, ai=DefensiveAI())
     enemy.health = 5
     enemy.take_turn(player)
-    assert 'shield' in enemy.status_effects
+    assert "shield" in enemy.status_effects

--- a/tests/test_companions.py
+++ b/tests/test_companions.py
@@ -1,11 +1,11 @@
 import os
-import sys
 import random
+import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from dungeoncrawler.dungeon import DungeonBase
-from dungeoncrawler.entities import Player, Enemy, Companion
+from dungeoncrawler.entities import Companion, Enemy, Player
 
 
 def test_attack_companion_deals_damage(monkeypatch):
@@ -15,8 +15,8 @@ def test_attack_companion_deals_damage(monkeypatch):
     wolf = Companion("Wolf", attack_power=5)
     game.player.companions.append(wolf)
 
-    monkeypatch.setattr('builtins.input', lambda _: '2')  # defend
-    monkeypatch.setattr(random, 'randint', lambda a, b: b)
+    monkeypatch.setattr("builtins.input", lambda _: "2")  # defend
+    monkeypatch.setattr(random, "randint", lambda a, b: b)
 
     game.battle(enemy)
 
@@ -31,8 +31,8 @@ def test_healer_companion_restores_health(monkeypatch):
     healer = Companion("Cleric", heal_amount=10)
     game.player.companions.append(healer)
 
-    monkeypatch.setattr('builtins.input', lambda _: '1')  # attack
-    monkeypatch.setattr(random, 'randint', lambda a, b: b)
+    monkeypatch.setattr("builtins.input", lambda _: "1")  # attack
+    monkeypatch.setattr(random, "randint", lambda a, b: b)
 
     game.battle(enemy)
 

--- a/tests/test_dungeon_generation.py
+++ b/tests/test_dungeon_generation.py
@@ -1,10 +1,11 @@
 import os
-import sys
 import random
+import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from dungeoncrawler.dungeon import DungeonBase
-from dungeoncrawler.entities import Player, Enemy
+from dungeoncrawler.entities import Enemy, Player
 
 
 def test_generate_dungeon_size_and_population():

--- a/tests/test_floor_events.py
+++ b/tests/test_floor_events.py
@@ -29,8 +29,9 @@ def test_floor_twelve_event_calls_shop():
 
 def test_floor_fifteen_event_riddle_rewards_gold():
     dungeon = setup_dungeon()
-    with patch("dungeoncrawler.dungeon.random.choice", return_value=("riddle", "answer")), \
-         patch("builtins.input", return_value="answer"):
+    with patch(
+        "dungeoncrawler.dungeon.random.choice", return_value=("riddle", "answer")
+    ), patch("builtins.input", return_value="answer"):
         gold_before = dungeon.player.gold
         dungeon.trigger_floor_event(15)
         assert dungeon.player.gold == gold_before + 50

--- a/tests/test_riddles.py
+++ b/tests/test_riddles.py
@@ -11,7 +11,8 @@ def test_riddles_loaded_and_used(monkeypatch, capsys):
     assert len(constants.RIDDLES) >= 5
 
     chosen = constants.RIDDLES[-1]
-    # Restrict the riddles list in the dungeon module so the trap must use our chosen riddle
+    # Restrict the riddles list in the dungeon module so the trap
+    # must use our chosen riddle
     monkeypatch.setattr(dungeon_module, "RIDDLES", [chosen])
     monkeypatch.setattr(builtins, "input", lambda _: chosen["answer"])
 

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -5,13 +5,13 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 import dungeoncrawler.dungeon as dungeon_module
 from dungeoncrawler.dungeon import DungeonBase
-from dungeoncrawler.entities import Player, Companion
+from dungeoncrawler.entities import Companion, Player
 from dungeoncrawler.items import Item, Weapon
 
 
 def test_save_and_load(tmp_path, monkeypatch):
     save_path = tmp_path / "save.json"
-    monkeypatch.setattr(dungeon_module, 'SAVE_FILE', str(save_path))
+    monkeypatch.setattr(dungeon_module, "SAVE_FILE", str(save_path))
 
     dungeon = DungeonBase(1, 1)
     dungeon.player = Player("Saver")

--- a/tests/test_shop.py
+++ b/tests/test_shop.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from dungeoncrawler.dungeon import DungeonBase
@@ -11,10 +12,10 @@ def test_shop_purchase(monkeypatch):
     dungeon = DungeonBase(1, 1)
     dungeon.player = Player("Buyer")
     dungeon.player.gold = 20
-    monkeypatch.setattr('builtins.input', lambda _: '1')
+    monkeypatch.setattr("builtins.input", lambda _: "1")
     dungeon.shop()
     assert dungeon.player.gold == 10
-    assert any(item.name == 'Health Potion' for item in dungeon.player.inventory)
+    assert any(item.name == "Health Potion" for item in dungeon.player.inventory)
 
 
 def test_sell_weapon(monkeypatch):
@@ -22,8 +23,8 @@ def test_sell_weapon(monkeypatch):
     dungeon.player = Player("Seller")
     weapon = Weapon("Sword", "A sharp sword", 10, 15, 40)
     dungeon.player.collect_item(weapon)
-    inputs = iter(['1', 'y'])
-    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+    inputs = iter(["1", "y"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
     dungeon.sell_items()
     assert dungeon.player.gold == 20
     assert weapon not in dungeon.player.inventory
@@ -34,8 +35,8 @@ def test_sell_item(monkeypatch):
     dungeon.player = Player("Seller")
     potion = Item("Health Potion", "Restores 20 health")
     dungeon.player.collect_item(potion)
-    inputs = iter(['1', 'y'])
-    monkeypatch.setattr('builtins.input', lambda _: next(inputs))
+    inputs = iter(["1", "y"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
     dungeon.sell_items()
     assert dungeon.player.gold == 5
     assert potion not in dungeon.player.inventory
@@ -46,7 +47,7 @@ def test_sell_unsellable(monkeypatch):
     dungeon.player = Player("Seller")
     rare_weapon = Weapon("Elven Longbow", "Bow", 15, 25, 0)
     dungeon.player.collect_item(rare_weapon)
-    monkeypatch.setattr('builtins.input', lambda _: '1')
+    monkeypatch.setattr("builtins.input", lambda _: "1")
     dungeon.sell_items()
     assert dungeon.player.gold == 0
     assert rare_weapon in dungeon.player.inventory

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,8 +1,10 @@
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from dungeoncrawler.entities import Player, Enemy
+from dungeoncrawler.entities import Enemy, Player
+
 
 class DummyEnemy(Enemy):
     def __init__(self):


### PR DESCRIPTION
## Summary
- Format `dungeoncrawler` and `tests` with Black and isort
- Add `.flake8` configuration and include Black/isort in requirements
- Update CI workflow to run Black, isort, and flake8 checks

## Testing
- `black --check dungeoncrawler tests`
- `isort dungeoncrawler tests --profile black --check-only -v`
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a5ff00f748326a5745389a7082855