### PR TITLE
Add persistent leaderboard and viewing command

### DIFF
--- a/dungeoncrawler/constants.py
+++ b/dungeoncrawler/constants.py
@@ -2,7 +2,8 @@ from pathlib import Path
 import json
 
 SAVE_FILE = "savegame.json"
-SCORE_FILE = "scores.json"
+# Default location for storing persistent leaderboard
+SCORE_FILE = Path.home() / ".dungeon_crawler" / "scores.json"
 ANNOUNCER_LINES = [
     "A decisive blow!",
     "You fight with determination.",

--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -31,10 +31,25 @@ def build_character():
 
 def main():
     game = DungeonBase(10, 10)
-    cont = input("Load existing save? (y/n): ").strip().lower()
-    if cont != "y":
-        game.player = build_character()
-    game.play_game()
+    while True:
+        print("1. Start New Game")
+        print("2. Load Game")
+        print("3. View Leaderboard")
+        print("4. Quit")
+        choice = input("Select an option: ").strip()
+        if choice == "1":
+            game.player = build_character()
+            game.play_game()
+        elif choice == "2":
+            game.player = None
+            game.play_game()
+        elif choice == "3":
+            game.view_leaderboard()
+        elif choice == "4":
+            print("Goodbye!")
+            return
+        else:
+            print("Invalid choice.")
 
 
 if __name__ == "__main__":

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import dungeoncrawler.dungeon as dungeon_module
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+
+
+def test_record_score_persistence(tmp_path, monkeypatch):
+    score_path = tmp_path / "scores.json"
+    monkeypatch.setattr(dungeon_module, 'SCORE_FILE', str(score_path))
+
+    dungeon = DungeonBase(1, 1)
+    dungeon.player = Player("Tester")
+
+    dungeon.record_score(floor=3, run_duration=120, seed=42)
+
+    with open(score_path) as f:
+        data = json.load(f)
+
+    assert len(data) == 1
+    record = data[0]
+    assert record["player_name"] == "Tester"
+    assert record["floor_reached"] == 3
+    assert record["run_duration"] == 120
+    assert record["seed"] == 42
+
+
+def test_view_leaderboard_displays(tmp_path, monkeypatch, capsys):
+    score_path = tmp_path / "scores.json"
+    records = [{
+        "player_name": "Alice",
+        "score": 50,
+        "floor_reached": 2,
+        "run_duration": 30,
+        "seed": 7,
+    }]
+    with open(score_path, 'w') as f:
+        json.dump(records, f)
+
+    monkeypatch.setattr(dungeon_module, 'SCORE_FILE', str(score_path))
+
+    dungeon = DungeonBase(1, 1)
+    dungeon.view_leaderboard()
+
+    captured = capsys.readouterr().out
+    assert "Alice" in captured
+    assert "50" in captured
+    assert "Floor 2" in captured
+    assert "Seed 7" in captured


### PR DESCRIPTION
## Summary
- Persist leaderboard to `~/.dungeon_crawler/scores.json` including player name, floor reached, run duration, and seed
- Add `view_leaderboard` method and expose it via a new main menu option
- Track run duration and seed for each run and display formatted leaderboard
- Introduce tests covering leaderboard persistence and display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a59ced2088326b8f82fe5ce0d5332