### PR TITLE
Add gettext internationalization support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ Thumbs.db
 
 # Sphinx build output
 docs/_build/
+
+# gettext compiled files
+*.mo

--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import random
 from typing import TYPE_CHECKING
+from gettext import gettext as _
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .dungeon import DungeonBase
@@ -23,7 +24,7 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
 
     player = game.player
     print(
-        f"You encountered a {enemy.name}! {enemy.ability.capitalize() if enemy.ability else ''} Boss incoming!"
+        _(f"You encountered a {enemy.name}! {enemy.ability.capitalize() if enemy.ability else ''} Boss incoming!")
     )
     game.announce(f"{player.name} engages {enemy.name}!")
     while player.is_alive() and enemy.is_alive():
@@ -39,13 +40,13 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
                     enemy.take_turn(player)
             continue
 
-        print(f"Player Health: {player.health}")
-        print(f"Enemy Health: {enemy.health}")
-        print("1. Attack\n2. Defend\n3. Use Health Potion\n4. Use Skill")
-        choice = input("Choose action: ")
+        print(_(f"Player Health: {player.health}"))
+        print(_(f"Enemy Health: {enemy.health}"))
+        print(_("1. Attack\n2. Defend\n3. Use Health Potion\n4. Use Skill"))
+        choice = input(_("Choose action: "))
         if choice == "1":
             player.attack(enemy)
-            game.announce("A fierce attack lands!")
+            game.announce(_("A fierce attack lands!"))
             if enemy.is_alive():
                 skip = enemy.apply_status_effects()
                 if enemy.is_alive() and not skip:
@@ -64,13 +65,13 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
                     enemy.take_turn(player)
         elif choice == "4":
             player.use_skill(enemy)
-            game.announce("Special skill unleashed!")
+            game.announce(_("Special skill unleashed!"))
             if enemy.is_alive():
                 skip = enemy.apply_status_effects()
                 if enemy.is_alive() and not skip:
                     enemy.take_turn(player)
         else:
-            print("Invalid choice!")
+            print(_("Invalid choice!"))
         player.decrement_cooldowns()
 
     if not enemy.is_alive():
@@ -78,6 +79,6 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
         if enemy.name in game.boss_loot:
             loot = random.choice(game.boss_loot[enemy.name])
             player.collect_item(loot)
-            print(f"The {enemy.name} dropped {loot.name}!")
-            game.announce(f"{player.name} obtains {loot.name}!")
+            print(_(f"The {enemy.name} dropped {loot.name}!"))
+            game.announce(_(f"{player.name} obtains {loot.name}!"))
 

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -4,6 +4,7 @@ import random
 import time
 from functools import lru_cache
 from pathlib import Path
+from gettext import gettext as _
 
 from .constants import ANNOUNCER_LINES, RIDDLES, SAVE_FILE, SCORE_FILE
 from .entities import Companion, Player
@@ -362,9 +363,9 @@ class DungeonBase:
     def __init__(self, width, height):
         self.width = width
         self.height = height
-        self.rooms = [[None for _ in range(width)] for _ in range(height)]
+        self.rooms = [[None for __ in range(width)] for __ in range(height)]
         self.room_names = [
-            [self.generate_room_name() for _ in range(width)] for _ in range(height)
+            [self.generate_room_name() for __ in range(width)] for __ in range(height)
         ]
         self.visited_rooms = set()
         self.player = None
@@ -398,7 +399,7 @@ class DungeonBase:
         self.seed = None
 
     def announce(self, msg):
-        print(f"[Announcer] {random.choice(ANNOUNCER_LINES)} {msg}")
+        print(_(f"[Announcer] {random.choice(ANNOUNCER_LINES)} {msg}"))
 
     def save_game(self, floor):
         def serialize_item(item):
@@ -541,23 +542,23 @@ class DungeonBase:
                 except (IOError, json.JSONDecodeError):
                     records = []
 
-        print("-- Leaderboard --")
+        print(_("-- Leaderboard --"))
         if not records:
-            print("No scores yet.")
+            print(_("No scores yet."))
             return
         for r in records:
             print(
-                f"{r.get('player_name', '?')}: {r.get('score', 0)} "
-                f"(Floor {r.get('floor_reached', '?')}, {r.get('run_duration', 0):.0f}s, Seed {r.get('seed', '?')})"
+                _(f"{r.get('player_name', '?')}: {r.get('score', 0)} "
+                  f"(Floor {r.get('floor_reached', '?')}, {r.get('run_duration', 0):.0f}s, Seed {r.get('seed', '?')})")
             )
 
     def offer_class(self):
         if self.player.class_type != "Novice":
             return
-        print("It's time to choose your class!")
-        print("1. Warrior 2. Mage 3. Rogue 4. Cleric 5. Paladin 6. Bard")
-        print("7. Barbarian 8. Druid 9. Ranger 10. Sorcerer 11. Monk")
-        print("12. Warlock 13. Necromancer 14. Shaman 15. Alchemist")
+        print(_("It's time to choose your class!"))
+        print(_("1. Warrior 2. Mage 3. Rogue 4. Cleric 5. Paladin 6. Bard"))
+        print(_("7. Barbarian 8. Druid 9. Ranger 10. Sorcerer 11. Monk"))
+        print(_("12. Warlock 13. Necromancer 14. Shaman 15. Alchemist"))
         classes = {
             "1": "Warrior",
             "2": "Mage",
@@ -577,24 +578,24 @@ class DungeonBase:
         }
         choice = ""
         while choice not in classes:
-            choice = input("Class: ")
+            choice = input(_("Class: "))
             if choice not in classes:
-                print("Invalid choice. Please try again.")
+                print(_("Invalid choice. Please try again."))
         self.player.choose_class(classes[choice])
 
     def offer_guild(self):
         if self.player.guild:
             return
-        print("Guilds now accept new members!")
-        print("1. Warriors' Guild - Bonus Health")
-        print("2. Mages' Guild - Bonus Attack")
-        print("3. Rogues' Guild - Faster Skills")
-        print("4. Healers' Circle - Extra Vitality")
-        print("5. Shadow Brotherhood - Heavy Strikes")
-        print("6. Arcane Order - Arcane Mastery")
-        print("7. Rangers' Lodge - Balanced Training")
-        print("8. Berserkers' Clan - Brutal Strength")
-        choice = input("Join which guild? (1-8 or skip): ")
+        print(_("Guilds now accept new members!"))
+        print(_("1. Warriors' Guild - Bonus Health"))
+        print(_("2. Mages' Guild - Bonus Attack"))
+        print(_("3. Rogues' Guild - Faster Skills"))
+        print(_("4. Healers' Circle - Extra Vitality"))
+        print(_("5. Shadow Brotherhood - Heavy Strikes"))
+        print(_("6. Arcane Order - Arcane Mastery"))
+        print(_("7. Rangers' Lodge - Balanced Training"))
+        print(_("8. Berserkers' Clan - Brutal Strength"))
+        choice = input(_("Join which guild? (1-8 or skip): "))
         guilds = {
             "1": "Warriors' Guild",
             "2": "Mages' Guild",
@@ -611,11 +612,11 @@ class DungeonBase:
     def offer_race(self):
         if self.player.race:
             return
-        print("New races are available to you!")
-        print("1. Human 2. Elf 3. Dwarf 4. Orc 5. Gnome 6. Halfling")
-        print("7. Catfolk 8. Lizardfolk 9. Tiefling 10. Aasimar 11. Goblin")
-        print("12. Dragonborn 13. Half-Elf 14. Kobold 15. Triton")
-        choice = input("Choose your race: ")
+        print(_("New races are available to you!"))
+        print(_("1. Human 2. Elf 3. Dwarf 4. Orc 5. Gnome 6. Halfling"))
+        print(_("7. Catfolk 8. Lizardfolk 9. Tiefling 10. Aasimar 11. Goblin"))
+        print(_("12. Dragonborn 13. Half-Elf 14. Kobold 15. Triton"))
+        choice = input(_("Choose your race: "))
         races = {
             "1": "Human",
             "2": "Elf",
@@ -683,7 +684,7 @@ class DungeonBase:
         if self.player is None:
             floor = self.load_game()
             if self.player:
-                cont = input("Continue your last adventure? (y/n): ")
+                cont = input(_("Continue your last adventure? (y/n): "))
                 if cont.lower() != "y":
                     self.player = None
                     floor = 1
@@ -695,27 +696,27 @@ class DungeonBase:
         self.seed = random.randrange(2**32)
         random.seed(self.seed)
         self.run_start = time.time()
-        print("Welcome to Dungeon Crawler!")
+        print(_("Welcome to Dungeon Crawler!"))
         while self.player.is_alive() and floor <= 18:
-            print(f"===== Entering Floor {floor} =====")
+            print(_(f"===== Entering Floor {floor} ====="))
             self.generate_dungeon(floor)
             self.trigger_floor_event(floor)
 
             while self.player.is_alive():
                 print(
-                    f"Position: ({self.player.x}, {self.player.y}) - {self.room_names[self.player.y][self.player.x]}"
+                    _(f"Position: ({self.player.x}, {self.player.y}) - {self.room_names[self.player.y][self.player.x]}")
                 )
                 print(
-                    f"Health: {self.player.health} | XP: {self.player.xp} | Gold: {self.player.gold} | Level: {self.player.level} | Floor: {floor} | Skill CD: {self.player.skill_cooldown}"
+                    _(f"Health: {self.player.health} | XP: {self.player.xp} | Gold: {self.player.gold} | Level: {self.player.level} | Floor: {floor} | Skill CD: {self.player.skill_cooldown}")
                 )
                 if self.player.guild:
-                    print(f"Guild: {self.player.guild}")
+                    print(_(f"Guild: {self.player.guild}"))
                 if self.player.race:
-                    print(f"Race: {self.player.race}")
+                    print(_(f"Race: {self.player.race}"))
                 print(
-                    "1. Move Left 2. Move Right 3. Move Up 4. Move Down 5. Visit Shop 6. Inventory 7. Quit 8. Show Map 9. View Leaderboard"
+                    _("1. Move Left 2. Move Right 3. Move Up 4. Move Down 5. Visit Shop 6. Inventory 7. Quit 8. Show Map 9. View Leaderboard")
                 )
-                choice = input("Action: ")
+                choice = input(_("Action: "))
 
                 if choice == "1":
                     self.move_player("left")
@@ -730,14 +731,14 @@ class DungeonBase:
                 elif choice == "6":
                     self.show_inventory()
                 elif choice == "7":
-                    print("Thanks for playing!")
+                    print(_("Thanks for playing!"))
                     return
                 elif choice == "8":
                     self.render_map()
                 elif choice == "9":
                     self.view_leaderboard()
                 else:
-                    print("Invalid choice!")
+                    print(_("Invalid choice!"))
 
                 if (
                     self.player.level >= 5
@@ -750,17 +751,17 @@ class DungeonBase:
                     and self.player.y == self.exit_coords[1]
                     and self.player.has_item("Key")
                 ):
-                    print("You reach the Sealed Gate.")
+                    print(_("You reach the Sealed Gate."))
                     proceed = input(
-                        "Would you like to descend to the next floor? (y/n): "
+                        _("Would you like to descend to the next floor? (y/n): ")
                     ).lower()
                     if proceed == "y":
                         floor += 1
                         self.save_game(floor)
                         break
                     else:
-                        print("You chose to exit the dungeon.")
-                        print(f"Final Score: {self.player.get_score()}")
+                        print(_("You chose to exit the dungeon."))
+                        print(_(f"Final Score: {self.player.get_score()}"))
                         self.record_score(floor)
                         if os.path.exists(SAVE_FILE):
                             try:
@@ -769,8 +770,8 @@ class DungeonBase:
                                 pass
                         return
 
-        print("You have died. Game Over!")
-        print(f"Final Score: {self.player.get_score()}")
+        print(_("You have died. Game Over!"))
+        print(_(f"Final Score: {self.player.get_score()}"))
         self.record_score(floor)
         if os.path.exists(SAVE_FILE):
             try:
@@ -792,16 +793,16 @@ class DungeonBase:
 
     def audience_gift(self):
         if random.random() < 0.1:
-            print("A package falls from above! It's a gift from the audience.")
+            print(_("A package falls from above! It's a gift from the audience."))
             if random.random() < 0.5:
                 item = Item("Health Potion", "Restores 20 health")
                 self.player.collect_item(item)
-                print(f"You received a {item.name}.")
+                print(_(f"You received a {item.name}."))
                 self.announce(f"{self.player.name} gains a helpful item!")
             else:
                 damage = random.randint(5, 15)
                 self.player.take_damage(damage)
-                print(f"Uh-oh! It explodes and deals {damage} damage.")
+                print(_(f"Uh-oh! It explodes and deals {damage} damage."))
                 self.announce("The crowd loves a good prank!")
 
     def grant_inspiration(self, turns=3):
@@ -823,14 +824,14 @@ class DungeonBase:
     def riddle_challenge(self):
         """Present the player with a riddle for a potential reward."""
         riddle, answer = random.choice(self.riddles)
-        print("A sage poses a riddle:\n" + riddle)
-        response = input("Answer: ").strip().lower()
+        print(_("A sage poses a riddle:\n") + riddle)
+        response = input(_("Answer: ")).strip().lower()
         if response == answer:
             reward = 50
-            print(f"Correct! You receive {reward} gold.")
+            print(_(f"Correct! You receive {reward} gold."))
             self.player.gold += reward
         else:
-            print("Incorrect! The sage vanishes in disappointment.")
+            print(_("Incorrect! The sage vanishes in disappointment."))
 
     def trigger_random_event(self, floor):
         """Randomly select and trigger an event for ``floor``."""
@@ -857,7 +858,7 @@ class DungeonBase:
             events[floor]()
 
     def _floor_one_event(self):
-        print("The crowd roars as you step into the arena for the first time.")
+        print(_("The crowd roars as you step into the arena for the first time."))
         self.offer_class()
 
     def _floor_two_event(self):
@@ -867,16 +868,16 @@ class DungeonBase:
         self.offer_race()
 
     def _floor_five_event(self):
-        print("A mysterious merchant sets up shop, selling exotic wares.")
+        print(_("A mysterious merchant sets up shop, selling exotic wares."))
 
     def _floor_eight_event(self):
-        print("You stumble upon a radiant shrine, filling you with determination.")
+        print(_("You stumble upon a radiant shrine, filling you with determination."))
         self.grant_inspiration()
 
     def _floor_twelve_event(self):
-        print("An elusive merchant appears, offering rare goods.")
+        print(_("An elusive merchant appears, offering rare goods."))
         self.shop()
 
     def _floor_fifteen_event(self):
-        print("A robed sage blocks your path, offering a riddle challenge.")
+        print(_("A robed sage blocks your path, offering a riddle challenge."))
         self.riddle_challenge()

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import random
+from gettext import gettext as _
 
 from .constants import ANNOUNCER_LINES
 from .items import Item, Weapon
@@ -78,7 +79,7 @@ class Player(Entity):
 
         self.health = self.max_health
         if announce:
-            print(f"Class selected: {self.class_type}.")
+            print(_(f"Class selected: {self.class_type}."))
 
     def is_alive(self):
         return self.health > 0
@@ -102,9 +103,9 @@ class Player(Entity):
             self.inventory.remove(potion)
             healed_amount = min(20, self.max_health - self.health)
             self.health += healed_amount
-            print(f"You used a Health Potion and gained {healed_amount} health.")
+            print(_(f"You used a Health Potion and gained {healed_amount} health."))
         else:
-            print("You don't have a Health Potion to use.")
+            print(_("You don't have a Health Potion to use."))
 
     def attack(self, enemy: Enemy) -> None:
         """Attack ``enemy`` using the equipped weapon or base attack power.
@@ -114,7 +115,7 @@ class Player(Entity):
         """
         damage: int = self.calculate_damage()
         self.apply_weapon_effect(enemy)
-        print(f"You attacked the {enemy.name} and dealt {damage} damage!")
+        print(_(f"You attacked the {enemy.name} and dealt {damage} damage!"))
         enemy.take_damage(damage)
         if not enemy.is_alive():
             self.process_enemy_defeat(enemy)
@@ -131,7 +132,7 @@ class Player(Entity):
             effect = self.weapon.effect
             enemy.status_effects = getattr(enemy, "status_effects", {})
             enemy.status_effects[effect] = 3
-            print(f"Your weapon inflicts {effect} on the {enemy.name}!")
+            print(_(f"Your weapon inflicts {effect} on the {enemy.name}!"))
 
     def process_enemy_defeat(self, enemy: Enemy) -> None:
         """Handle rewards for defeating ``enemy`` such as XP and gold."""
@@ -140,8 +141,8 @@ class Player(Entity):
         if self.level >= 3:
             gold_dropped += 5
         self.gold += gold_dropped
-        print(f"You defeated the {enemy.name}!")
-        print(f"You gained {enemy.xp} XP and {gold_dropped} gold.")
+        print(_(f"You defeated the {enemy.name}!"))
+        print(_(f"You gained {enemy.xp} XP and {gold_dropped} gold."))
         while self.xp >= self.level * 20:
             self.xp -= self.level * 20
             self.level_up()
@@ -149,12 +150,12 @@ class Player(Entity):
     def defend(self, enemy):
         damage = max(0, enemy.attack_power - 5)
         self.health -= damage
-        print(f"The {enemy.name} attacked you and dealt {damage} damage.")
+        print(_(f"The {enemy.name} attacked you and dealt {damage} damage."))
 
     def take_damage(self, damage):
         if "shield" in self.status_effects:
             damage = max(0, damage - 5)
-            print("Your shield absorbs 5 damage!")
+            print(_("Your shield absorbs 5 damage!"))
         self.health = max(0, self.health - damage)
 
     def apply_status_effects(self):
@@ -163,7 +164,7 @@ class Player(Entity):
             poison_turns = self.status_effects["poison"]
             if poison_turns > 0:
                 self.health -= 3
-                print("You take 3 poison damage!")
+                print(_("You take 3 poison damage!"))
                 self.status_effects["poison"] -= 1
             if self.status_effects["poison"] <= 0:
                 del self.status_effects["poison"]
@@ -171,7 +172,7 @@ class Player(Entity):
             burn_turns = self.status_effects["burn"]
             if burn_turns > 0:
                 self.health -= 4
-                print("You suffer 4 burn damage!")
+                print(_("You suffer 4 burn damage!"))
                 self.status_effects["burn"] -= 1
             if self.status_effects["burn"] <= 0:
                 del self.status_effects["burn"]
@@ -179,14 +180,14 @@ class Player(Entity):
             bleed_turns = self.status_effects["bleed"]
             if bleed_turns > 0:
                 self.health -= 2
-                print("You bleed for 2 damage!")
+                print(_("You bleed for 2 damage!"))
                 self.status_effects["bleed"] -= 1
             if self.status_effects["bleed"] <= 0:
                 del self.status_effects["bleed"]
         if "freeze" in self.status_effects:
             freeze_turns = self.status_effects["freeze"]
             if freeze_turns > 0:
-                print("You're frozen and lose your turn!")
+                print(_("You're frozen and lose your turn!"))
                 self.status_effects["freeze"] -= 1
                 skip_turn = True
             if self.status_effects["freeze"] <= 0:
@@ -194,7 +195,7 @@ class Player(Entity):
         if "stun" in self.status_effects:
             stun_turns = self.status_effects["stun"]
             if stun_turns > 0:
-                print("You're stunned and can't move!")
+                print(_("You're stunned and can't move!"))
                 self.status_effects["stun"] -= 1
                 skip_turn = True
             if self.status_effects["stun"] <= 0:
@@ -202,7 +203,7 @@ class Player(Entity):
         if "shield" in self.status_effects:
             self.status_effects["shield"] -= 1
             if self.status_effects["shield"] <= 0:
-                print("Your shield fades.")
+                print(_("Your shield fades."))
                 del self.status_effects["shield"]
         if "inspire" in self.status_effects:
             if self.status_effects["inspire"] == 3:
@@ -219,92 +220,92 @@ class Player(Entity):
 
     def use_skill(self, enemy):
         if self.skill_cooldown > 0:
-            print(f"Your skill is on cooldown for {self.skill_cooldown} more turn(s).")
+            print(_(f"Your skill is on cooldown for {self.skill_cooldown} more turn(s)."))
             return
         if self.class_type == "Warrior":
             damage = self.attack_power * 2
-            print(f"You unleash a mighty Power Strike dealing {damage} damage!")
+            print(_(f"You unleash a mighty Power Strike dealing {damage} damage!"))
             enemy.take_damage(damage)
         elif self.class_type == "Mage":
             damage = self.attack_power + random.randint(10, 15)
-            print(f"You cast Fireball dealing {damage} damage!")
+            print(_(f"You cast Fireball dealing {damage} damage!"))
             enemy.take_damage(damage)
             enemy.status_effects = getattr(enemy, "status_effects", {})
             enemy.status_effects["burn"] = 3
         elif self.class_type == "Rogue":
             damage = self.attack_power + random.randint(5, 10)
-            print(f"You perform a sneaky Backstab for {damage} damage!")
+            print(_(f"You perform a sneaky Backstab for {damage} damage!"))
             enemy.take_damage(damage)
         elif self.class_type == "Cleric":
             heal = min(20, self.max_health - self.health)
             self.health += heal
-            print(f"You invoke Healing Light and recover {heal} health!")
+            print(_(f"You invoke Healing Light and recover {heal} health!"))
         elif self.class_type == "Paladin":
             damage = self.attack_power + random.randint(5, 12)
-            print(f"You smite the {enemy.name} for {damage} holy damage!")
+            print(_(f"You smite the {enemy.name} for {damage} holy damage!"))
             enemy.take_damage(damage)
             heal = min(10, self.max_health - self.health)
             if heal:
                 self.health += heal
-                print(f"Divine power heals you for {heal} HP!")
+                print(_(f"Divine power heals you for {heal} HP!"))
         elif self.class_type == "Bard":
-            print("You play an inspiring tune, bolstering your spirit!")
+            print(_("You play an inspiring tune, bolstering your spirit!"))
             self.status_effects["inspire"] = 3
         elif self.class_type == "Barbarian":
             damage = self.attack_power + random.randint(8, 12)
             enemy.take_damage(damage)
             heal = min(10, self.max_health - self.health)
             self.health += heal
-            print(f"You enter a rage, dealing {damage} damage and healing {heal}!")
+            print(_(f"You enter a rage, dealing {damage} damage and healing {heal}!"))
         elif self.class_type == "Druid":
             damage = self.attack_power + random.randint(5, 10)
             enemy.take_damage(damage)
             enemy.status_effects["freeze"] = 1
             heal = min(5, self.max_health - self.health)
             self.health += heal
-            print(f"Nature's wrath deals {damage} damage and restores {heal} health!")
+            print(_(f"Nature's wrath deals {damage} damage and restores {heal} health!"))
         elif self.class_type == "Ranger":
             damage = self.attack_power + random.randint(6, 12)
             enemy.take_damage(damage)
             enemy.status_effects["poison"] = 3
-            print(f"A volley of arrows hits for {damage} damage and poisons the foe!")
+            print(_(f"A volley of arrows hits for {damage} damage and poisons the foe!"))
         elif self.class_type == "Sorcerer":
             damage = self.attack_power + random.randint(12, 18)
             enemy.take_damage(damage)
             enemy.status_effects["burn"] = 3
-            print(f"You unleash Arcane Blast for {damage} damage!")
+            print(_(f"You unleash Arcane Blast for {damage} damage!"))
         elif self.class_type == "Monk":
             damage = self.attack_power + random.randint(4, 8)
             enemy.take_damage(damage)
             enemy.take_damage(damage)
-            print(f"You strike twice with a flurry for {damage * 2} total damage!")
+            print(_(f"You strike twice with a flurry for {damage * 2} total damage!"))
         elif self.class_type == "Warlock":
             damage = self.attack_power + random.randint(8, 12)
             enemy.take_damage(damage)
             heal = min(damage // 2, self.max_health - self.health)
             self.health += heal
-            print(f"Eldritch energy deals {damage} damage and heals you for {heal}!")
+            print(_(f"Eldritch energy deals {damage} damage and heals you for {heal}!"))
         elif self.class_type == "Necromancer":
             damage = self.attack_power + random.randint(5, 10)
             enemy.take_damage(damage)
             heal = min(damage // 2, self.max_health - self.health)
             self.health += heal
-            print(f"You siphon the enemy's soul for {damage} damage and {heal} health!")
+            print(_(f"You siphon the enemy's soul for {damage} damage and {heal} health!"))
         elif self.class_type == "Shaman":
             heal = min(15, self.max_health - self.health)
             self.health += heal
             damage = self.attack_power + random.randint(4, 8)
             enemy.take_damage(damage)
-            print(f"Spirits mend you for {heal} and shock the foe for {damage} damage!")
+            print(_(f"Spirits mend you for {heal} and shock the foe for {damage} damage!"))
         elif self.class_type == "Alchemist":
             damage = self.attack_power + random.randint(8, 12)
             enemy.take_damage(damage)
             enemy.status_effects["burn"] = 3
             print(
-                f"An explosive flask bursts for {damage} damage and sets the foe ablaze!"
+                _(f"An explosive flask bursts for {damage} damage and sets the foe ablaze!")
             )
         else:
-            print("You don't have a special skill.")
+            print(_("You don't have a special skill."))
             return
         if not enemy.is_alive():
             self.process_enemy_defeat(enemy)
@@ -315,14 +316,14 @@ class Player(Entity):
         self.max_health += 10
         self.health = self.max_health
         self.attack_power += 3
-        print(f"\nYou leveled up to level {self.level}!")
-        print(f"Max Health increased to {self.max_health}")
-        print(f"Attack Power increased to {self.attack_power}")
+        print(_(f"\nYou leveled up to level {self.level}!"))
+        print(_(f"Max Health increased to {self.max_health}"))
+        print(_(f"Attack Power increased to {self.attack_power}"))
         print(random.choice(ANNOUNCER_LINES))
         if self.level == 3:
-            print("You've unlocked Gold Finder: +5 gold after each kill.")
+            print(_("You've unlocked Gold Finder: +5 gold after each kill."))
         if self.level == 5:
-            print("You've unlocked Passive Regen: Heal 1 HP per move.")
+            print(_("You've unlocked Passive Regen: Heal 1 HP per move."))
 
     def join_guild(self, guild):
         self.guild = guild
@@ -347,7 +348,7 @@ class Player(Entity):
             self.attack_power += 1
         elif guild == "Berserkers' Clan":
             self.attack_power += 3
-        print(f"You have joined the {guild}!")
+        print(_(f"You have joined the {guild}!"))
 
     def choose_race(self, race):
         self.race = race
@@ -394,18 +395,18 @@ class Player(Entity):
         elif race == "Triton":
             self.max_health += 3
             self.health += 3
-        print(f"Race selected: {race}.")
+        print(_(f"Race selected: {race}."))
 
     def equip_weapon(self, weapon):
         if weapon in self.inventory and isinstance(weapon, Weapon):
             if self.weapon:
                 self.inventory.append(self.weapon)
-                print(f"You unequipped the {self.weapon.name}")
+                print(_(f"You unequipped the {self.weapon.name}"))
             self.weapon = weapon
             self.inventory.remove(weapon)
-            print(f"You equipped the {weapon.name}")
+            print(_(f"You equipped the {weapon.name}"))
         else:
-            print("You don't have a valid weapon to equip.")
+            print(_("You don't have a valid weapon to equip."))
 
     def get_score(self):
         return self.level * 100 + len(self.inventory) * 10 + self.gold
@@ -438,7 +439,7 @@ class Enemy(Entity):
     def take_damage(self, damage):
         if "shield" in self.status_effects:
             damage = max(0, damage - 5)
-            print(f"The {self.name}'s shield absorbs 5 damage!")
+            print(_(f"The {self.name}'s shield absorbs 5 damage!"))
         self.health = max(0, self.health - damage)
 
     def drop_gold(self):
@@ -450,34 +451,34 @@ class Enemy(Entity):
         if "poison" in self.status_effects:
             if self.status_effects["poison"] > 0:
                 self.health -= 3
-                print(f"The {self.name} takes 3 poison damage!")
+                print(_(f"The {self.name} takes 3 poison damage!"))
                 self.status_effects["poison"] -= 1
             if self.status_effects["poison"] <= 0:
                 del self.status_effects["poison"]
         if "burn" in self.status_effects:
             if self.status_effects["burn"] > 0:
                 self.health -= 4
-                print(f"The {self.name} suffers 4 burn damage!")
+                print(_(f"The {self.name} suffers 4 burn damage!"))
                 self.status_effects["burn"] -= 1
             if self.status_effects["burn"] <= 0:
                 del self.status_effects["burn"]
         if "bleed" in self.status_effects:
             if self.status_effects["bleed"] > 0:
                 self.health -= 2
-                print(f"The {self.name} bleeds for 2 damage!")
+                print(_(f"The {self.name} bleeds for 2 damage!"))
                 self.status_effects["bleed"] -= 1
             if self.status_effects["bleed"] <= 0:
                 del self.status_effects["bleed"]
         if "freeze" in self.status_effects:
             if self.status_effects["freeze"] > 0:
-                print(f"The {self.name} is frozen and can't move!")
+                print(_(f"The {self.name} is frozen and can't move!"))
                 self.status_effects["freeze"] -= 1
                 skip_turn = True
             if self.status_effects["freeze"] <= 0:
                 del self.status_effects["freeze"]
         if "stun" in self.status_effects:
             if self.status_effects["stun"] > 0:
-                print(f"The {self.name} is stunned and can't move!")
+                print(_(f"The {self.name} is stunned and can't move!"))
                 self.status_effects["stun"] -= 1
                 skip_turn = True
             if self.status_effects["stun"] <= 0:
@@ -485,13 +486,13 @@ class Enemy(Entity):
         if "shield" in self.status_effects:
             self.status_effects["shield"] -= 1
             if self.status_effects["shield"] <= 0:
-                print(f"The {self.name}'s shield fades.")
+                print(_(f"The {self.name}'s shield fades."))
                 del self.status_effects["shield"]
         return skip_turn
 
     def defend(self):
         self.status_effects["shield"] = 1
-        print(f"The {self.name} raises its guard!")
+        print(_(f"The {self.name} raises its guard!"))
 
     def take_turn(self, player):
         action = "attack"
@@ -506,24 +507,24 @@ class Enemy(Entity):
         damage = random.randint(self.attack_power // 2, self.attack_power)
         if self.ability == "lifesteal":
             self.health += damage // 3
-            print(f"The {self.name} drains life and heals for {damage // 3}!")
+            print(_(f"The {self.name} drains life and heals for {damage // 3}!"))
         elif self.ability == "poison":
             player.status_effects["poison"] = 3
         elif self.ability == "burn":
             player.status_effects["burn"] = 3
         elif self.ability == "stun":
             player.status_effects["stun"] = 1
-            print(f"The {self.name} stuns you!")
+            print(_(f"The {self.name} stuns you!"))
         elif self.ability == "bleed":
             player.status_effects["bleed"] = 3
         elif self.ability == "freeze":
             player.status_effects["freeze"] = 1
-            print(f"The {self.name} freezes you for 1 turns!")
+            print(_(f"The {self.name} freezes you for 1 turns!"))
         elif self.ability == "double_strike" and random.random() < 0.25:
-            print(f"The {self.name} strikes twice!")
+            print(_(f"The {self.name} strikes twice!"))
             player.take_damage(damage)
         player.take_damage(damage)
-        print(f"The {self.name} attacked you and dealt {damage} damage.")
+        print(_(f"The {self.name} attacked you and dealt {damage} damage."))
 
 
 class Companion(Entity):
@@ -556,9 +557,9 @@ class Companion(Entity):
         if self.attack_power and enemy.is_alive():
             dmg = random.randint(max(1, self.attack_power // 2), self.attack_power)
             enemy.take_damage(dmg)
-            print(f"{self.name} strikes {enemy.name} for {dmg} damage!")
+            print(_(f"{self.name} strikes {enemy.name} for {dmg} damage!"))
         if self.heal_amount and player.is_alive():
             heal = min(self.heal_amount, player.max_health - player.health)
             if heal > 0:
                 player.health += heal
-                print(f"{self.name} heals {player.name} for {heal} HP!")
+                print(_(f"{self.name} heals {player.name} for {heal} HP!"))

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import random
 from typing import TYPE_CHECKING
+from gettext import gettext as _
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .dungeon import DungeonBase
@@ -28,14 +29,14 @@ class PuzzleEvent(BaseEvent):
 
     def trigger(self, game: "DungeonBase") -> None:
         riddle, answer = random.choice(game.riddles)
-        print("A sage presents a riddle:\n" + riddle)
-        response = input("Answer: ").strip().lower()
+        print(_("A sage presents a riddle:\n") + riddle)
+        response = input(_("Answer: ")).strip().lower()
         if response == answer:
             reward = 50
-            print(f"Correct! You receive {reward} gold.")
+            print(_(f"Correct! You receive {reward} gold."))
             game.player.gold += reward
         else:
-            print("Incorrect! The sage vanishes in disappointment.")
+            print(_("Incorrect! The sage vanishes in disappointment."))
 
 
 class TrapEvent(BaseEvent):
@@ -44,4 +45,4 @@ class TrapEvent(BaseEvent):
     def trigger(self, game: "DungeonBase") -> None:
         damage = random.randint(5, 20)
         game.player.take_damage(damage)
-        print(f"A trap is sprung! You take {damage} damage.")
+        print(_(f"A trap is sprung! You take {damage} damage."))

--- a/dungeoncrawler/i18n.py
+++ b/dungeoncrawler/i18n.py
@@ -1,0 +1,20 @@
+import gettext
+import locale
+from pathlib import Path
+
+def set_language(lang: str | None = None) -> None:
+    """Initialize translations for the given language code.
+
+    Parameters
+    ----------
+    lang:
+        Optional two-letter language code.  If omitted the system locale is
+        used.  Falls back to the built-in untranslated strings when the
+        requested language is not available.
+    """
+    if lang is None:
+        lang = locale.getdefaultlocale()[0]
+    if lang:
+        lang = lang.split('_')[0]
+    localedir = Path(__file__).resolve().parent.parent / "locale"
+    gettext.translation("messages", localedir=localedir, languages=[lang], fallback=True).install()

--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -7,14 +7,10 @@ race and guild selections are deferred to later floors and offered by the
 """
 
 import argparse
+from gettext import gettext as _
 
 from .config import load_config
-from .dungeon import DungeonBase
-from .entities import Player
-# Explicitly import modules that now host game subsystems.
-from . import combat as combat_module  # noqa: F401
-from . import map as dungeon_map  # noqa: F401
-from . import shop as shop_module  # noqa: F401
+from .i18n import set_language
 
 
 def build_character():
@@ -25,14 +21,16 @@ def build_character():
     the gradual progression described in the novels.
     """
 
+    from .entities import Player
+
     name = ""
     while not name:
-        name = input("Enter your name: ").strip()
+        name = input(_("Enter your name: ")).strip()
         if not name:
-            print("Name cannot be blank.")
+            print(_("Name cannot be blank."))
 
     player = Player(name)
-    print(f"Welcome {player.name}! Your journey is just beginning.")
+    print(_("Welcome {name}! Your journey is just beginning.").format(name=player.name))
     return player
 
 
@@ -43,13 +41,23 @@ def main(argv=None):
     parser.add_argument(
         "--skip-tutorial",
         action="store_true",
-        help="Do not run the interactive tutorial",
+        help=_("Do not run the interactive tutorial"),
     )
+    parser.add_argument("--lang", help=_("Language code for translations"))
     args = parser.parse_args(argv)
+
+    set_language(args.lang)
+
+    global DungeonBase, Player
+    from .dungeon import DungeonBase
+    from .entities import Player
+    from . import combat as combat_module  # noqa: F401
+    from . import map as dungeon_map  # noqa: F401
+    from . import shop as shop_module  # noqa: F401
 
     cfg = load_config()
     game = DungeonBase(cfg.screen_width, cfg.screen_height)
-    cont = input("Load existing save? (y/n): ").strip().lower()
+    cont = input(_("Load existing save? (y/n): ")).strip().lower()
     if cont != "y":
         game.player = build_character()
         if args.skip_tutorial:

--- a/dungeoncrawler/shop.py
+++ b/dungeoncrawler/shop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from gettext import gettext as _
 
 from .items import Item, Weapon
 
@@ -13,17 +14,17 @@ if TYPE_CHECKING:  # pragma: no cover - only for type hints
 def shop(game: "DungeonBase") -> None:
     """Interact with the shop allowing the player to buy or sell items."""
 
-    print("Welcome to the Shop!")
-    print(f"Gold: {game.player.gold}")
+    print(_("Welcome to the Shop!"))
+    print(_(f"Gold: {game.player.gold}"))
     for i, item in enumerate(game.shop_items, 1):
         price = item.price if isinstance(item, Weapon) else 10
-        print(f"{i}. {item.name} - {price} Gold")
+        print(_(f"{i}. {item.name} - {price} Gold"))
     sell_option = len(game.shop_items) + 1
     exit_option = sell_option + 1
-    print(f"{sell_option}. Sell Items")
-    print(f"{exit_option}. Exit")
+    print(_(f"{sell_option}. Sell Items"))
+    print(_(f"{exit_option}. Exit"))
 
-    choice = input("Choose an option:")
+    choice = input(_("Choose an option:"))
     if choice.isdigit():
         choice = int(choice)
         if 1 <= choice <= len(game.shop_items):
@@ -32,17 +33,17 @@ def shop(game: "DungeonBase") -> None:
             if game.player.gold >= price:
                 game.player.collect_item(item)
                 game.player.gold -= price
-                print(f"You bought {item.name}.")
+                print(_(f"You bought {item.name}."))
             else:
-                print("Not enough gold.")
+                print(_("Not enough gold."))
         elif choice == sell_option:
             sell_items(game)
         elif choice == exit_option:
-            print("Leaving the shop.")
+            print(_("Leaving the shop."))
         else:
-            print("Invalid choice.")
+            print(_("Invalid choice."))
     else:
-        print("Invalid input.")
+        print(_("Invalid input."))
 
 
 def get_sale_price(item):
@@ -62,53 +63,53 @@ def sell_items(game: "DungeonBase") -> None:
     """Sell items from the player's inventory."""
 
     if not game.player.inventory:
-        print("You have nothing to sell.")
+        print(_("You have nothing to sell."))
         return
 
-    print("Your Items:")
+    print(_("Your Items:"))
     for i, item in enumerate(game.player.inventory, 1):
         sale_price = get_sale_price(item)
         if sale_price is None:
-            print(f"{i}. {item.name} - Cannot sell")
+            print(_(f"{i}. {item.name} - Cannot sell"))
         else:
-            print(f"{i}. {item.name} - {sale_price} Gold")
-    print(f"{len(game.player.inventory)+1}. Back")
+            print(_(f"{i}. {item.name} - {sale_price} Gold"))
+    print(_(f"{len(game.player.inventory)+1}. Back"))
 
-    choice = input("Sell what?")
+    choice = input(_("Sell what?"))
     if choice.isdigit():
         choice = int(choice)
         if 1 <= choice <= len(game.player.inventory):
             item = game.player.inventory[choice - 1]
             sale_price = get_sale_price(item)
             if sale_price is None:
-                print("You can't sell that item.")
+                print(_("You can't sell that item."))
                 return
-            confirm = input(f"Sell {item.name} for {sale_price} gold? (y/n) ")
+            confirm = input(_(f"Sell {item.name} for {sale_price} gold? (y/n) "))
             if confirm.lower() == "y":
                 game.player.inventory.pop(choice - 1)
                 game.player.gold += sale_price
-                print(f"You sold {item.name}.")
+                print(_(f"You sold {item.name}."))
         elif choice == len(game.player.inventory) + 1:
             return
         else:
-            print("Invalid choice.")
+            print(_("Invalid choice."))
     else:
-        print("Invalid input.")
+        print(_("Invalid input."))
 
 
 def show_inventory(game: "DungeonBase") -> None:
     """Display the player's inventory and allow equipping weapons."""
 
     if not game.player.inventory:
-        print("Your inventory is empty.")
+        print(_("Your inventory is empty."))
         return
 
-    print("Your Inventory:")
+    print(_("Your Inventory:"))
     for i, item in enumerate(game.player.inventory, 1):
         equipped = " (Equipped)" if item == game.player.weapon else ""
-        print(f"{i}. {item.name}{equipped} - {item.description}")
+        print(_(f"{i}. {item.name}{equipped} - {item.description}"))
 
-    choice = input("Enter item number to equip weapon, or press Enter to go back: ")
+    choice = input(_("Enter item number to equip weapon, or press Enter to go back: "))
     if choice.isdigit():
         idx = int(choice) - 1
         if 0 <= idx < len(game.player.inventory):
@@ -116,7 +117,7 @@ def show_inventory(game: "DungeonBase") -> None:
             if isinstance(item, Weapon):
                 game.player.equip_weapon(item)
             else:
-                print("You can only equip weapons.")
+                print(_("You can only equip weapons."))
         else:
-            print("Invalid selection.")
+            print(_("Invalid selection."))
 

--- a/dungeoncrawler/tutorial.py
+++ b/dungeoncrawler/tutorial.py
@@ -1,6 +1,7 @@
 """Interactive tutorial for basic game mechanics."""
 
 from __future__ import annotations
+from gettext import gettext as _
 
 
 def run(game) -> None:
@@ -12,32 +13,32 @@ def run(game) -> None:
     the next section.
     """
 
-    print("=== Welcome to the Dungeon Crawler tutorial! ===")
-    print("Let's begin with movement. Use '1' (left), '2' (right), '3' (up) or '4' (down).")
+    print(_("=== Welcome to the Dungeon Crawler tutorial! ==="))
+    print(_("Let's begin with movement. Use '1' (left), '2' (right), '3' (up) or '4' (down)."))
     while True:
-        move = input("Move: ").strip()
+        move = input(_("Move: ")).strip()
         if move in {"1", "2", "3", "4"}:
-            print("Good job! You can navigate the dungeon using those keys.")
+            print(_("Good job! You can navigate the dungeon using those keys."))
             break
-        print("Please use one of 1, 2, 3 or 4 to move.")
+        print(_("Please use one of 1, 2, 3 or 4 to move."))
 
-    print("Now let's practice combat. Type 'attack' to strike the training dummy.")
+    print(_("Now let's practice combat. Type 'attack' to strike the training dummy."))
     while True:
-        action = input("Action: ").strip().lower()
+        action = input(_("Action: ")).strip().lower()
         if action == "attack":
-            print("The dummy falls apart. A solid hit!")
+            print(_("The dummy falls apart. A solid hit!"))
             break
-        print("Type 'attack' to perform an attack.")
+        print(_("Type 'attack' to perform an attack."))
 
-    print("Finally, open your inventory by typing 'inventory'.")
+    print(_("Finally, open your inventory by typing 'inventory'."))
     while True:
-        action = input("Command: ").strip().lower()
+        action = input(_("Command: ")).strip().lower()
         if action == "inventory":
-            print("Your empty bag opens. You'll fill it with loot soon enough.")
+            print(_("Your empty bag opens. You'll fill it with loot soon enough."))
             break
-        print("Type 'inventory' to check your belongings.")
+        print(_("Type 'inventory' to check your belongings."))
 
-    print("That's it for the basics. Good luck in the dungeon!")
+    print(_("That's it for the basics. Good luck in the dungeon!"))
     game.tutorial_complete = True
 
 

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -1,0 +1,983 @@
+# English translations for PACKAGE package.
+# Copyright (C) 2025 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-11 22:48+0000\n"
+"PO-Revision-Date: 2025-08-11 22:48+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: dungeoncrawler/map.py:98
+#, python-brace-format
+msgid "A powerful boss guards this floor! The {name} lurks nearby..."
+msgstr "A powerful boss guards this floor! The {name} lurks nearby..."
+
+#: dungeoncrawler/map.py:111
+#, python-brace-format
+msgid "✨ The boss dropped a unique weapon: {loot.name}!"
+msgstr "✨ The boss dropped a unique weapon: {loot.name}!"
+
+#: dungeoncrawler/map.py:145
+msgid "You can't move that way."
+msgstr "You can't move that way."
+
+#: dungeoncrawler/map.py:196
+msgid "Press '?' for legend, q to exit"
+msgstr "Press '?' for legend, q to exit"
+
+#: dungeoncrawler/map.py:198
+msgid "@: Player"
+msgstr "@: Player"
+
+#: dungeoncrawler/map.py:198
+msgid "E: Exit"
+msgstr "E: Exit"
+
+#: dungeoncrawler/map.py:198
+msgid ".: Explored"
+msgstr ".: Explored"
+
+#: dungeoncrawler/map.py:198
+msgid "#: Unexplored"
+msgstr "#: Unexplored"
+
+#: dungeoncrawler/map.py:227
+#, python-brace-format
+msgid "{lore[name]}"
+msgstr "{lore[name]}"
+
+#: dungeoncrawler/map.py:234
+#, python-brace-format
+msgid "You meet {room.name}. {room.description}"
+msgstr "You meet {room.name}. {room.description}"
+
+#: dungeoncrawler/map.py:235
+msgid "Recruit this companion? (y/n): "
+msgstr "Recruit this companion? (y/n): "
+
+#: dungeoncrawler/map.py:243
+#, python-brace-format
+msgid "{game.player.name} gains a companion!"
+msgstr "{game.player.name} gains a companion!"
+
+#: dungeoncrawler/map.py:246
+#, python-brace-format
+msgid "You found a {room.name}!"
+msgstr "You found a {room.name}!"
+
+#: dungeoncrawler/map.py:248
+#, python-brace-format
+msgid "{game.player.name} obtained {room.name}!"
+msgstr "{game.player.name} obtained {room.name}!"
+
+#: dungeoncrawler/map.py:255
+#, python-brace-format
+msgid "You found a treasure chest with {gold} gold!"
+msgstr "You found a treasure chest with {gold} gold!"
+
+#: dungeoncrawler/map.py:258
+#, python-brace-format
+msgid "Inside you also discover {loot.name}!"
+msgstr "Inside you also discover {loot.name}!"
+
+#: dungeoncrawler/map.py:260
+#, python-brace-format
+msgid "{game.player.name} picks up {loot.name}!"
+msgstr "{game.player.name} picks up {loot.name}!"
+
+#: dungeoncrawler/map.py:264
+msgid "You enter a glowing chamber with ancient runes etched in the stone."
+msgstr "You enter a glowing chamber with ancient runes etched in the stone."
+
+#: dungeoncrawler/map.py:266
+#, python-brace-format
+msgid "Your current weapon is: {game.player.weapon.name}"
+msgstr "Your current weapon is: {game.player.weapon.name}"
+
+#: dungeoncrawler/map.py:267
+msgid "You may enchant it with a status effect for 30 gold."
+msgstr "You may enchant it with a status effect for 30 gold."
+
+#: dungeoncrawler/map.py:268
+msgid "1. Poison  2. Burn  3. Freeze  4. Cancel"
+msgstr "1. Poison  2. Burn  3. Freeze  4. Cancel"
+
+#: dungeoncrawler/map.py:269
+msgid "Choose enchantment: "
+msgstr "Choose enchantment: "
+
+#: dungeoncrawler/map.py:271
+msgid "Your weapon is already enchanted! You can't add another enchantment."
+msgstr "Your weapon is already enchanted! You can't add another enchantment."
+
+#: dungeoncrawler/map.py:277
+#, python-brace-format
+msgid "Your weapon is now enchanted with {effect}!"
+msgstr "Your weapon is now enchanted with {effect}!"
+
+#: dungeoncrawler/map.py:279
+msgid "You leave the enchantment chamber untouched."
+msgstr "You leave the enchantment chamber untouched."
+
+#: dungeoncrawler/map.py:281
+msgid "Not enough gold or invalid choice."
+msgstr "Not enough gold or invalid choice."
+
+#: dungeoncrawler/map.py:283
+msgid "You need a weapon to enchant."
+msgstr "You need a weapon to enchant."
+
+#: dungeoncrawler/map.py:287
+msgid "You meet a grizzled blacksmith hammering at a forge."
+msgstr "You meet a grizzled blacksmith hammering at a forge."
+
+#: dungeoncrawler/map.py:290
+#, python-brace-format
+msgid ""
+"Your weapon: {game.player.weapon.name} "
+"({game.player.weapon.min_damage}-{game.player.weapon.max_damage})"
+msgstr ""
+"Your weapon: {game.player.weapon.name} "
+"({game.player.weapon.min_damage}-{game.player.weapon.max_damage})"
+
+#: dungeoncrawler/map.py:292
+msgid "Would you like to upgrade your weapon for 50 gold? +3 min/max damage"
+msgstr "Would you like to upgrade your weapon for 50 gold? +3 min/max damage"
+
+#: dungeoncrawler/map.py:293
+msgid "Upgrade? (y/n): "
+msgstr "Upgrade? (y/n): "
+
+#: dungeoncrawler/map.py:298
+msgid "Your weapon has been reforged and is stronger!"
+msgstr "Your weapon has been reforged and is stronger!"
+
+#: dungeoncrawler/map.py:300
+msgid "You don't have enough gold."
+msgstr "You don't have enough gold."
+
+#: dungeoncrawler/map.py:302
+msgid "Maybe next time."
+msgstr "Maybe next time."
+
+#: dungeoncrawler/map.py:305
+msgid ""
+"The blacksmith scoffs. 'No weapon? Come back when you have something worth "
+"forging.'"
+msgstr ""
+"The blacksmith scoffs. 'No weapon? Come back when you have something worth "
+"forging.'"
+
+#: dungeoncrawler/map.py:312
+msgid "A soothing warmth envelops you. Your wounds are fully healed."
+msgstr "A soothing warmth envelops you. Your wounds are fully healed."
+
+#: dungeoncrawler/map.py:318
+msgid "A trap springs! Solve this riddle to escape unharmed:"
+msgstr "A trap springs! Solve this riddle to escape unharmed:"
+
+#: dungeoncrawler/map.py:320 dungeoncrawler/dungeon.py:828
+#: dungeoncrawler/events.py:33
+msgid "Answer: "
+msgstr "Answer: "
+
+#: dungeoncrawler/map.py:322
+msgid "The mechanism clicks harmlessly. You solved it!"
+msgstr "The mechanism clicks harmlessly. You solved it!"
+
+#: dungeoncrawler/map.py:323
+msgid "Brilliant puzzle solving!"
+msgstr "Brilliant puzzle solving!"
+
+#: dungeoncrawler/map.py:327
+#, python-brace-format
+msgid "Wrong answer! You take {damage} damage."
+msgstr "Wrong answer! You take {damage} damage."
+
+#: dungeoncrawler/map.py:333
+msgid "🎉 You unlocked the exit and escaped the dungeon!"
+msgstr "🎉 You unlocked the exit and escaped the dungeon!"
+
+#: dungeoncrawler/map.py:334
+msgid "Final Score: {game.player.get_score()}"
+msgstr "Final Score: {game.player.get_score()}"
+
+#: dungeoncrawler/map.py:337
+msgid "The exit is locked. You need a key!"
+msgstr "The exit is locked. You need a key!"
+
+#: dungeoncrawler/main.py:26
+msgid "Enter your name: "
+msgstr "Enter your name: "
+
+#: dungeoncrawler/main.py:28
+msgid "Name cannot be blank."
+msgstr "Name cannot be blank."
+
+#: dungeoncrawler/main.py:31
+#, python-brace-format
+msgid "Welcome {name}! Your journey is just beginning."
+msgstr "Welcome {name}! Your journey is just beginning."
+
+#: dungeoncrawler/main.py:42
+msgid "Do not run the interactive tutorial"
+msgstr "Do not run the interactive tutorial"
+
+#: dungeoncrawler/main.py:44
+msgid "Language code for translations"
+msgstr "Language code for translations"
+
+#: dungeoncrawler/main.py:58
+msgid "Load existing save? (y/n): "
+msgstr "Load existing save? (y/n): "
+
+#: dungeoncrawler/shop.py:17
+msgid "Welcome to the Shop!"
+msgstr "Welcome to the Shop!"
+
+#: dungeoncrawler/shop.py:18
+#, python-brace-format
+msgid "Gold: {game.player.gold}"
+msgstr "Gold: {game.player.gold}"
+
+#: dungeoncrawler/shop.py:21
+#, python-brace-format
+msgid "{i}. {item.name} - {price} Gold"
+msgstr "{i}. {item.name} - {price} Gold"
+
+#: dungeoncrawler/shop.py:24
+#, python-brace-format
+msgid "{sell_option}. Sell Items"
+msgstr "{sell_option}. Sell Items"
+
+#: dungeoncrawler/shop.py:25
+#, python-brace-format
+msgid "{exit_option}. Exit"
+msgstr "{exit_option}. Exit"
+
+#: dungeoncrawler/shop.py:27
+msgid "Choose an option:"
+msgstr "Choose an option:"
+
+#: dungeoncrawler/shop.py:36
+#, python-brace-format
+msgid "You bought {item.name}."
+msgstr "You bought {item.name}."
+
+#: dungeoncrawler/shop.py:38
+msgid "Not enough gold."
+msgstr "Not enough gold."
+
+#: dungeoncrawler/shop.py:42
+msgid "Leaving the shop."
+msgstr "Leaving the shop."
+
+#: dungeoncrawler/shop.py:44 dungeoncrawler/shop.py:95
+msgid "Invalid choice."
+msgstr "Invalid choice."
+
+#: dungeoncrawler/shop.py:46 dungeoncrawler/shop.py:97
+msgid "Invalid input."
+msgstr "Invalid input."
+
+#: dungeoncrawler/shop.py:66
+msgid "You have nothing to sell."
+msgstr "You have nothing to sell."
+
+#: dungeoncrawler/shop.py:69
+msgid "Your Items:"
+msgstr "Your Items:"
+
+#: dungeoncrawler/shop.py:73
+#, python-brace-format
+msgid "{i}. {item.name} - Cannot sell"
+msgstr "{i}. {item.name} - Cannot sell"
+
+#: dungeoncrawler/shop.py:75
+#, python-brace-format
+msgid "{i}. {item.name} - {sale_price} Gold"
+msgstr "{i}. {item.name} - {sale_price} Gold"
+
+#: dungeoncrawler/shop.py:76
+msgid "{len(game.player.inventory)+1}. Back"
+msgstr "{len(game.player.inventory)+1}. Back"
+
+#: dungeoncrawler/shop.py:78
+msgid "Sell what?"
+msgstr "Sell what?"
+
+#: dungeoncrawler/shop.py:85
+msgid "You can't sell that item."
+msgstr "You can't sell that item."
+
+#: dungeoncrawler/shop.py:87
+#, python-brace-format
+msgid "Sell {item.name} for {sale_price} gold? (y/n) "
+msgstr "Sell {item.name} for {sale_price} gold? (y/n) "
+
+#: dungeoncrawler/shop.py:91
+#, python-brace-format
+msgid "You sold {item.name}."
+msgstr "You sold {item.name}."
+
+#: dungeoncrawler/shop.py:104
+msgid "Your inventory is empty."
+msgstr "Your inventory is empty."
+
+#: dungeoncrawler/shop.py:107
+msgid "Your Inventory:"
+msgstr "Your Inventory:"
+
+#: dungeoncrawler/shop.py:110
+#, python-brace-format
+msgid "{i}. {item.name}{equipped} - {item.description}"
+msgstr "{i}. {item.name}{equipped} - {item.description}"
+
+#: dungeoncrawler/shop.py:112
+msgid "Enter item number to equip weapon, or press Enter to go back: "
+msgstr "Enter item number to equip weapon, or press Enter to go back: "
+
+#: dungeoncrawler/shop.py:120
+msgid "You can only equip weapons."
+msgstr "You can only equip weapons."
+
+#: dungeoncrawler/shop.py:122
+msgid "Invalid selection."
+msgstr "Invalid selection."
+
+#: dungeoncrawler/tutorial.py:16
+msgid "=== Welcome to the Dungeon Crawler tutorial! ==="
+msgstr "=== Welcome to the Dungeon Crawler tutorial! ==="
+
+#: dungeoncrawler/tutorial.py:17
+msgid ""
+"Let's begin with movement. Use '1' (left), '2' (right), '3' (up) or '4' "
+"(down)."
+msgstr ""
+"Let's begin with movement. Use '1' (left), '2' (right), '3' (up) or '4' "
+"(down)."
+
+#: dungeoncrawler/tutorial.py:19
+msgid "Move: "
+msgstr "Move: "
+
+#: dungeoncrawler/tutorial.py:21
+msgid "Good job! You can navigate the dungeon using those keys."
+msgstr "Good job! You can navigate the dungeon using those keys."
+
+#: dungeoncrawler/tutorial.py:23
+msgid "Please use one of 1, 2, 3 or 4 to move."
+msgstr "Please use one of 1, 2, 3 or 4 to move."
+
+#: dungeoncrawler/tutorial.py:25
+msgid "Now let's practice combat. Type 'attack' to strike the training dummy."
+msgstr ""
+"Now let's practice combat. Type 'attack' to strike the training dummy."
+
+#: dungeoncrawler/tutorial.py:27 dungeoncrawler/dungeon.py:719
+msgid "Action: "
+msgstr "Action: "
+
+#: dungeoncrawler/tutorial.py:29
+msgid "The dummy falls apart. A solid hit!"
+msgstr "The dummy falls apart. A solid hit!"
+
+#: dungeoncrawler/tutorial.py:31
+msgid "Type 'attack' to perform an attack."
+msgstr "Type 'attack' to perform an attack."
+
+#: dungeoncrawler/tutorial.py:33
+msgid "Finally, open your inventory by typing 'inventory'."
+msgstr "Finally, open your inventory by typing 'inventory'."
+
+#: dungeoncrawler/tutorial.py:35
+msgid "Command: "
+msgstr "Command: "
+
+#: dungeoncrawler/tutorial.py:37
+msgid "Your empty bag opens. You'll fill it with loot soon enough."
+msgstr "Your empty bag opens. You'll fill it with loot soon enough."
+
+#: dungeoncrawler/tutorial.py:39
+msgid "Type 'inventory' to check your belongings."
+msgstr "Type 'inventory' to check your belongings."
+
+#: dungeoncrawler/tutorial.py:41
+msgid "That's it for the basics. Good luck in the dungeon!"
+msgstr "That's it for the basics. Good luck in the dungeon!"
+
+#: dungeoncrawler/entities.py:81
+#, python-brace-format
+msgid "Class selected: {self.class_type}."
+msgstr "Class selected: {self.class_type}."
+
+#: dungeoncrawler/entities.py:105
+#, python-brace-format
+msgid "You used a Health Potion and gained {healed_amount} health."
+msgstr "You used a Health Potion and gained {healed_amount} health."
+
+#: dungeoncrawler/entities.py:107
+msgid "You don't have a Health Potion to use."
+msgstr "You don't have a Health Potion to use."
+
+#: dungeoncrawler/entities.py:117
+#, python-brace-format
+msgid "You attacked the {enemy.name} and dealt {damage} damage!"
+msgstr "You attacked the {enemy.name} and dealt {damage} damage!"
+
+#: dungeoncrawler/entities.py:134
+#, python-brace-format
+msgid "Your weapon inflicts {effect} on the {enemy.name}!"
+msgstr "Your weapon inflicts {effect} on the {enemy.name}!"
+
+#: dungeoncrawler/entities.py:143
+#, python-brace-format
+msgid "You defeated the {enemy.name}!"
+msgstr "You defeated the {enemy.name}!"
+
+#: dungeoncrawler/entities.py:144
+#, python-brace-format
+msgid "You gained {enemy.xp} XP and {gold_dropped} gold."
+msgstr "You gained {enemy.xp} XP and {gold_dropped} gold."
+
+#: dungeoncrawler/entities.py:152
+#, python-brace-format
+msgid "The {enemy.name} attacked you and dealt {damage} damage."
+msgstr "The {enemy.name} attacked you and dealt {damage} damage."
+
+#: dungeoncrawler/entities.py:157
+msgid "Your shield absorbs 5 damage!"
+msgstr "Your shield absorbs 5 damage!"
+
+#: dungeoncrawler/entities.py:166
+msgid "You take 3 poison damage!"
+msgstr "You take 3 poison damage!"
+
+#: dungeoncrawler/entities.py:174
+msgid "You suffer 4 burn damage!"
+msgstr "You suffer 4 burn damage!"
+
+#: dungeoncrawler/entities.py:182
+msgid "You bleed for 2 damage!"
+msgstr "You bleed for 2 damage!"
+
+#: dungeoncrawler/entities.py:189
+msgid "You're frozen and lose your turn!"
+msgstr "You're frozen and lose your turn!"
+
+#: dungeoncrawler/entities.py:197
+msgid "You're stunned and can't move!"
+msgstr "You're stunned and can't move!"
+
+#: dungeoncrawler/entities.py:205
+msgid "Your shield fades."
+msgstr "Your shield fades."
+
+#: dungeoncrawler/entities.py:222
+#, python-brace-format
+msgid "Your skill is on cooldown for {self.skill_cooldown} more turn(s)."
+msgstr "Your skill is on cooldown for {self.skill_cooldown} more turn(s)."
+
+#: dungeoncrawler/entities.py:226
+#, python-brace-format
+msgid "You unleash a mighty Power Strike dealing {damage} damage!"
+msgstr "You unleash a mighty Power Strike dealing {damage} damage!"
+
+#: dungeoncrawler/entities.py:230
+#, python-brace-format
+msgid "You cast Fireball dealing {damage} damage!"
+msgstr "You cast Fireball dealing {damage} damage!"
+
+#: dungeoncrawler/entities.py:236
+#, python-brace-format
+msgid "You perform a sneaky Backstab for {damage} damage!"
+msgstr "You perform a sneaky Backstab for {damage} damage!"
+
+#: dungeoncrawler/entities.py:241
+#, python-brace-format
+msgid "You invoke Healing Light and recover {heal} health!"
+msgstr "You invoke Healing Light and recover {heal} health!"
+
+#: dungeoncrawler/entities.py:244
+#, python-brace-format
+msgid "You smite the {enemy.name} for {damage} holy damage!"
+msgstr "You smite the {enemy.name} for {damage} holy damage!"
+
+#: dungeoncrawler/entities.py:249
+#, python-brace-format
+msgid "Divine power heals you for {heal} HP!"
+msgstr "Divine power heals you for {heal} HP!"
+
+#: dungeoncrawler/entities.py:251
+msgid "You play an inspiring tune, bolstering your spirit!"
+msgstr "You play an inspiring tune, bolstering your spirit!"
+
+#: dungeoncrawler/entities.py:258
+#, python-brace-format
+msgid "You enter a rage, dealing {damage} damage and healing {heal}!"
+msgstr "You enter a rage, dealing {damage} damage and healing {heal}!"
+
+#: dungeoncrawler/entities.py:265
+#, python-brace-format
+msgid "Nature's wrath deals {damage} damage and restores {heal} health!"
+msgstr "Nature's wrath deals {damage} damage and restores {heal} health!"
+
+#: dungeoncrawler/entities.py:270
+#, python-brace-format
+msgid "A volley of arrows hits for {damage} damage and poisons the foe!"
+msgstr "A volley of arrows hits for {damage} damage and poisons the foe!"
+
+#: dungeoncrawler/entities.py:275
+#, python-brace-format
+msgid "You unleash Arcane Blast for {damage} damage!"
+msgstr "You unleash Arcane Blast for {damage} damage!"
+
+#: dungeoncrawler/entities.py:280
+msgid "You strike twice with a flurry for {damage * 2} total damage!"
+msgstr "You strike twice with a flurry for {damage * 2} total damage!"
+
+#: dungeoncrawler/entities.py:286
+#, python-brace-format
+msgid "Eldritch energy deals {damage} damage and heals you for {heal}!"
+msgstr "Eldritch energy deals {damage} damage and heals you for {heal}!"
+
+#: dungeoncrawler/entities.py:292
+#, python-brace-format
+msgid "You siphon the enemy's soul for {damage} damage and {heal} health!"
+msgstr "You siphon the enemy's soul for {damage} damage and {heal} health!"
+
+#: dungeoncrawler/entities.py:298
+#, python-brace-format
+msgid "Spirits mend you for {heal} and shock the foe for {damage} damage!"
+msgstr "Spirits mend you for {heal} and shock the foe for {damage} damage!"
+
+#: dungeoncrawler/entities.py:304
+#, python-brace-format
+msgid "An explosive flask bursts for {damage} damage and sets the foe ablaze!"
+msgstr ""
+"An explosive flask bursts for {damage} damage and sets the foe ablaze!"
+
+#: dungeoncrawler/entities.py:307
+msgid "You don't have a special skill."
+msgstr "You don't have a special skill."
+
+#: dungeoncrawler/entities.py:318
+#, python-brace-format
+msgid ""
+"\n"
+"You leveled up to level {self.level}!"
+msgstr ""
+"\n"
+"You leveled up to level {self.level}!"
+
+#: dungeoncrawler/entities.py:319
+#, python-brace-format
+msgid "Max Health increased to {self.max_health}"
+msgstr "Max Health increased to {self.max_health}"
+
+#: dungeoncrawler/entities.py:320
+#, python-brace-format
+msgid "Attack Power increased to {self.attack_power}"
+msgstr "Attack Power increased to {self.attack_power}"
+
+#: dungeoncrawler/entities.py:323
+msgid "You've unlocked Gold Finder: +5 gold after each kill."
+msgstr "You've unlocked Gold Finder: +5 gold after each kill."
+
+#: dungeoncrawler/entities.py:325
+msgid "You've unlocked Passive Regen: Heal 1 HP per move."
+msgstr "You've unlocked Passive Regen: Heal 1 HP per move."
+
+#: dungeoncrawler/entities.py:350
+#, python-brace-format
+msgid "You have joined the {guild}!"
+msgstr "You have joined the {guild}!"
+
+#: dungeoncrawler/entities.py:397
+#, python-brace-format
+msgid "Race selected: {race}."
+msgstr "Race selected: {race}."
+
+#: dungeoncrawler/entities.py:403
+#, python-brace-format
+msgid "You unequipped the {self.weapon.name}"
+msgstr "You unequipped the {self.weapon.name}"
+
+#: dungeoncrawler/entities.py:406
+#, python-brace-format
+msgid "You equipped the {weapon.name}"
+msgstr "You equipped the {weapon.name}"
+
+#: dungeoncrawler/entities.py:408
+msgid "You don't have a valid weapon to equip."
+msgstr "You don't have a valid weapon to equip."
+
+#: dungeoncrawler/entities.py:441
+#, python-brace-format
+msgid "The {self.name}'s shield absorbs 5 damage!"
+msgstr "The {self.name}'s shield absorbs 5 damage!"
+
+#: dungeoncrawler/entities.py:453
+#, python-brace-format
+msgid "The {self.name} takes 3 poison damage!"
+msgstr "The {self.name} takes 3 poison damage!"
+
+#: dungeoncrawler/entities.py:460
+#, python-brace-format
+msgid "The {self.name} suffers 4 burn damage!"
+msgstr "The {self.name} suffers 4 burn damage!"
+
+#: dungeoncrawler/entities.py:467
+#, python-brace-format
+msgid "The {self.name} bleeds for 2 damage!"
+msgstr "The {self.name} bleeds for 2 damage!"
+
+#: dungeoncrawler/entities.py:473
+#, python-brace-format
+msgid "The {self.name} is frozen and can't move!"
+msgstr "The {self.name} is frozen and can't move!"
+
+#: dungeoncrawler/entities.py:480
+#, python-brace-format
+msgid "The {self.name} is stunned and can't move!"
+msgstr "The {self.name} is stunned and can't move!"
+
+#: dungeoncrawler/entities.py:488
+#, python-brace-format
+msgid "The {self.name}'s shield fades."
+msgstr "The {self.name}'s shield fades."
+
+#: dungeoncrawler/entities.py:494
+#, python-brace-format
+msgid "The {self.name} raises its guard!"
+msgstr "The {self.name} raises its guard!"
+
+#: dungeoncrawler/entities.py:509
+msgid "The {self.name} drains life and heals for {damage // 3}!"
+msgstr "The {self.name} drains life and heals for {damage // 3}!"
+
+#: dungeoncrawler/entities.py:516
+#, python-brace-format
+msgid "The {self.name} stuns you!"
+msgstr "The {self.name} stuns you!"
+
+#: dungeoncrawler/entities.py:521
+#, python-brace-format
+msgid "The {self.name} freezes you for 1 turns!"
+msgstr "The {self.name} freezes you for 1 turns!"
+
+#: dungeoncrawler/entities.py:523
+#, python-brace-format
+msgid "The {self.name} strikes twice!"
+msgstr "The {self.name} strikes twice!"
+
+#: dungeoncrawler/entities.py:526
+#, python-brace-format
+msgid "The {self.name} attacked you and dealt {damage} damage."
+msgstr "The {self.name} attacked you and dealt {damage} damage."
+
+#: dungeoncrawler/entities.py:559
+#, python-brace-format
+msgid "{self.name} strikes {enemy.name} for {dmg} damage!"
+msgstr "{self.name} strikes {enemy.name} for {dmg} damage!"
+
+#: dungeoncrawler/entities.py:564
+#, python-brace-format
+msgid "{self.name} heals {player.name} for {heal} HP!"
+msgstr "{self.name} heals {player.name} for {heal} HP!"
+
+#: dungeoncrawler/dungeon.py:402
+msgid "[Announcer] {random.choice(ANNOUNCER_LINES)} {msg}"
+msgstr "[Announcer] {random.choice(ANNOUNCER_LINES)} {msg}"
+
+#: dungeoncrawler/dungeon.py:545
+msgid "-- Leaderboard --"
+msgstr "-- Leaderboard --"
+
+#: dungeoncrawler/dungeon.py:547
+msgid "No scores yet."
+msgstr "No scores yet."
+
+#: dungeoncrawler/dungeon.py:551
+msgid "{r.get('player_name', '?')}: {r.get('score', 0)} "
+msgstr "{r.get('player_name', '?')}: {r.get('score', 0)} "
+
+#: dungeoncrawler/dungeon.py:558
+msgid "It's time to choose your class!"
+msgstr "It's time to choose your class!"
+
+#: dungeoncrawler/dungeon.py:559
+msgid "1. Warrior 2. Mage 3. Rogue 4. Cleric 5. Paladin 6. Bard"
+msgstr "1. Warrior 2. Mage 3. Rogue 4. Cleric 5. Paladin 6. Bard"
+
+#: dungeoncrawler/dungeon.py:560
+msgid "7. Barbarian 8. Druid 9. Ranger 10. Sorcerer 11. Monk"
+msgstr "7. Barbarian 8. Druid 9. Ranger 10. Sorcerer 11. Monk"
+
+#: dungeoncrawler/dungeon.py:561
+msgid "12. Warlock 13. Necromancer 14. Shaman 15. Alchemist"
+msgstr "12. Warlock 13. Necromancer 14. Shaman 15. Alchemist"
+
+#: dungeoncrawler/dungeon.py:581
+msgid "Class: "
+msgstr "Class: "
+
+#: dungeoncrawler/dungeon.py:583
+msgid "Invalid choice. Please try again."
+msgstr "Invalid choice. Please try again."
+
+#: dungeoncrawler/dungeon.py:589
+msgid "Guilds now accept new members!"
+msgstr "Guilds now accept new members!"
+
+#: dungeoncrawler/dungeon.py:590
+msgid "1. Warriors' Guild - Bonus Health"
+msgstr "1. Warriors' Guild - Bonus Health"
+
+#: dungeoncrawler/dungeon.py:591
+msgid "2. Mages' Guild - Bonus Attack"
+msgstr "2. Mages' Guild - Bonus Attack"
+
+#: dungeoncrawler/dungeon.py:592
+msgid "3. Rogues' Guild - Faster Skills"
+msgstr "3. Rogues' Guild - Faster Skills"
+
+#: dungeoncrawler/dungeon.py:593
+msgid "4. Healers' Circle - Extra Vitality"
+msgstr "4. Healers' Circle - Extra Vitality"
+
+#: dungeoncrawler/dungeon.py:594
+msgid "5. Shadow Brotherhood - Heavy Strikes"
+msgstr "5. Shadow Brotherhood - Heavy Strikes"
+
+#: dungeoncrawler/dungeon.py:595
+msgid "6. Arcane Order - Arcane Mastery"
+msgstr "6. Arcane Order - Arcane Mastery"
+
+#: dungeoncrawler/dungeon.py:596
+msgid "7. Rangers' Lodge - Balanced Training"
+msgstr "7. Rangers' Lodge - Balanced Training"
+
+#: dungeoncrawler/dungeon.py:597
+msgid "8. Berserkers' Clan - Brutal Strength"
+msgstr "8. Berserkers' Clan - Brutal Strength"
+
+#: dungeoncrawler/dungeon.py:598
+msgid "Join which guild? (1-8 or skip): "
+msgstr "Join which guild? (1-8 or skip): "
+
+#: dungeoncrawler/dungeon.py:615
+msgid "New races are available to you!"
+msgstr "New races are available to you!"
+
+#: dungeoncrawler/dungeon.py:616
+msgid "1. Human 2. Elf 3. Dwarf 4. Orc 5. Gnome 6. Halfling"
+msgstr "1. Human 2. Elf 3. Dwarf 4. Orc 5. Gnome 6. Halfling"
+
+#: dungeoncrawler/dungeon.py:617
+msgid "7. Catfolk 8. Lizardfolk 9. Tiefling 10. Aasimar 11. Goblin"
+msgstr "7. Catfolk 8. Lizardfolk 9. Tiefling 10. Aasimar 11. Goblin"
+
+#: dungeoncrawler/dungeon.py:618
+msgid "12. Dragonborn 13. Half-Elf 14. Kobold 15. Triton"
+msgstr "12. Dragonborn 13. Half-Elf 14. Kobold 15. Triton"
+
+#: dungeoncrawler/dungeon.py:619
+msgid "Choose your race: "
+msgstr "Choose your race: "
+
+#: dungeoncrawler/dungeon.py:687
+msgid "Continue your last adventure? (y/n): "
+msgstr "Continue your last adventure? (y/n): "
+
+#: dungeoncrawler/dungeon.py:699
+msgid "Welcome to Dungeon Crawler!"
+msgstr "Welcome to Dungeon Crawler!"
+
+#: dungeoncrawler/dungeon.py:701
+#, python-brace-format
+msgid "===== Entering Floor {floor} ====="
+msgstr "===== Entering Floor {floor} ====="
+
+#: dungeoncrawler/dungeon.py:707
+msgid ""
+"Position: ({self.player.x}, {self.player.y}) - "
+"{self.room_names[self.player.y][self.player.x]}"
+msgstr ""
+"Position: ({self.player.x}, {self.player.y}) - "
+"{self.room_names[self.player.y][self.player.x]}"
+
+#: dungeoncrawler/dungeon.py:710
+#, python-brace-format
+msgid ""
+"Health: {self.player.health} | XP: {self.player.xp} | Gold: "
+"{self.player.gold} | Level: {self.player.level} | Floor: {floor} | Skill CD:"
+" {self.player.skill_cooldown}"
+msgstr ""
+"Health: {self.player.health} | XP: {self.player.xp} | Gold: "
+"{self.player.gold} | Level: {self.player.level} | Floor: {floor} | Skill CD:"
+" {self.player.skill_cooldown}"
+
+#: dungeoncrawler/dungeon.py:713
+#, python-brace-format
+msgid "Guild: {self.player.guild}"
+msgstr "Guild: {self.player.guild}"
+
+#: dungeoncrawler/dungeon.py:715
+#, python-brace-format
+msgid "Race: {self.player.race}"
+msgstr "Race: {self.player.race}"
+
+#: dungeoncrawler/dungeon.py:717
+msgid ""
+"1. Move Left 2. Move Right 3. Move Up 4. Move Down 5. Visit Shop 6. "
+"Inventory 7. Quit 8. Show Map 9. View Leaderboard"
+msgstr ""
+"1. Move Left 2. Move Right 3. Move Up 4. Move Down 5. Visit Shop 6. "
+"Inventory 7. Quit 8. Show Map 9. View Leaderboard"
+
+#: dungeoncrawler/dungeon.py:734
+msgid "Thanks for playing!"
+msgstr "Thanks for playing!"
+
+#: dungeoncrawler/dungeon.py:741 dungeoncrawler/combat.py:74
+msgid "Invalid choice!"
+msgstr "Invalid choice!"
+
+#: dungeoncrawler/dungeon.py:754
+msgid "You reach the Sealed Gate."
+msgstr "You reach the Sealed Gate."
+
+#: dungeoncrawler/dungeon.py:756
+msgid "Would you like to descend to the next floor? (y/n): "
+msgstr "Would you like to descend to the next floor? (y/n): "
+
+#: dungeoncrawler/dungeon.py:763
+msgid "You chose to exit the dungeon."
+msgstr "You chose to exit the dungeon."
+
+#: dungeoncrawler/dungeon.py:764 dungeoncrawler/dungeon.py:774
+msgid "Final Score: {self.player.get_score()}"
+msgstr "Final Score: {self.player.get_score()}"
+
+#: dungeoncrawler/dungeon.py:773
+msgid "You have died. Game Over!"
+msgstr "You have died. Game Over!"
+
+#: dungeoncrawler/dungeon.py:796
+msgid "A package falls from above! It's a gift from the audience."
+msgstr "A package falls from above! It's a gift from the audience."
+
+#: dungeoncrawler/dungeon.py:800
+#, python-brace-format
+msgid "You received a {item.name}."
+msgstr "You received a {item.name}."
+
+#: dungeoncrawler/dungeon.py:805
+#, python-brace-format
+msgid "Uh-oh! It explodes and deals {damage} damage."
+msgstr "Uh-oh! It explodes and deals {damage} damage."
+
+#: dungeoncrawler/dungeon.py:827
+msgid "A sage poses a riddle:\n"
+msgstr "A sage poses a riddle:\n"
+
+#: dungeoncrawler/dungeon.py:831 dungeoncrawler/events.py:36
+#, python-brace-format
+msgid "Correct! You receive {reward} gold."
+msgstr "Correct! You receive {reward} gold."
+
+#: dungeoncrawler/dungeon.py:834 dungeoncrawler/events.py:39
+msgid "Incorrect! The sage vanishes in disappointment."
+msgstr "Incorrect! The sage vanishes in disappointment."
+
+#: dungeoncrawler/dungeon.py:861
+msgid "The crowd roars as you step into the arena for the first time."
+msgstr "The crowd roars as you step into the arena for the first time."
+
+#: dungeoncrawler/dungeon.py:871
+msgid "A mysterious merchant sets up shop, selling exotic wares."
+msgstr "A mysterious merchant sets up shop, selling exotic wares."
+
+#: dungeoncrawler/dungeon.py:874
+msgid "You stumble upon a radiant shrine, filling you with determination."
+msgstr "You stumble upon a radiant shrine, filling you with determination."
+
+#: dungeoncrawler/dungeon.py:878
+msgid "An elusive merchant appears, offering rare goods."
+msgstr "An elusive merchant appears, offering rare goods."
+
+#: dungeoncrawler/dungeon.py:882
+msgid "A robed sage blocks your path, offering a riddle challenge."
+msgstr "A robed sage blocks your path, offering a riddle challenge."
+
+#: dungeoncrawler/events.py:32
+msgid "A sage presents a riddle:\n"
+msgstr "A sage presents a riddle:\n"
+
+#: dungeoncrawler/events.py:48
+#, python-brace-format
+msgid "A trap is sprung! You take {damage} damage."
+msgstr "A trap is sprung! You take {damage} damage."
+
+#: dungeoncrawler/combat.py:27
+msgid ""
+"You encountered a {enemy.name}! {enemy.ability.capitalize() if enemy.ability"
+" else ''} Boss incoming!"
+msgstr ""
+"You encountered a {enemy.name}! {enemy.ability.capitalize() if enemy.ability"
+" else ''} Boss incoming!"
+
+#: dungeoncrawler/combat.py:43
+#, python-brace-format
+msgid "Player Health: {player.health}"
+msgstr "Player Health: {player.health}"
+
+#: dungeoncrawler/combat.py:44
+#, python-brace-format
+msgid "Enemy Health: {enemy.health}"
+msgstr "Enemy Health: {enemy.health}"
+
+#: dungeoncrawler/combat.py:45
+msgid ""
+"1. Attack\n"
+"2. Defend\n"
+"3. Use Health Potion\n"
+"4. Use Skill"
+msgstr ""
+"1. Attack\n"
+"2. Defend\n"
+"3. Use Health Potion\n"
+"4. Use Skill"
+
+#: dungeoncrawler/combat.py:46
+msgid "Choose action: "
+msgstr "Choose action: "
+
+#: dungeoncrawler/combat.py:49
+msgid "A fierce attack lands!"
+msgstr "A fierce attack lands!"
+
+#: dungeoncrawler/combat.py:68
+msgid "Special skill unleashed!"
+msgstr "Special skill unleashed!"
+
+#: dungeoncrawler/combat.py:82
+#, python-brace-format
+msgid "The {enemy.name} dropped {loot.name}!"
+msgstr "The {enemy.name} dropped {loot.name}!"
+
+#: dungeoncrawler/combat.py:83
+#, python-brace-format
+msgid "{player.name} obtains {loot.name}!"
+msgstr "{player.name} obtains {loot.name}!"

--- a/locale/es/LC_MESSAGES/messages.po
+++ b/locale/es/LC_MESSAGES/messages.po
@@ -1,0 +1,960 @@
+# Spanish translations for PACKAGE package.
+# Copyright (C) 2025 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-11 22:48+0000\n"
+"PO-Revision-Date: 2025-08-11 22:48+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: dungeoncrawler/map.py:98
+#, python-brace-format
+msgid "A powerful boss guards this floor! The {name} lurks nearby..."
+msgstr ""
+
+#: dungeoncrawler/map.py:111
+#, python-brace-format
+msgid "✨ The boss dropped a unique weapon: {loot.name}!"
+msgstr ""
+
+#: dungeoncrawler/map.py:145
+msgid "You can't move that way."
+msgstr ""
+
+#: dungeoncrawler/map.py:196
+msgid "Press '?' for legend, q to exit"
+msgstr ""
+
+#: dungeoncrawler/map.py:198
+msgid "@: Player"
+msgstr ""
+
+#: dungeoncrawler/map.py:198
+msgid "E: Exit"
+msgstr ""
+
+#: dungeoncrawler/map.py:198
+msgid ".: Explored"
+msgstr ""
+
+#: dungeoncrawler/map.py:198
+msgid "#: Unexplored"
+msgstr ""
+
+#: dungeoncrawler/map.py:227
+#, python-brace-format
+msgid "{lore[name]}"
+msgstr ""
+
+#: dungeoncrawler/map.py:234
+#, python-brace-format
+msgid "You meet {room.name}. {room.description}"
+msgstr ""
+
+#: dungeoncrawler/map.py:235
+msgid "Recruit this companion? (y/n): "
+msgstr ""
+
+#: dungeoncrawler/map.py:243
+#, python-brace-format
+msgid "{game.player.name} gains a companion!"
+msgstr ""
+
+#: dungeoncrawler/map.py:246
+#, python-brace-format
+msgid "You found a {room.name}!"
+msgstr ""
+
+#: dungeoncrawler/map.py:248
+#, python-brace-format
+msgid "{game.player.name} obtained {room.name}!"
+msgstr ""
+
+#: dungeoncrawler/map.py:255
+#, python-brace-format
+msgid "You found a treasure chest with {gold} gold!"
+msgstr ""
+
+#: dungeoncrawler/map.py:258
+#, python-brace-format
+msgid "Inside you also discover {loot.name}!"
+msgstr ""
+
+#: dungeoncrawler/map.py:260
+#, python-brace-format
+msgid "{game.player.name} picks up {loot.name}!"
+msgstr ""
+
+#: dungeoncrawler/map.py:264
+msgid "You enter a glowing chamber with ancient runes etched in the stone."
+msgstr ""
+
+#: dungeoncrawler/map.py:266
+#, python-brace-format
+msgid "Your current weapon is: {game.player.weapon.name}"
+msgstr ""
+
+#: dungeoncrawler/map.py:267
+msgid "You may enchant it with a status effect for 30 gold."
+msgstr ""
+
+#: dungeoncrawler/map.py:268
+msgid "1. Poison  2. Burn  3. Freeze  4. Cancel"
+msgstr ""
+
+#: dungeoncrawler/map.py:269
+msgid "Choose enchantment: "
+msgstr ""
+
+#: dungeoncrawler/map.py:271
+msgid "Your weapon is already enchanted! You can't add another enchantment."
+msgstr ""
+
+#: dungeoncrawler/map.py:277
+#, python-brace-format
+msgid "Your weapon is now enchanted with {effect}!"
+msgstr ""
+
+#: dungeoncrawler/map.py:279
+msgid "You leave the enchantment chamber untouched."
+msgstr ""
+
+#: dungeoncrawler/map.py:281
+msgid "Not enough gold or invalid choice."
+msgstr ""
+
+#: dungeoncrawler/map.py:283
+msgid "You need a weapon to enchant."
+msgstr ""
+
+#: dungeoncrawler/map.py:287
+msgid "You meet a grizzled blacksmith hammering at a forge."
+msgstr ""
+
+#: dungeoncrawler/map.py:290
+#, python-brace-format
+msgid ""
+"Your weapon: {game.player.weapon.name} ({game.player.weapon.min_damage}-"
+"{game.player.weapon.max_damage})"
+msgstr ""
+
+#: dungeoncrawler/map.py:292
+msgid "Would you like to upgrade your weapon for 50 gold? +3 min/max damage"
+msgstr ""
+
+#: dungeoncrawler/map.py:293
+msgid "Upgrade? (y/n): "
+msgstr ""
+
+#: dungeoncrawler/map.py:298
+msgid "Your weapon has been reforged and is stronger!"
+msgstr ""
+
+#: dungeoncrawler/map.py:300
+msgid "You don't have enough gold."
+msgstr ""
+
+#: dungeoncrawler/map.py:302
+msgid "Maybe next time."
+msgstr ""
+
+#: dungeoncrawler/map.py:305
+msgid ""
+"The blacksmith scoffs. 'No weapon? Come back when you have something worth "
+"forging.'"
+msgstr ""
+
+#: dungeoncrawler/map.py:312
+msgid "A soothing warmth envelops you. Your wounds are fully healed."
+msgstr ""
+
+#: dungeoncrawler/map.py:318
+msgid "A trap springs! Solve this riddle to escape unharmed:"
+msgstr ""
+
+#: dungeoncrawler/map.py:320 dungeoncrawler/dungeon.py:828
+#: dungeoncrawler/events.py:33
+msgid "Answer: "
+msgstr ""
+
+#: dungeoncrawler/map.py:322
+msgid "The mechanism clicks harmlessly. You solved it!"
+msgstr ""
+
+#: dungeoncrawler/map.py:323
+msgid "Brilliant puzzle solving!"
+msgstr ""
+
+#: dungeoncrawler/map.py:327
+#, python-brace-format
+msgid "Wrong answer! You take {damage} damage."
+msgstr ""
+
+#: dungeoncrawler/map.py:333
+msgid "🎉 You unlocked the exit and escaped the dungeon!"
+msgstr ""
+
+#: dungeoncrawler/map.py:334
+msgid "Final Score: {game.player.get_score()}"
+msgstr ""
+
+#: dungeoncrawler/map.py:337
+msgid "The exit is locked. You need a key!"
+msgstr ""
+
+#: dungeoncrawler/main.py:26
+msgid "Enter your name: "
+msgstr ""
+
+#: dungeoncrawler/main.py:28
+msgid "Name cannot be blank."
+msgstr ""
+
+#: dungeoncrawler/main.py:31
+#, python-brace-format
+msgid "Welcome {name}! Your journey is just beginning."
+msgstr ""
+
+#: dungeoncrawler/main.py:42
+msgid "Do not run the interactive tutorial"
+msgstr ""
+
+#: dungeoncrawler/main.py:44
+msgid "Language code for translations"
+msgstr ""
+
+#: dungeoncrawler/main.py:58
+msgid "Load existing save? (y/n): "
+msgstr ""
+
+#: dungeoncrawler/shop.py:17
+msgid "Welcome to the Shop!"
+msgstr ""
+
+#: dungeoncrawler/shop.py:18
+#, python-brace-format
+msgid "Gold: {game.player.gold}"
+msgstr ""
+
+#: dungeoncrawler/shop.py:21
+#, python-brace-format
+msgid "{i}. {item.name} - {price} Gold"
+msgstr ""
+
+#: dungeoncrawler/shop.py:24
+#, python-brace-format
+msgid "{sell_option}. Sell Items"
+msgstr ""
+
+#: dungeoncrawler/shop.py:25
+#, python-brace-format
+msgid "{exit_option}. Exit"
+msgstr ""
+
+#: dungeoncrawler/shop.py:27
+msgid "Choose an option:"
+msgstr ""
+
+#: dungeoncrawler/shop.py:36
+#, python-brace-format
+msgid "You bought {item.name}."
+msgstr ""
+
+#: dungeoncrawler/shop.py:38
+msgid "Not enough gold."
+msgstr ""
+
+#: dungeoncrawler/shop.py:42
+msgid "Leaving the shop."
+msgstr ""
+
+#: dungeoncrawler/shop.py:44 dungeoncrawler/shop.py:95
+msgid "Invalid choice."
+msgstr ""
+
+#: dungeoncrawler/shop.py:46 dungeoncrawler/shop.py:97
+msgid "Invalid input."
+msgstr ""
+
+#: dungeoncrawler/shop.py:66
+msgid "You have nothing to sell."
+msgstr ""
+
+#: dungeoncrawler/shop.py:69
+msgid "Your Items:"
+msgstr ""
+
+#: dungeoncrawler/shop.py:73
+#, python-brace-format
+msgid "{i}. {item.name} - Cannot sell"
+msgstr ""
+
+#: dungeoncrawler/shop.py:75
+#, python-brace-format
+msgid "{i}. {item.name} - {sale_price} Gold"
+msgstr ""
+
+#: dungeoncrawler/shop.py:76
+msgid "{len(game.player.inventory)+1}. Back"
+msgstr ""
+
+#: dungeoncrawler/shop.py:78
+msgid "Sell what?"
+msgstr ""
+
+#: dungeoncrawler/shop.py:85
+msgid "You can't sell that item."
+msgstr ""
+
+#: dungeoncrawler/shop.py:87
+#, python-brace-format
+msgid "Sell {item.name} for {sale_price} gold? (y/n) "
+msgstr ""
+
+#: dungeoncrawler/shop.py:91
+#, python-brace-format
+msgid "You sold {item.name}."
+msgstr ""
+
+#: dungeoncrawler/shop.py:104
+msgid "Your inventory is empty."
+msgstr ""
+
+#: dungeoncrawler/shop.py:107
+msgid "Your Inventory:"
+msgstr ""
+
+#: dungeoncrawler/shop.py:110
+#, python-brace-format
+msgid "{i}. {item.name}{equipped} - {item.description}"
+msgstr ""
+
+#: dungeoncrawler/shop.py:112
+msgid "Enter item number to equip weapon, or press Enter to go back: "
+msgstr ""
+
+#: dungeoncrawler/shop.py:120
+msgid "You can only equip weapons."
+msgstr ""
+
+#: dungeoncrawler/shop.py:122
+msgid "Invalid selection."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:16
+msgid "=== Welcome to the Dungeon Crawler tutorial! ==="
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:17
+msgid ""
+"Let's begin with movement. Use '1' (left), '2' (right), '3' (up) or "
+"'4' (down)."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:19
+msgid "Move: "
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:21
+msgid "Good job! You can navigate the dungeon using those keys."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:23
+msgid "Please use one of 1, 2, 3 or 4 to move."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:25
+msgid "Now let's practice combat. Type 'attack' to strike the training dummy."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:27 dungeoncrawler/dungeon.py:719
+msgid "Action: "
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:29
+msgid "The dummy falls apart. A solid hit!"
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:31
+msgid "Type 'attack' to perform an attack."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:33
+msgid "Finally, open your inventory by typing 'inventory'."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:35
+msgid "Command: "
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:37
+msgid "Your empty bag opens. You'll fill it with loot soon enough."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:39
+msgid "Type 'inventory' to check your belongings."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:41
+msgid "That's it for the basics. Good luck in the dungeon!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:81
+#, python-brace-format
+msgid "Class selected: {self.class_type}."
+msgstr ""
+
+#: dungeoncrawler/entities.py:105
+#, python-brace-format
+msgid "You used a Health Potion and gained {healed_amount} health."
+msgstr ""
+
+#: dungeoncrawler/entities.py:107
+msgid "You don't have a Health Potion to use."
+msgstr ""
+
+#: dungeoncrawler/entities.py:117
+#, python-brace-format
+msgid "You attacked the {enemy.name} and dealt {damage} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:134
+#, python-brace-format
+msgid "Your weapon inflicts {effect} on the {enemy.name}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:143
+#, python-brace-format
+msgid "You defeated the {enemy.name}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:144
+#, python-brace-format
+msgid "You gained {enemy.xp} XP and {gold_dropped} gold."
+msgstr ""
+
+#: dungeoncrawler/entities.py:152
+#, python-brace-format
+msgid "The {enemy.name} attacked you and dealt {damage} damage."
+msgstr ""
+
+#: dungeoncrawler/entities.py:157
+msgid "Your shield absorbs 5 damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:166
+msgid "You take 3 poison damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:174
+msgid "You suffer 4 burn damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:182
+msgid "You bleed for 2 damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:189
+msgid "You're frozen and lose your turn!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:197
+msgid "You're stunned and can't move!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:205
+msgid "Your shield fades."
+msgstr ""
+
+#: dungeoncrawler/entities.py:222
+#, python-brace-format
+msgid "Your skill is on cooldown for {self.skill_cooldown} more turn(s)."
+msgstr ""
+
+#: dungeoncrawler/entities.py:226
+#, python-brace-format
+msgid "You unleash a mighty Power Strike dealing {damage} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:230
+#, python-brace-format
+msgid "You cast Fireball dealing {damage} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:236
+#, python-brace-format
+msgid "You perform a sneaky Backstab for {damage} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:241
+#, python-brace-format
+msgid "You invoke Healing Light and recover {heal} health!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:244
+#, python-brace-format
+msgid "You smite the {enemy.name} for {damage} holy damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:249
+#, python-brace-format
+msgid "Divine power heals you for {heal} HP!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:251
+msgid "You play an inspiring tune, bolstering your spirit!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:258
+#, python-brace-format
+msgid "You enter a rage, dealing {damage} damage and healing {heal}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:265
+#, python-brace-format
+msgid "Nature's wrath deals {damage} damage and restores {heal} health!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:270
+#, python-brace-format
+msgid "A volley of arrows hits for {damage} damage and poisons the foe!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:275
+#, python-brace-format
+msgid "You unleash Arcane Blast for {damage} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:280
+msgid "You strike twice with a flurry for {damage * 2} total damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:286
+#, python-brace-format
+msgid "Eldritch energy deals {damage} damage and heals you for {heal}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:292
+#, python-brace-format
+msgid "You siphon the enemy's soul for {damage} damage and {heal} health!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:298
+#, python-brace-format
+msgid "Spirits mend you for {heal} and shock the foe for {damage} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:304
+#, python-brace-format
+msgid "An explosive flask bursts for {damage} damage and sets the foe ablaze!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:307
+msgid "You don't have a special skill."
+msgstr ""
+
+#: dungeoncrawler/entities.py:318
+#, python-brace-format
+msgid ""
+"\n"
+"You leveled up to level {self.level}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:319
+#, python-brace-format
+msgid "Max Health increased to {self.max_health}"
+msgstr ""
+
+#: dungeoncrawler/entities.py:320
+#, python-brace-format
+msgid "Attack Power increased to {self.attack_power}"
+msgstr ""
+
+#: dungeoncrawler/entities.py:323
+msgid "You've unlocked Gold Finder: +5 gold after each kill."
+msgstr ""
+
+#: dungeoncrawler/entities.py:325
+msgid "You've unlocked Passive Regen: Heal 1 HP per move."
+msgstr ""
+
+#: dungeoncrawler/entities.py:350
+#, python-brace-format
+msgid "You have joined the {guild}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:397
+#, python-brace-format
+msgid "Race selected: {race}."
+msgstr ""
+
+#: dungeoncrawler/entities.py:403
+#, python-brace-format
+msgid "You unequipped the {self.weapon.name}"
+msgstr ""
+
+#: dungeoncrawler/entities.py:406
+#, python-brace-format
+msgid "You equipped the {weapon.name}"
+msgstr ""
+
+#: dungeoncrawler/entities.py:408
+msgid "You don't have a valid weapon to equip."
+msgstr ""
+
+#: dungeoncrawler/entities.py:441
+#, python-brace-format
+msgid "The {self.name}'s shield absorbs 5 damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:453
+#, python-brace-format
+msgid "The {self.name} takes 3 poison damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:460
+#, python-brace-format
+msgid "The {self.name} suffers 4 burn damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:467
+#, python-brace-format
+msgid "The {self.name} bleeds for 2 damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:473
+#, python-brace-format
+msgid "The {self.name} is frozen and can't move!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:480
+#, python-brace-format
+msgid "The {self.name} is stunned and can't move!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:488
+#, python-brace-format
+msgid "The {self.name}'s shield fades."
+msgstr ""
+
+#: dungeoncrawler/entities.py:494
+#, python-brace-format
+msgid "The {self.name} raises its guard!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:509
+msgid "The {self.name} drains life and heals for {damage // 3}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:516
+#, python-brace-format
+msgid "The {self.name} stuns you!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:521
+#, python-brace-format
+msgid "The {self.name} freezes you for 1 turns!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:523
+#, python-brace-format
+msgid "The {self.name} strikes twice!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:526
+#, python-brace-format
+msgid "The {self.name} attacked you and dealt {damage} damage."
+msgstr ""
+
+#: dungeoncrawler/entities.py:559
+#, python-brace-format
+msgid "{self.name} strikes {enemy.name} for {dmg} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:564
+#, python-brace-format
+msgid "{self.name} heals {player.name} for {heal} HP!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:402
+msgid "[Announcer] {random.choice(ANNOUNCER_LINES)} {msg}"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:545
+msgid "-- Leaderboard --"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:547
+msgid "No scores yet."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:551
+msgid "{r.get('player_name', '?')}: {r.get('score', 0)} "
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:558
+msgid "It's time to choose your class!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:559
+msgid "1. Warrior 2. Mage 3. Rogue 4. Cleric 5. Paladin 6. Bard"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:560
+msgid "7. Barbarian 8. Druid 9. Ranger 10. Sorcerer 11. Monk"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:561
+msgid "12. Warlock 13. Necromancer 14. Shaman 15. Alchemist"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:581
+msgid "Class: "
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:583
+msgid "Invalid choice. Please try again."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:589
+msgid "Guilds now accept new members!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:590
+msgid "1. Warriors' Guild - Bonus Health"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:591
+msgid "2. Mages' Guild - Bonus Attack"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:592
+msgid "3. Rogues' Guild - Faster Skills"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:593
+msgid "4. Healers' Circle - Extra Vitality"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:594
+msgid "5. Shadow Brotherhood - Heavy Strikes"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:595
+msgid "6. Arcane Order - Arcane Mastery"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:596
+msgid "7. Rangers' Lodge - Balanced Training"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:597
+msgid "8. Berserkers' Clan - Brutal Strength"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:598
+msgid "Join which guild? (1-8 or skip): "
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:615
+msgid "New races are available to you!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:616
+msgid "1. Human 2. Elf 3. Dwarf 4. Orc 5. Gnome 6. Halfling"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:617
+msgid "7. Catfolk 8. Lizardfolk 9. Tiefling 10. Aasimar 11. Goblin"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:618
+msgid "12. Dragonborn 13. Half-Elf 14. Kobold 15. Triton"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:619
+msgid "Choose your race: "
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:687
+msgid "Continue your last adventure? (y/n): "
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:699
+msgid "Welcome to Dungeon Crawler!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:701
+#, python-brace-format
+msgid "===== Entering Floor {floor} ====="
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:707
+msgid ""
+"Position: ({self.player.x}, {self.player.y}) - {self.room_names[self.player."
+"y][self.player.x]}"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:710
+#, python-brace-format
+msgid ""
+"Health: {self.player.health} | XP: {self.player.xp} | Gold: {self.player."
+"gold} | Level: {self.player.level} | Floor: {floor} | Skill CD: {self.player."
+"skill_cooldown}"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:713
+#, python-brace-format
+msgid "Guild: {self.player.guild}"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:715
+#, python-brace-format
+msgid "Race: {self.player.race}"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:717
+msgid ""
+"1. Move Left 2. Move Right 3. Move Up 4. Move Down 5. Visit Shop 6. "
+"Inventory 7. Quit 8. Show Map 9. View Leaderboard"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:734
+msgid "Thanks for playing!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:741 dungeoncrawler/combat.py:74
+msgid "Invalid choice!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:754
+msgid "You reach the Sealed Gate."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:756
+msgid "Would you like to descend to the next floor? (y/n): "
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:763
+msgid "You chose to exit the dungeon."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:764 dungeoncrawler/dungeon.py:774
+msgid "Final Score: {self.player.get_score()}"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:773
+msgid "You have died. Game Over!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:796
+msgid "A package falls from above! It's a gift from the audience."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:800
+#, python-brace-format
+msgid "You received a {item.name}."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:805
+#, python-brace-format
+msgid "Uh-oh! It explodes and deals {damage} damage."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:827
+msgid "A sage poses a riddle:\n"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:831 dungeoncrawler/events.py:36
+#, python-brace-format
+msgid "Correct! You receive {reward} gold."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:834 dungeoncrawler/events.py:39
+msgid "Incorrect! The sage vanishes in disappointment."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:861
+msgid "The crowd roars as you step into the arena for the first time."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:871
+msgid "A mysterious merchant sets up shop, selling exotic wares."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:874
+msgid "You stumble upon a radiant shrine, filling you with determination."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:878
+msgid "An elusive merchant appears, offering rare goods."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:882
+msgid "A robed sage blocks your path, offering a riddle challenge."
+msgstr ""
+
+#: dungeoncrawler/events.py:32
+msgid "A sage presents a riddle:\n"
+msgstr ""
+
+#: dungeoncrawler/events.py:48
+#, python-brace-format
+msgid "A trap is sprung! You take {damage} damage."
+msgstr ""
+
+#: dungeoncrawler/combat.py:27
+msgid ""
+"You encountered a {enemy.name}! {enemy.ability.capitalize() if enemy.ability "
+"else ''} Boss incoming!"
+msgstr ""
+
+#: dungeoncrawler/combat.py:43
+#, python-brace-format
+msgid "Player Health: {player.health}"
+msgstr ""
+
+#: dungeoncrawler/combat.py:44
+#, python-brace-format
+msgid "Enemy Health: {enemy.health}"
+msgstr ""
+
+#: dungeoncrawler/combat.py:45
+msgid ""
+"1. Attack\n"
+"2. Defend\n"
+"3. Use Health Potion\n"
+"4. Use Skill"
+msgstr ""
+
+#: dungeoncrawler/combat.py:46
+msgid "Choose action: "
+msgstr ""
+
+#: dungeoncrawler/combat.py:49
+msgid "A fierce attack lands!"
+msgstr ""
+
+#: dungeoncrawler/combat.py:68
+msgid "Special skill unleashed!"
+msgstr ""
+
+#: dungeoncrawler/combat.py:82
+#, python-brace-format
+msgid "The {enemy.name} dropped {loot.name}!"
+msgstr ""
+
+#: dungeoncrawler/combat.py:83
+#, python-brace-format
+msgid "{player.name} obtains {loot.name}!"
+msgstr ""

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -1,0 +1,960 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-11 22:49+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: dungeoncrawler/map.py:98
+#, python-brace-format
+msgid "A powerful boss guards this floor! The {name} lurks nearby..."
+msgstr ""
+
+#: dungeoncrawler/map.py:111
+#, python-brace-format
+msgid "✨ The boss dropped a unique weapon: {loot.name}!"
+msgstr ""
+
+#: dungeoncrawler/map.py:145
+msgid "You can't move that way."
+msgstr ""
+
+#: dungeoncrawler/map.py:196
+msgid "Press '?' for legend, q to exit"
+msgstr ""
+
+#: dungeoncrawler/map.py:198
+msgid "@: Player"
+msgstr ""
+
+#: dungeoncrawler/map.py:198
+msgid "E: Exit"
+msgstr ""
+
+#: dungeoncrawler/map.py:198
+msgid ".: Explored"
+msgstr ""
+
+#: dungeoncrawler/map.py:198
+msgid "#: Unexplored"
+msgstr ""
+
+#: dungeoncrawler/map.py:227
+#, python-brace-format
+msgid "{lore[name]}"
+msgstr ""
+
+#: dungeoncrawler/map.py:234
+#, python-brace-format
+msgid "You meet {room.name}. {room.description}"
+msgstr ""
+
+#: dungeoncrawler/map.py:235
+msgid "Recruit this companion? (y/n): "
+msgstr ""
+
+#: dungeoncrawler/map.py:243
+#, python-brace-format
+msgid "{game.player.name} gains a companion!"
+msgstr ""
+
+#: dungeoncrawler/map.py:246
+#, python-brace-format
+msgid "You found a {room.name}!"
+msgstr ""
+
+#: dungeoncrawler/map.py:248
+#, python-brace-format
+msgid "{game.player.name} obtained {room.name}!"
+msgstr ""
+
+#: dungeoncrawler/map.py:255
+#, python-brace-format
+msgid "You found a treasure chest with {gold} gold!"
+msgstr ""
+
+#: dungeoncrawler/map.py:258
+#, python-brace-format
+msgid "Inside you also discover {loot.name}!"
+msgstr ""
+
+#: dungeoncrawler/map.py:260
+#, python-brace-format
+msgid "{game.player.name} picks up {loot.name}!"
+msgstr ""
+
+#: dungeoncrawler/map.py:264
+msgid "You enter a glowing chamber with ancient runes etched in the stone."
+msgstr ""
+
+#: dungeoncrawler/map.py:266
+#, python-brace-format
+msgid "Your current weapon is: {game.player.weapon.name}"
+msgstr ""
+
+#: dungeoncrawler/map.py:267
+msgid "You may enchant it with a status effect for 30 gold."
+msgstr ""
+
+#: dungeoncrawler/map.py:268
+msgid "1. Poison  2. Burn  3. Freeze  4. Cancel"
+msgstr ""
+
+#: dungeoncrawler/map.py:269
+msgid "Choose enchantment: "
+msgstr ""
+
+#: dungeoncrawler/map.py:271
+msgid "Your weapon is already enchanted! You can't add another enchantment."
+msgstr ""
+
+#: dungeoncrawler/map.py:277
+#, python-brace-format
+msgid "Your weapon is now enchanted with {effect}!"
+msgstr ""
+
+#: dungeoncrawler/map.py:279
+msgid "You leave the enchantment chamber untouched."
+msgstr ""
+
+#: dungeoncrawler/map.py:281
+msgid "Not enough gold or invalid choice."
+msgstr ""
+
+#: dungeoncrawler/map.py:283
+msgid "You need a weapon to enchant."
+msgstr ""
+
+#: dungeoncrawler/map.py:287
+msgid "You meet a grizzled blacksmith hammering at a forge."
+msgstr ""
+
+#: dungeoncrawler/map.py:290
+#, python-brace-format
+msgid ""
+"Your weapon: {game.player.weapon.name} ({game.player.weapon.min_damage}-"
+"{game.player.weapon.max_damage})"
+msgstr ""
+
+#: dungeoncrawler/map.py:292
+msgid "Would you like to upgrade your weapon for 50 gold? +3 min/max damage"
+msgstr ""
+
+#: dungeoncrawler/map.py:293
+msgid "Upgrade? (y/n): "
+msgstr ""
+
+#: dungeoncrawler/map.py:298
+msgid "Your weapon has been reforged and is stronger!"
+msgstr ""
+
+#: dungeoncrawler/map.py:300
+msgid "You don't have enough gold."
+msgstr ""
+
+#: dungeoncrawler/map.py:302
+msgid "Maybe next time."
+msgstr ""
+
+#: dungeoncrawler/map.py:305
+msgid ""
+"The blacksmith scoffs. 'No weapon? Come back when you have something worth "
+"forging.'"
+msgstr ""
+
+#: dungeoncrawler/map.py:312
+msgid "A soothing warmth envelops you. Your wounds are fully healed."
+msgstr ""
+
+#: dungeoncrawler/map.py:318
+msgid "A trap springs! Solve this riddle to escape unharmed:"
+msgstr ""
+
+#: dungeoncrawler/map.py:320 dungeoncrawler/dungeon.py:828
+#: dungeoncrawler/events.py:33
+msgid "Answer: "
+msgstr ""
+
+#: dungeoncrawler/map.py:322
+msgid "The mechanism clicks harmlessly. You solved it!"
+msgstr ""
+
+#: dungeoncrawler/map.py:323
+msgid "Brilliant puzzle solving!"
+msgstr ""
+
+#: dungeoncrawler/map.py:327
+#, python-brace-format
+msgid "Wrong answer! You take {damage} damage."
+msgstr ""
+
+#: dungeoncrawler/map.py:333
+msgid "🎉 You unlocked the exit and escaped the dungeon!"
+msgstr ""
+
+#: dungeoncrawler/map.py:334
+msgid "Final Score: {game.player.get_score()}"
+msgstr ""
+
+#: dungeoncrawler/map.py:337
+msgid "The exit is locked. You need a key!"
+msgstr ""
+
+#: dungeoncrawler/main.py:26
+msgid "Enter your name: "
+msgstr ""
+
+#: dungeoncrawler/main.py:28
+msgid "Name cannot be blank."
+msgstr ""
+
+#: dungeoncrawler/main.py:31
+#, python-brace-format
+msgid "Welcome {name}! Your journey is just beginning."
+msgstr ""
+
+#: dungeoncrawler/main.py:42
+msgid "Do not run the interactive tutorial"
+msgstr ""
+
+#: dungeoncrawler/main.py:44
+msgid "Language code for translations"
+msgstr ""
+
+#: dungeoncrawler/main.py:58
+msgid "Load existing save? (y/n): "
+msgstr ""
+
+#: dungeoncrawler/shop.py:17
+msgid "Welcome to the Shop!"
+msgstr ""
+
+#: dungeoncrawler/shop.py:18
+#, python-brace-format
+msgid "Gold: {game.player.gold}"
+msgstr ""
+
+#: dungeoncrawler/shop.py:21
+#, python-brace-format
+msgid "{i}. {item.name} - {price} Gold"
+msgstr ""
+
+#: dungeoncrawler/shop.py:24
+#, python-brace-format
+msgid "{sell_option}. Sell Items"
+msgstr ""
+
+#: dungeoncrawler/shop.py:25
+#, python-brace-format
+msgid "{exit_option}. Exit"
+msgstr ""
+
+#: dungeoncrawler/shop.py:27
+msgid "Choose an option:"
+msgstr ""
+
+#: dungeoncrawler/shop.py:36
+#, python-brace-format
+msgid "You bought {item.name}."
+msgstr ""
+
+#: dungeoncrawler/shop.py:38
+msgid "Not enough gold."
+msgstr ""
+
+#: dungeoncrawler/shop.py:42
+msgid "Leaving the shop."
+msgstr ""
+
+#: dungeoncrawler/shop.py:44 dungeoncrawler/shop.py:95
+msgid "Invalid choice."
+msgstr ""
+
+#: dungeoncrawler/shop.py:46 dungeoncrawler/shop.py:97
+msgid "Invalid input."
+msgstr ""
+
+#: dungeoncrawler/shop.py:66
+msgid "You have nothing to sell."
+msgstr ""
+
+#: dungeoncrawler/shop.py:69
+msgid "Your Items:"
+msgstr ""
+
+#: dungeoncrawler/shop.py:73
+#, python-brace-format
+msgid "{i}. {item.name} - Cannot sell"
+msgstr ""
+
+#: dungeoncrawler/shop.py:75
+#, python-brace-format
+msgid "{i}. {item.name} - {sale_price} Gold"
+msgstr ""
+
+#: dungeoncrawler/shop.py:76
+msgid "{len(game.player.inventory)+1}. Back"
+msgstr ""
+
+#: dungeoncrawler/shop.py:78
+msgid "Sell what?"
+msgstr ""
+
+#: dungeoncrawler/shop.py:85
+msgid "You can't sell that item."
+msgstr ""
+
+#: dungeoncrawler/shop.py:87
+#, python-brace-format
+msgid "Sell {item.name} for {sale_price} gold? (y/n) "
+msgstr ""
+
+#: dungeoncrawler/shop.py:91
+#, python-brace-format
+msgid "You sold {item.name}."
+msgstr ""
+
+#: dungeoncrawler/shop.py:104
+msgid "Your inventory is empty."
+msgstr ""
+
+#: dungeoncrawler/shop.py:107
+msgid "Your Inventory:"
+msgstr ""
+
+#: dungeoncrawler/shop.py:110
+#, python-brace-format
+msgid "{i}. {item.name}{equipped} - {item.description}"
+msgstr ""
+
+#: dungeoncrawler/shop.py:112
+msgid "Enter item number to equip weapon, or press Enter to go back: "
+msgstr ""
+
+#: dungeoncrawler/shop.py:120
+msgid "You can only equip weapons."
+msgstr ""
+
+#: dungeoncrawler/shop.py:122
+msgid "Invalid selection."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:16
+msgid "=== Welcome to the Dungeon Crawler tutorial! ==="
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:17
+msgid ""
+"Let's begin with movement. Use '1' (left), '2' (right), '3' (up) or "
+"'4' (down)."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:19
+msgid "Move: "
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:21
+msgid "Good job! You can navigate the dungeon using those keys."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:23
+msgid "Please use one of 1, 2, 3 or 4 to move."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:25
+msgid "Now let's practice combat. Type 'attack' to strike the training dummy."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:27 dungeoncrawler/dungeon.py:719
+msgid "Action: "
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:29
+msgid "The dummy falls apart. A solid hit!"
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:31
+msgid "Type 'attack' to perform an attack."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:33
+msgid "Finally, open your inventory by typing 'inventory'."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:35
+msgid "Command: "
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:37
+msgid "Your empty bag opens. You'll fill it with loot soon enough."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:39
+msgid "Type 'inventory' to check your belongings."
+msgstr ""
+
+#: dungeoncrawler/tutorial.py:41
+msgid "That's it for the basics. Good luck in the dungeon!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:81
+#, python-brace-format
+msgid "Class selected: {self.class_type}."
+msgstr ""
+
+#: dungeoncrawler/entities.py:105
+#, python-brace-format
+msgid "You used a Health Potion and gained {healed_amount} health."
+msgstr ""
+
+#: dungeoncrawler/entities.py:107
+msgid "You don't have a Health Potion to use."
+msgstr ""
+
+#: dungeoncrawler/entities.py:117
+#, python-brace-format
+msgid "You attacked the {enemy.name} and dealt {damage} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:134
+#, python-brace-format
+msgid "Your weapon inflicts {effect} on the {enemy.name}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:143
+#, python-brace-format
+msgid "You defeated the {enemy.name}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:144
+#, python-brace-format
+msgid "You gained {enemy.xp} XP and {gold_dropped} gold."
+msgstr ""
+
+#: dungeoncrawler/entities.py:152
+#, python-brace-format
+msgid "The {enemy.name} attacked you and dealt {damage} damage."
+msgstr ""
+
+#: dungeoncrawler/entities.py:157
+msgid "Your shield absorbs 5 damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:166
+msgid "You take 3 poison damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:174
+msgid "You suffer 4 burn damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:182
+msgid "You bleed for 2 damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:189
+msgid "You're frozen and lose your turn!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:197
+msgid "You're stunned and can't move!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:205
+msgid "Your shield fades."
+msgstr ""
+
+#: dungeoncrawler/entities.py:222
+#, python-brace-format
+msgid "Your skill is on cooldown for {self.skill_cooldown} more turn(s)."
+msgstr ""
+
+#: dungeoncrawler/entities.py:226
+#, python-brace-format
+msgid "You unleash a mighty Power Strike dealing {damage} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:230
+#, python-brace-format
+msgid "You cast Fireball dealing {damage} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:236
+#, python-brace-format
+msgid "You perform a sneaky Backstab for {damage} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:241
+#, python-brace-format
+msgid "You invoke Healing Light and recover {heal} health!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:244
+#, python-brace-format
+msgid "You smite the {enemy.name} for {damage} holy damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:249
+#, python-brace-format
+msgid "Divine power heals you for {heal} HP!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:251
+msgid "You play an inspiring tune, bolstering your spirit!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:258
+#, python-brace-format
+msgid "You enter a rage, dealing {damage} damage and healing {heal}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:265
+#, python-brace-format
+msgid "Nature's wrath deals {damage} damage and restores {heal} health!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:270
+#, python-brace-format
+msgid "A volley of arrows hits for {damage} damage and poisons the foe!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:275
+#, python-brace-format
+msgid "You unleash Arcane Blast for {damage} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:280
+msgid "You strike twice with a flurry for {damage * 2} total damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:286
+#, python-brace-format
+msgid "Eldritch energy deals {damage} damage and heals you for {heal}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:292
+#, python-brace-format
+msgid "You siphon the enemy's soul for {damage} damage and {heal} health!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:298
+#, python-brace-format
+msgid "Spirits mend you for {heal} and shock the foe for {damage} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:304
+#, python-brace-format
+msgid "An explosive flask bursts for {damage} damage and sets the foe ablaze!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:307
+msgid "You don't have a special skill."
+msgstr ""
+
+#: dungeoncrawler/entities.py:318
+#, python-brace-format
+msgid ""
+"\n"
+"You leveled up to level {self.level}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:319
+#, python-brace-format
+msgid "Max Health increased to {self.max_health}"
+msgstr ""
+
+#: dungeoncrawler/entities.py:320
+#, python-brace-format
+msgid "Attack Power increased to {self.attack_power}"
+msgstr ""
+
+#: dungeoncrawler/entities.py:323
+msgid "You've unlocked Gold Finder: +5 gold after each kill."
+msgstr ""
+
+#: dungeoncrawler/entities.py:325
+msgid "You've unlocked Passive Regen: Heal 1 HP per move."
+msgstr ""
+
+#: dungeoncrawler/entities.py:350
+#, python-brace-format
+msgid "You have joined the {guild}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:397
+#, python-brace-format
+msgid "Race selected: {race}."
+msgstr ""
+
+#: dungeoncrawler/entities.py:403
+#, python-brace-format
+msgid "You unequipped the {self.weapon.name}"
+msgstr ""
+
+#: dungeoncrawler/entities.py:406
+#, python-brace-format
+msgid "You equipped the {weapon.name}"
+msgstr ""
+
+#: dungeoncrawler/entities.py:408
+msgid "You don't have a valid weapon to equip."
+msgstr ""
+
+#: dungeoncrawler/entities.py:441
+#, python-brace-format
+msgid "The {self.name}'s shield absorbs 5 damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:453
+#, python-brace-format
+msgid "The {self.name} takes 3 poison damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:460
+#, python-brace-format
+msgid "The {self.name} suffers 4 burn damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:467
+#, python-brace-format
+msgid "The {self.name} bleeds for 2 damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:473
+#, python-brace-format
+msgid "The {self.name} is frozen and can't move!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:480
+#, python-brace-format
+msgid "The {self.name} is stunned and can't move!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:488
+#, python-brace-format
+msgid "The {self.name}'s shield fades."
+msgstr ""
+
+#: dungeoncrawler/entities.py:494
+#, python-brace-format
+msgid "The {self.name} raises its guard!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:509
+msgid "The {self.name} drains life and heals for {damage // 3}!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:516
+#, python-brace-format
+msgid "The {self.name} stuns you!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:521
+#, python-brace-format
+msgid "The {self.name} freezes you for 1 turns!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:523
+#, python-brace-format
+msgid "The {self.name} strikes twice!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:526
+#, python-brace-format
+msgid "The {self.name} attacked you and dealt {damage} damage."
+msgstr ""
+
+#: dungeoncrawler/entities.py:559
+#, python-brace-format
+msgid "{self.name} strikes {enemy.name} for {dmg} damage!"
+msgstr ""
+
+#: dungeoncrawler/entities.py:564
+#, python-brace-format
+msgid "{self.name} heals {player.name} for {heal} HP!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:402
+msgid "[Announcer] {random.choice(ANNOUNCER_LINES)} {msg}"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:545
+msgid "-- Leaderboard --"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:547
+msgid "No scores yet."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:551
+msgid "{r.get('player_name', '?')}: {r.get('score', 0)} "
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:558
+msgid "It's time to choose your class!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:559
+msgid "1. Warrior 2. Mage 3. Rogue 4. Cleric 5. Paladin 6. Bard"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:560
+msgid "7. Barbarian 8. Druid 9. Ranger 10. Sorcerer 11. Monk"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:561
+msgid "12. Warlock 13. Necromancer 14. Shaman 15. Alchemist"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:581
+msgid "Class: "
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:583
+msgid "Invalid choice. Please try again."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:589
+msgid "Guilds now accept new members!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:590
+msgid "1. Warriors' Guild - Bonus Health"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:591
+msgid "2. Mages' Guild - Bonus Attack"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:592
+msgid "3. Rogues' Guild - Faster Skills"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:593
+msgid "4. Healers' Circle - Extra Vitality"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:594
+msgid "5. Shadow Brotherhood - Heavy Strikes"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:595
+msgid "6. Arcane Order - Arcane Mastery"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:596
+msgid "7. Rangers' Lodge - Balanced Training"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:597
+msgid "8. Berserkers' Clan - Brutal Strength"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:598
+msgid "Join which guild? (1-8 or skip): "
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:615
+msgid "New races are available to you!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:616
+msgid "1. Human 2. Elf 3. Dwarf 4. Orc 5. Gnome 6. Halfling"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:617
+msgid "7. Catfolk 8. Lizardfolk 9. Tiefling 10. Aasimar 11. Goblin"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:618
+msgid "12. Dragonborn 13. Half-Elf 14. Kobold 15. Triton"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:619
+msgid "Choose your race: "
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:687
+msgid "Continue your last adventure? (y/n): "
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:699
+msgid "Welcome to Dungeon Crawler!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:701
+#, python-brace-format
+msgid "===== Entering Floor {floor} ====="
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:707
+msgid ""
+"Position: ({self.player.x}, {self.player.y}) - {self.room_names[self.player."
+"y][self.player.x]}"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:710
+#, python-brace-format
+msgid ""
+"Health: {self.player.health} | XP: {self.player.xp} | Gold: {self.player."
+"gold} | Level: {self.player.level} | Floor: {floor} | Skill CD: {self.player."
+"skill_cooldown}"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:713
+#, python-brace-format
+msgid "Guild: {self.player.guild}"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:715
+#, python-brace-format
+msgid "Race: {self.player.race}"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:717
+msgid ""
+"1. Move Left 2. Move Right 3. Move Up 4. Move Down 5. Visit Shop 6. "
+"Inventory 7. Quit 8. Show Map 9. View Leaderboard"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:734
+msgid "Thanks for playing!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:741 dungeoncrawler/combat.py:74
+msgid "Invalid choice!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:754
+msgid "You reach the Sealed Gate."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:756
+msgid "Would you like to descend to the next floor? (y/n): "
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:763
+msgid "You chose to exit the dungeon."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:764 dungeoncrawler/dungeon.py:774
+msgid "Final Score: {self.player.get_score()}"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:773
+msgid "You have died. Game Over!"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:796
+msgid "A package falls from above! It's a gift from the audience."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:800
+#, python-brace-format
+msgid "You received a {item.name}."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:805
+#, python-brace-format
+msgid "Uh-oh! It explodes and deals {damage} damage."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:827
+msgid "A sage poses a riddle:\n"
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:831 dungeoncrawler/events.py:36
+#, python-brace-format
+msgid "Correct! You receive {reward} gold."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:834 dungeoncrawler/events.py:39
+msgid "Incorrect! The sage vanishes in disappointment."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:861
+msgid "The crowd roars as you step into the arena for the first time."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:871
+msgid "A mysterious merchant sets up shop, selling exotic wares."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:874
+msgid "You stumble upon a radiant shrine, filling you with determination."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:878
+msgid "An elusive merchant appears, offering rare goods."
+msgstr ""
+
+#: dungeoncrawler/dungeon.py:882
+msgid "A robed sage blocks your path, offering a riddle challenge."
+msgstr ""
+
+#: dungeoncrawler/events.py:32
+msgid "A sage presents a riddle:\n"
+msgstr ""
+
+#: dungeoncrawler/events.py:48
+#, python-brace-format
+msgid "A trap is sprung! You take {damage} damage."
+msgstr ""
+
+#: dungeoncrawler/combat.py:27
+msgid ""
+"You encountered a {enemy.name}! {enemy.ability.capitalize() if enemy.ability "
+"else ''} Boss incoming!"
+msgstr ""
+
+#: dungeoncrawler/combat.py:43
+#, python-brace-format
+msgid "Player Health: {player.health}"
+msgstr ""
+
+#: dungeoncrawler/combat.py:44
+#, python-brace-format
+msgid "Enemy Health: {enemy.health}"
+msgstr ""
+
+#: dungeoncrawler/combat.py:45
+msgid ""
+"1. Attack\n"
+"2. Defend\n"
+"3. Use Health Potion\n"
+"4. Use Skill"
+msgstr ""
+
+#: dungeoncrawler/combat.py:46
+msgid "Choose action: "
+msgstr ""
+
+#: dungeoncrawler/combat.py:49
+msgid "A fierce attack lands!"
+msgstr ""
+
+#: dungeoncrawler/combat.py:68
+msgid "Special skill unleashed!"
+msgstr ""
+
+#: dungeoncrawler/combat.py:82
+#, python-brace-format
+msgid "The {enemy.name} dropped {loot.name}!"
+msgstr ""
+
+#: dungeoncrawler/combat.py:83
+#, python-brace-format
+msgid "{player.name} obtains {loot.name}!"
+msgstr ""


### PR DESCRIPTION
## Summary
- introduce i18n infrastructure with a `set_language` helper
- add `--lang` flag to select translations and wrap user strings in `_()`
- generate translation templates, provide English and Spanish locales, and ignore compiled `.mo` files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a72311f708326b0c72997e95d67fb