### PR TITLE
Add interactive tutorial and save persistence

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from .constants import ANNOUNCER_LINES, RIDDLES, SAVE_FILE, SCORE_FILE
-from .entities import Companion, Enemy, Player
+from .entities import Companion, Player
 from .items import Item, Weapon
 from .plugins import apply_enemy_plugins, apply_item_plugins
 from . import combat as combat_module
@@ -119,6 +119,7 @@ def floor_size(floor):
     """Return map size for a given floor with cap at 15x15."""
     size = min(7 + floor, 15)
     return (size, size)
+
 
 # Floor specific configuration
 FLOOR_CONFIGS = {
@@ -367,6 +368,7 @@ class DungeonBase:
         self.visited_rooms = set()
         self.player = None
         self.exit_coords = None
+        self.tutorial_complete = False
         self.shop_items = [
             Item("Health Potion", "Restores 20 health"),
             Weapon("Sword", "A sharp sword", 10, 15, 40),
@@ -412,6 +414,7 @@ class DungeonBase:
 
         data = {
             "floor": floor,
+            "tutorial_complete": self.tutorial_complete,
             "player": {
                 "name": self.player.name,
                 "level": self.player.level,
@@ -444,6 +447,7 @@ class DungeonBase:
                     data = json.load(f)
             except (IOError, json.JSONDecodeError):
                 return 1
+            self.tutorial_complete = data.get("tutorial_complete", False)
             self.player = Player(
                 data["player"]["name"], data["player"].get("class", "Novice")
             )

--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -6,6 +6,8 @@ race and guild selections are deferred to later floors and offered by the
 ``DungeonBase`` floor events.
 """
 
+import argparse
+
 from .config import load_config
 from .dungeon import DungeonBase
 from .entities import Player
@@ -34,12 +36,28 @@ def build_character():
     return player
 
 
-def main():
+def main(argv=None):
+    """Run the game with optional command line arguments."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--skip-tutorial",
+        action="store_true",
+        help="Do not run the interactive tutorial",
+    )
+    args = parser.parse_args(argv)
+
     cfg = load_config()
     game = DungeonBase(cfg.screen_width, cfg.screen_height)
     cont = input("Load existing save? (y/n): ").strip().lower()
     if cont != "y":
         game.player = build_character()
+        if args.skip_tutorial:
+            game.tutorial_complete = True
+        elif not game.tutorial_complete:
+            from .tutorial import run as run_tutorial
+
+            run_tutorial(game)
     game.play_game()
 
 

--- a/dungeoncrawler/tutorial.py
+++ b/dungeoncrawler/tutorial.py
@@ -1,0 +1,52 @@
+"""Interactive tutorial for basic game mechanics."""
+
+from __future__ import annotations
+
+
+def run(game) -> None:
+    """Run the tutorial sequence.
+
+    The tutorial walks the player through movement, combat and
+    inventory management. It relies on simple text prompts that must
+    be acknowledged with the appropriate command before moving on to
+    the next section.
+    """
+
+    print("=== Welcome to the Dungeon Crawler tutorial! ===")
+    print("Let's begin with movement. Use '1' (left), '2' (right), '3' (up) or '4' (down).")
+    while True:
+        move = input("Move: ").strip()
+        if move in {"1", "2", "3", "4"}:
+            print("Good job! You can navigate the dungeon using those keys.")
+            break
+        print("Please use one of 1, 2, 3 or 4 to move.")
+
+    print("Now let's practice combat. Type 'attack' to strike the training dummy.")
+    while True:
+        action = input("Action: ").strip().lower()
+        if action == "attack":
+            print("The dummy falls apart. A solid hit!")
+            break
+        print("Type 'attack' to perform an attack.")
+
+    print("Finally, open your inventory by typing 'inventory'.")
+    while True:
+        action = input("Command: ").strip().lower()
+        if action == "inventory":
+            print("Your empty bag opens. You'll fill it with loot soon enough.")
+            break
+        print("Type 'inventory' to check your belongings.")
+
+    print("That's it for the basics. Good luck in the dungeon!")
+    game.tutorial_complete = True
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience script
+    from .config import load_config
+    from .dungeon import DungeonBase
+    from .main import build_character
+
+    cfg = load_config()
+    game = DungeonBase(cfg.screen_width, cfg.screen_height)
+    game.player = build_character()
+    run(game)

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import dungeoncrawler.dungeon as dungeon_module
+from dungeoncrawler import tutorial as tutorial_module
+from dungeoncrawler.main import main
+from dungeoncrawler.dungeon import DungeonBase
+
+
+def test_tutorial_runs_once_per_save(tmp_path, monkeypatch):
+    save_path = tmp_path / "save.json"
+    monkeypatch.setattr(dungeon_module, "SAVE_FILE", str(save_path))
+
+    calls = []
+
+    def fake_tutorial(game):
+        calls.append(True)
+        game.tutorial_complete = True
+
+    monkeypatch.setattr(tutorial_module, "run", fake_tutorial)
+
+    def fake_play_game(self):
+        if self.player is None:
+            self.load_game()
+        self.save_game(1)
+
+    monkeypatch.setattr(DungeonBase, "play_game", fake_play_game)
+
+    inputs = iter(["n", "Alice"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    main([])
+    assert len(calls) == 1
+
+    inputs = iter(["y"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    main([])
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- Add interactive tutorial guiding movement, combat and inventory
- Trigger tutorial after character creation with optional `--skip-tutorial`
- Persist tutorial completion state in save data
- Test to ensure tutorial executes only once per save

## Testing
- `flake8 dungeoncrawler/dungeon.py dungeoncrawler/tutorial.py dungeoncrawler/main.py tests/test_tutorial.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a6f0515ac8326af2bc31eeb265d0d