### PR TITLE
Rebalance combat scaling and standardize loot

### DIFF
--- a/data/bosses.json
+++ b/data/bosses.json
@@ -84,7 +84,7 @@
         "name": "Frozen Talon",
         "description": "Ice-forged claw that freezes.",
         "min_damage": 24,
-        "max_damage": 31,
+        "max_damage": 32,
         "price": 0
       }
     ]
@@ -101,7 +101,7 @@
       {
         "name": "Cryptblade",
         "description": "Blade of necrotic energy.",
-        "min_damage": 25,
+        "min_damage": 26,
         "max_damage": 34,
         "price": 0
       }
@@ -155,7 +155,7 @@
       {
         "name": "Thunder Cleaver",
         "description": "Sword crackling with lightning.",
-        "min_damage": 26,
+        "min_damage": 27,
         "max_damage": 35,
         "price": 0
       }

--- a/data/enemies.json
+++ b/data/enemies.json
@@ -1,181 +1,97 @@
 {
   "Astral Dragon": {
     "stats": [
-      220,
-      260,
-      30,
-      40,
+      230,
+      270,
+      32,
+      42,
       15
     ]
   },
   "Bandit": {
     "stats": [
-      50,
-      80,
-      6,
-      14,
+      60,
+      90,
+      8,
+      16,
       3
     ]
   },
   "Basilisk": {
+    "ability": "freeze",
     "stats": [
-      120,
-      160,
-      14,
-      24,
+      130,
+      170,
+      16,
+      26,
       7
-    ],
-    "ability": "freeze"
+    ]
   },
   "Beholder": {
     "stats": [
-      200,
-      240,
-      26,
-      36,
+      210,
+      250,
+      28,
+      38,
       13
     ]
   },
   "Cultist": {
     "stats": [
-      65,
-      95,
-      9,
-      16,
+      75,
+      105,
+      11,
+      18,
       3
     ]
   },
   "Cyclops": {
     "stats": [
-      190,
-      230,
-      24,
-      34,
+      200,
+      240,
+      26,
+      36,
       12
     ]
   },
   "Dark Knight": {
+    "ability": "double_strike",
     "stats": [
-      170,
-      210,
-      21,
-      29,
+      180,
+      220,
+      23,
+      31,
       10
-    ],
-    "ability": "double_strike"
+    ]
   },
   "Demon": {
     "stats": [
-      120,
-      160,
-      15,
-      26,
+      130,
+      170,
+      17,
+      28,
       8
     ]
   },
   "Gargoyle": {
     "stats": [
-      90,
-      130,
-      10,
-      22,
+      100,
+      140,
+      12,
+      24,
       6
     ]
   },
   "Ghoul": {
     "stats": [
-      70,
-      100,
-      8,
-      15,
-      4
-    ]
-  },
-  "Giant Spider": {
-    "stats": [
-      70,
+      80,
       110,
-      9,
+      10,
       17,
       4
     ]
   },
-  "Goblin": {
-    "stats": [
-      40,
-      70,
-      5,
-      12,
-      2
-    ]
-  },
-  "Harpy": {
-    "stats": [
-      70,
-      110,
-      10,
-      18,
-      4
-    ]
-  },
-  "Hydra": {
-    "stats": [
-      180,
-      220,
-      22,
-      32,
-      11
-    ],
-    "ability": "poison"
-  },
-  "Lich": {
-    "stats": [
-      130,
-      170,
-      14,
-      26,
-      7
-    ],
-    "ability": "lifesteal"
-  },
-  "Minotaur": {
-    "stats": [
-      140,
-      180,
-      16,
-      28,
-      8
-    ]
-  },
-  "Orc": {
-    "stats": [
-      80,
-      110,
-      10,
-      18,
-      4
-    ]
-  },
-  "Phoenix": {
-    "stats": [
-      160,
-      200,
-      20,
-      30,
-      10
-    ],
-    "ability": "burn"
-  },
-  "Revenant": {
-    "stats": [
-      150,
-      190,
-      18,
-      28,
-      9
-    ]
-  },
-  "Shade": {
+  "Giant Spider": {
     "stats": [
       80,
       120,
@@ -184,79 +100,163 @@
       4
     ]
   },
-  "Skeleton": {
+  "Goblin": {
     "stats": [
-      60,
-      90,
+      50,
+      80,
       7,
       14,
+      2
+    ]
+  },
+  "Harpy": {
+    "stats": [
+      80,
+      120,
+      12,
+      20,
+      4
+    ]
+  },
+  "Hydra": {
+    "ability": "poison",
+    "stats": [
+      190,
+      230,
+      24,
+      34,
+      11
+    ]
+  },
+  "Lich": {
+    "ability": "lifesteal",
+    "stats": [
+      140,
+      180,
+      16,
+      28,
+      7
+    ]
+  },
+  "Minotaur": {
+    "stats": [
+      150,
+      190,
+      18,
+      30,
+      8
+    ]
+  },
+  "Orc": {
+    "stats": [
+      90,
+      120,
+      12,
+      20,
+      4
+    ]
+  },
+  "Phoenix": {
+    "ability": "burn",
+    "stats": [
+      170,
+      210,
+      22,
+      32,
+      10
+    ]
+  },
+  "Revenant": {
+    "stats": [
+      160,
+      200,
+      20,
+      30,
+      9
+    ]
+  },
+  "Shade": {
+    "stats": [
+      90,
+      130,
+      13,
+      21,
+      4
+    ]
+  },
+  "Skeleton": {
+    "stats": [
+      70,
+      100,
+      9,
+      16,
       3
     ]
   },
   "Slime King": {
     "stats": [
-      130,
-      170,
-      13,
-      21,
+      140,
+      180,
+      15,
+      23,
       6
     ]
   },
   "Troll": {
     "stats": [
-      110,
-      150,
-      13,
-      23,
+      120,
+      160,
+      15,
+      25,
       6
     ]
   },
   "Vampire": {
-    "stats": [
-      90,
-      130,
-      10,
-      20,
-      5
-    ],
-    "ability": "lifesteal"
-  },
-  "Warlock": {
-    "stats": [
-      110,
-      150,
-      15,
-      25,
-      6
-    ],
-    "ability": "burn"
-  },
-  "Werewolf": {
-    "stats": [
-      100,
-      140,
-      12,
-      20,
-      5
-    ],
-    "ability": "double_strike"
-  },
-  "Wraith": {
+    "ability": "lifesteal",
     "stats": [
       100,
       140,
       12,
       22,
+      5
+    ]
+  },
+  "Warlock": {
+    "ability": "burn",
+    "stats": [
+      120,
+      160,
+      17,
+      27,
       6
-    ],
-    "ability": "poison"
+    ]
+  },
+  "Werewolf": {
+    "ability": "double_strike",
+    "stats": [
+      110,
+      150,
+      14,
+      22,
+      5
+    ]
+  },
+  "Wraith": {
+    "ability": "poison",
+    "stats": [
+      110,
+      150,
+      14,
+      24,
+      6
+    ]
   },
   "Zombie": {
     "stats": [
-      60,
-      100,
-      6,
-      14,
+      70,
+      110,
+      8,
+      16,
       3
     ]
   }

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -112,10 +112,17 @@ def load_bosses():
 ENEMY_STATS, ENEMY_ABILITIES = load_enemies()
 BOSS_STATS, BOSS_LOOT = load_bosses()
 apply_enemy_plugins(ENEMY_STATS, ENEMY_ABILITIES)
+
+
+def floor_size(floor):
+    """Return map size for a given floor with cap at 15x15."""
+    size = min(7 + floor, 15)
+    return (size, size)
+
 # Floor specific configuration
 FLOOR_CONFIGS = {
     1: {
-        "size": (8, 8),
+        "size": floor_size(1),
         "enemies": ["Goblin", "Skeleton", "Bandit"],
         "bosses": ["Bone Tyrant"],
         "places": {
@@ -127,7 +134,7 @@ FLOOR_CONFIGS = {
         },
     },
     2: {
-        "size": (9, 9),
+        "size": floor_size(2),
         "enemies": ["Orc", "Cultist", "Ghoul", "Bandit"],
         "bosses": ["Inferno Golem", "Frost Warden"],
         "places": {
@@ -139,7 +146,7 @@ FLOOR_CONFIGS = {
         },
     },
     3: {
-        "size": (10, 10),
+        "size": floor_size(3),
         "enemies": ["Vampire", "Warlock", "Wraith", "Werewolf"],
         "bosses": ["Shadow Reaver", "Doom Bringer"],
         "places": {
@@ -151,7 +158,7 @@ FLOOR_CONFIGS = {
         },
     },
     4: {
-        "size": (11, 11),
+        "size": floor_size(4),
         "enemies": ["Basilisk", "Gargoyle", "Troll", "Lich"],
         "bosses": ["Void Serpent", "Ember Lord", "Glacier Fiend"],
         "places": {
@@ -163,7 +170,7 @@ FLOOR_CONFIGS = {
         },
     },
     5: {
-        "size": (12, 12),
+        "size": floor_size(5),
         "enemies": ["Phoenix", "Hydra", "Revenant", "Beholder"],
         "bosses": ["Grave Monarch", "Storm Reaper"],
         "places": {
@@ -175,7 +182,7 @@ FLOOR_CONFIGS = {
         },
     },
     6: {
-        "size": (13, 13),
+        "size": floor_size(6),
         "enemies": ["Minotaur", "Demon", "Harpy", "Shade"],
         "bosses": ["Bone Tyrant", "Inferno Golem"],
         "places": {
@@ -187,7 +194,7 @@ FLOOR_CONFIGS = {
         },
     },
     7: {
-        "size": (14, 14),
+        "size": floor_size(7),
         "enemies": ["Giant Spider", "Slime King", "Zombie", "Gargoyle"],
         "bosses": ["Frost Warden", "Shadow Reaver"],
         "places": {
@@ -199,7 +206,7 @@ FLOOR_CONFIGS = {
         },
     },
     8: {
-        "size": (15, 15),
+        "size": floor_size(8),
         "enemies": ["Dark Knight", "Cyclops", "Basilisk", "Werewolf"],
         "bosses": ["Doom Bringer", "Void Serpent"],
         "places": {
@@ -211,7 +218,7 @@ FLOOR_CONFIGS = {
         },
     },
     9: {
-        "size": (15, 15),
+        "size": floor_size(9),
         "enemies": ["Hydra", "Beholder", "Revenant", "Warlock"],
         "bosses": ["Ember Lord", "Glacier Fiend"],
         "places": {
@@ -223,7 +230,7 @@ FLOOR_CONFIGS = {
         },
     },
     10: {
-        "size": (15, 15),
+        "size": floor_size(10),
         "enemies": ["Phoenix", "Dark Knight", "Cyclops", "Minotaur"],
         "bosses": ["Grave Monarch", "Storm Reaper"],
         "places": {
@@ -235,7 +242,7 @@ FLOOR_CONFIGS = {
         },
     },
     11: {
-        "size": (15, 15),
+        "size": floor_size(11),
         "enemies": ["Astral Dragon", "Demon", "Harpy", "Shade"],
         "bosses": ["Bone Tyrant", "Inferno Golem", "Frost Warden"],
         "places": {
@@ -247,7 +254,7 @@ FLOOR_CONFIGS = {
         },
     },
     12: {
-        "size": (15, 15),
+        "size": floor_size(12),
         "enemies": ["Giant Spider", "Slime King", "Zombie", "Warlock"],
         "bosses": ["Shadow Reaver", "Doom Bringer", "Void Serpent"],
         "places": {
@@ -259,7 +266,7 @@ FLOOR_CONFIGS = {
         },
     },
     13: {
-        "size": (15, 15),
+        "size": floor_size(13),
         "enemies": ["Basilisk", "Gargoyle", "Troll", "Lich"],
         "bosses": ["Ember Lord", "Glacier Fiend", "Grave Monarch"],
         "places": {
@@ -271,7 +278,7 @@ FLOOR_CONFIGS = {
         },
     },
     14: {
-        "size": (15, 15),
+        "size": floor_size(14),
         "enemies": ["Hydra", "Beholder", "Revenant", "Dark Knight"],
         "bosses": ["Storm Reaper"],
         "places": {
@@ -283,7 +290,7 @@ FLOOR_CONFIGS = {
         },
     },
     15: {
-        "size": (15, 15),
+        "size": floor_size(15),
         "enemies": ["Cyclops", "Astral Dragon", "Phoenix", "Minotaur"],
         "bosses": ["Doom Bringer", "Void Serpent"],
         "places": {
@@ -295,7 +302,7 @@ FLOOR_CONFIGS = {
         },
     },
     16: {
-        "size": (15, 15),
+        "size": floor_size(16),
         "enemies": ["Demon", "Harpy", "Shade", "Giant Spider"],
         "bosses": ["Ember Lord", "Glacier Fiend"],
         "places": {
@@ -307,7 +314,7 @@ FLOOR_CONFIGS = {
         },
     },
     17: {
-        "size": (15, 15),
+        "size": floor_size(17),
         "enemies": ["Slime King", "Zombie", "Gargoyle", "Warlock"],
         "bosses": ["Grave Monarch", "Storm Reaper"],
         "places": {
@@ -319,7 +326,7 @@ FLOOR_CONFIGS = {
         },
     },
     18: {
-        "size": (15, 15),
+        "size": floor_size(18),
         "enemies": ["Hydra", "Beholder", "Astral Dragon", "Dark Knight"],
         "bosses": ["Bone Tyrant", "Doom Bringer", "Void Serpent"],
         "places": {

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -87,3 +87,23 @@ def test_defensive_ai_defends(player):
     enemy.health = 5
     enemy.take_turn(player)
     assert "shield" in enemy.status_effects
+
+
+def test_player_damage_range():
+    player = Player("Hero")
+    player.weapon = Weapon("Variance Blade", "", 10, 20, 0)
+    enemy = Enemy("Training Dummy", 100, 0, 0, 0)
+    random.seed(0)
+    start = enemy.health
+    player.attack(enemy)
+    damage = start - enemy.health
+    assert 10 <= damage <= 20
+
+
+def test_enemy_damage_range(player):
+    enemy = Enemy("Orc", 30, 20, 0, 0)
+    random.seed(0)
+    start = player.health
+    enemy.attack(player)
+    damage = start - player.health
+    assert 10 <= damage <= 20


### PR DESCRIPTION
## Summary
- derive floor sizes with a helper to clarify dungeon scaling
- raise enemy HP and attack ranges to smooth difficulty
- normalize boss loot damage ranges for consistent rewards
- add regression tests ensuring player and enemy damage stay within expected ranges

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a66ffc098832690860ec5cdbc443e