### PR TITLE
Use curses for map display with legend and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ floor one, a guild becomes available on floor two, and races are unlocked on
 floor three. Use the number menu to explore rooms, fight monsters, visit
 shops, and descend deeper into the dungeon.
 
-At any time you may choose **8. Show Map** to display a grid of the dungeon. The map marks your location with `@`, rooms you've visited with `.`, and unexplored or blocked rooms with `#`.
+At any time you may choose **8. Show Map** to display a grid of the dungeon. The map marks your location with `@`, rooms you've visited with `.`, unexplored or blocked rooms with `#`, and the exit with `E`. While viewing the map, press `?` to toggle a legend of these symbols. Press `q` to return to the game.
 
 Progress is automatically saved whenever you clear a floor. On the next launch you will be asked if you want to continue.
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,0 +1,28 @@
+import os
+import random
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+from dungeoncrawler import map as dungeon_map
+
+
+def test_render_map_snapshot():
+    random.seed(0)
+    game = DungeonBase(1, 1)
+    game.player = Player("Tester")
+    dungeon_map.generate_dungeon(game, floor=1)
+    rendered = dungeon_map.render_map_string(game)
+    expected = (
+        "########\n"
+        "########\n"
+        "########\n"
+        "########\n"
+        "####@###\n"
+        "###E####\n"
+        "########\n"
+        "########"
+    )
+    assert rendered == expected


### PR DESCRIPTION
## Summary
- render dungeon map with curses colors and toggleable legend
- expose `render_map_string` and add snapshot test
- document map symbols and key bindings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a6ddc18288326ba421eca5ae1bad9