### PR TITLE
Ensure save directory exists and robust save handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ At any time you may choose **8. Show Map** to display a grid of the dungeon. The
 
 Progress is automatically saved whenever you clear a floor. On the next launch you will be asked if you want to continue.
 
+Save data is written to `~/.dungeon_crawler/saves/savegame.json`. The file is a
+JSON document containing the current floor and full player state including
+statistics, inventory, equipped weapon and companions. High scores are stored in
+`scores.json` alongside the save file.
+
 ## Objectives
 
 - Survive each floor and defeat the boss to descend.

--- a/dungeoncrawler/constants.py
+++ b/dungeoncrawler/constants.py
@@ -5,8 +5,10 @@ from pathlib import Path
 from .config import config
 
 # Configuration-driven values
-SAVE_FILE = config.save_file
-SCORE_FILE = config.score_file
+SAVE_DIR = Path.home() / ".dungeon_crawler" / "saves"
+SAVE_DIR.mkdir(parents=True, exist_ok=True)
+SAVE_FILE = SAVE_DIR / config.save_file
+SCORE_FILE = SAVE_DIR / config.score_file
 MAX_FLOORS = config.max_floors
 SCREEN_WIDTH = config.screen_width
 SCREEN_HEIGHT = config.screen_height
@@ -34,8 +36,11 @@ def load_riddles():
 
     data_dir = Path(__file__).resolve().parent.parent / "data"
     path = data_dir / "riddles.json"
-    with open(path) as f:
-        riddles = json.load(f)
+    try:
+        with open(path) as f:
+            riddles = json.load(f)
+    except (IOError, json.JSONDecodeError):
+        return []
     # Normalise answers for case-insensitive comparison
     for r in riddles:
         r["answer"] = r["answer"].lower()

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -417,13 +417,19 @@ class DungeonBase:
                 ],
             },
         }
-        with open(SAVE_FILE, "w") as f:
-            json.dump(data, f)
+        try:
+            with open(SAVE_FILE, "w") as f:
+                json.dump(data, f)
+        except IOError:
+            pass
 
     def load_game(self):
         if os.path.exists(SAVE_FILE):
-            with open(SAVE_FILE) as f:
-                data = json.load(f)
+            try:
+                with open(SAVE_FILE) as f:
+                    data = json.load(f)
+            except (IOError, json.JSONDecodeError):
+                return 1
             self.player = Player(
                 data["player"]["name"], data["player"].get("class", "Novice")
             )
@@ -474,14 +480,20 @@ class DungeonBase:
     def record_score(self, floor):
         records = []
         if os.path.exists(SCORE_FILE):
-            with open(SCORE_FILE) as f:
-                records = json.load(f)
+            try:
+                with open(SCORE_FILE) as f:
+                    records = json.load(f)
+            except (IOError, json.JSONDecodeError):
+                records = []
         records.append(
             {"name": self.player.name, "score": self.player.get_score(), "floor": floor}
         )
         records = sorted(records, key=lambda x: x["score"], reverse=True)[:10]
-        with open(SCORE_FILE, "w") as f:
-            json.dump(records, f, indent=2)
+        try:
+            with open(SCORE_FILE, "w") as f:
+                json.dump(records, f, indent=2)
+        except IOError:
+            pass
         print("-- Leaderboard --")
         for r in records:
             print(f"{r['name']}: {r['score']} (Floor {r.get('floor', '?')})")
@@ -692,14 +704,20 @@ class DungeonBase:
                         print(f"Final Score: {self.player.get_score()}")
                         self.record_score(floor)
                         if os.path.exists(SAVE_FILE):
-                            os.remove(SAVE_FILE)
+                            try:
+                                os.remove(SAVE_FILE)
+                            except OSError:
+                                pass
                         return
 
         print("You have died. Game Over!")
         print(f"Final Score: {self.player.get_score()}")
         self.record_score(floor)
         if os.path.exists(SAVE_FILE):
-            os.remove(SAVE_FILE)
+            try:
+                os.remove(SAVE_FILE)
+            except OSError:
+                pass
 
     def move_player(self, direction):
         map_module.move_player(self, direction)

--- a/dungeoncrawler/plugins.py
+++ b/dungeoncrawler/plugins.py
@@ -22,8 +22,11 @@ def _load_json_from_mod(mod, filename):
     mod_path = Path(mod.__file__).parent
     json_path = mod_path / "data" / filename
     if json_path.exists():
-        with open(json_path) as f:
-            return json.load(f)
+        try:
+            with open(json_path) as f:
+                return json.load(f)
+        except (IOError, json.JSONDecodeError):
+            return None
     return None
 
 

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import dungeoncrawler.dungeon as dungeon_module
+from dungeoncrawler.dungeon import DungeonBase
+
+
+def test_load_missing_file(tmp_path, monkeypatch):
+    save_path = tmp_path / "save.json"
+    monkeypatch.setattr(dungeon_module, "SAVE_FILE", str(save_path))
+    dungeon = DungeonBase(1, 1)
+    floor = dungeon.load_game()
+    assert floor == 1
+
+
+def test_load_corrupt_file(tmp_path, monkeypatch):
+    save_path = tmp_path / "save.json"
+    save_path.write_text("{")
+    monkeypatch.setattr(dungeon_module, "SAVE_FILE", str(save_path))
+    dungeon = DungeonBase(1, 1)
+    floor = dungeon.load_game()
+    assert floor == 1


### PR DESCRIPTION
## Summary
- Ensure `~/.dungeon_crawler/saves` directory exists and use it for save and score files
- Guard all JSON file operations against I/O and decode errors
- Add tests for loading when save files are missing or corrupt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a64a2b93083269c68d4c6bbb578fb