### PR TITLE
Add modular random events for dungeon floors

### DIFF
--- a/docs/gameplay_guide.rst
+++ b/docs/gameplay_guide.rst
@@ -7,3 +7,13 @@ At any time choose **8. Show Map** to display the dungeon grid. The map marks yo
 
 Progress is automatically saved whenever you clear a floor.
 
+Random Events
+-------------
+As you explore, floors can trigger random events:
+
+* **MerchantEvent** – a travelling merchant appears and opens the shop.
+* **PuzzleEvent** – solve a riddle for a chance to earn extra gold.
+* **TrapEvent** – an unexpected hazard deals damage to the player.
+
+These events add variety and can occur on any floor.
+

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -11,6 +11,7 @@ from .plugins import apply_enemy_plugins, apply_item_plugins
 from . import combat as combat_module
 from . import map as map_module
 from . import shop as shop_module
+from .events import MerchantEvent, PuzzleEvent, TrapEvent
 
 # ---------------------------------------------------------------------------
 # Data loading utilities
@@ -338,6 +339,12 @@ FLOOR_CONFIGS = {
         },
     },
 }
+
+
+# Register default event types for each floor configuration
+EVENT_TYPES = [MerchantEvent, PuzzleEvent, TrapEvent]
+for cfg in FLOOR_CONFIGS.values():
+    cfg.setdefault("events", EVENT_TYPES)
 
 
 class DungeonBase:
@@ -779,6 +786,15 @@ class DungeonBase:
             self.player.gold += reward
         else:
             print("Incorrect! The sage vanishes in disappointment.")
+
+    def trigger_random_event(self, floor):
+        """Randomly select and trigger an event for ``floor``."""
+        cfg = self.floor_configs.get(floor, {})
+        events = cfg.get("events")
+        if events:
+            event_cls = random.choice(events)
+            event = event_cls()
+            event.trigger(self)
 
     # Floor-specific events keep gameplay varied without hardcoding logic in
     # play_game. Additional floors can be added here easily.

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -1,0 +1,47 @@
+"""Event system for random floor encounters."""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from .dungeon import DungeonBase
+
+
+class BaseEvent:
+    """Abstract base class for all events."""
+
+    def trigger(self, game: "DungeonBase") -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class MerchantEvent(BaseEvent):
+    """Open the in-game shop."""
+
+    def trigger(self, game: "DungeonBase") -> None:
+        game.shop()
+
+
+class PuzzleEvent(BaseEvent):
+    """Present a riddle that rewards gold when solved."""
+
+    def trigger(self, game: "DungeonBase") -> None:
+        riddle, answer = random.choice(game.riddles)
+        print("A sage presents a riddle:\n" + riddle)
+        response = input("Answer: ").strip().lower()
+        if response == answer:
+            reward = 50
+            print(f"Correct! You receive {reward} gold.")
+            game.player.gold += reward
+        else:
+            print("Incorrect! The sage vanishes in disappointment.")
+
+
+class TrapEvent(BaseEvent):
+    """Inflict random damage to the player."""
+
+    def trigger(self, game: "DungeonBase") -> None:
+        damage = random.randint(5, 20)
+        game.player.take_damage(damage)
+        print(f"A trap is sprung! You take {damage} damage.")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from unittest.mock import patch
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+from dungeoncrawler.events import MerchantEvent, PuzzleEvent, TrapEvent
+
+
+def setup_game():
+    game = DungeonBase(5, 5)
+    game.player = Player("hero")
+    return game
+
+
+def test_merchant_event_calls_shop():
+    game = setup_game()
+    event = MerchantEvent()
+    with patch.object(DungeonBase, "shop") as mock_shop:
+        event.trigger(game)
+        assert mock_shop.called
+
+
+def test_puzzle_event_rewards_on_correct_answer():
+    game = setup_game()
+    event = PuzzleEvent()
+    with patch("dungeoncrawler.events.random.choice", return_value=("riddle", "answer")), \
+         patch("builtins.input", return_value="answer"):
+        gold_before = game.player.gold
+        event.trigger(game)
+        assert game.player.gold == gold_before + 50
+
+
+def test_trap_event_deals_damage():
+    game = setup_game()
+    event = TrapEvent()
+    with patch("dungeoncrawler.events.random.randint", return_value=10):
+        health_before = game.player.health
+        event.trigger(game)
+        assert game.player.health == health_before - 10
+
+
+def test_random_event_selection_from_floor_config():
+    game = setup_game()
+    with patch("dungeoncrawler.dungeon.random.choice", return_value=MerchantEvent), \
+         patch.object(DungeonBase, "shop") as mock_shop:
+        game.trigger_random_event(1)
+        assert mock_shop.called


### PR DESCRIPTION
## Summary
- implement `MerchantEvent`, `PuzzleEvent`, and `TrapEvent`
- allow floors to register random events and trigger them via `trigger_random_event`
- document random events in the gameplay guide
- test event triggering and outcomes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a6917c460832680b657232bbe0be4