### PR TITLE
Add persistent leaderboard and viewing command

### DIFF
--- a/dungeoncrawler/constants.py
+++ b/dungeoncrawler/constants.py
@@ -5,10 +5,17 @@ from pathlib import Path
 from .config import config
 
 # Configuration-driven values
-SAVE_DIR = Path.home() / ".dungeon_crawler" / "saves"
+# Base directory for all persistent data
+BASE_DIR = Path.home() / ".dungeon_crawler"
+BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Save files remain in a subdirectory to keep things tidy
+SAVE_DIR = BASE_DIR / "saves"
 SAVE_DIR.mkdir(parents=True, exist_ok=True)
 SAVE_FILE = SAVE_DIR / config.save_file
-SCORE_FILE = SAVE_DIR / config.score_file
+
+# Leaderboard is stored directly in ``~/.dungeon_crawler``
+SCORE_FILE = BASE_DIR / config.score_file
 MAX_FLOORS = config.max_floors
 SCREEN_WIDTH = config.screen_width
 SCREEN_HEIGHT = config.screen_height

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -1,0 +1,49 @@
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import dungeoncrawler.dungeon as dungeon_module
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+
+
+def test_record_score_persistence(tmp_path, monkeypatch):
+    score_path = tmp_path / "scores.json"
+    monkeypatch.setattr(dungeon_module, "SCORE_FILE", str(score_path))
+
+    dungeon = DungeonBase(1, 1)
+    dungeon.player = Player("Tester")
+    dungeon.run_start = 1
+    dungeon.seed = 1234
+    monkeypatch.setattr(dungeon_module.time, "time", lambda: 11)
+
+    dungeon.record_score(5)
+    data = json.loads(score_path.read_text())
+    assert data[0]["player_name"] == "Tester"
+    assert data[0]["floor_reached"] == 5
+    assert data[0]["seed"] == 1234
+    assert data[0]["run_duration"] == 10
+
+
+def test_view_leaderboard_display(tmp_path, monkeypatch, capsys):
+    score_path = tmp_path / "scores.json"
+    records = [
+        {
+            "player_name": "Alice",
+            "score": 100,
+            "floor_reached": 4,
+            "run_duration": 30,
+            "seed": 42,
+        }
+    ]
+    score_path.write_text(json.dumps(records))
+    monkeypatch.setattr(dungeon_module, "SCORE_FILE", str(score_path))
+
+    dungeon = DungeonBase(1, 1)
+    dungeon.view_leaderboard()
+    captured = capsys.readouterr()
+    assert "Alice" in captured.out
+    assert "Floor 4" in captured.out
+    assert "Seed 42" in captured.out


### PR DESCRIPTION
## Summary
- Store leaderboard in `~/.dungeon_crawler/scores.json`
- Track run seed and duration and record player name and floor reached
- Add `view_leaderboard` command and tests for leaderboard persistence/display

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a70e8defc83269d1783a53f68de58