### PR TITLE
Add packaging metadata and release docs

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,20 @@
+# Releasing
+
+Steps to publish a new version of Dungeon Crawler to PyPI.
+
+1. Ensure `pyproject.toml` has the correct version.
+2. Commit and tag the release:
+   ```bash
+   git commit -am "Release vX.Y.Z"
+   git tag vX.Y.Z
+   ```
+3. Build and upload the package:
+   ```bash
+   python -m pip install build twine
+   python -m build
+   twine upload dist/*
+   ```
+4. Push commits and tags:
+   ```bash
+   git push && git push --tags
+   ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,17 @@ requires-python = ">=3.8"
 authors = [{name = "Dungeon Crawler Team"}]
 dependencies = []
 
+[project.optional-dependencies]
+dev = [
+    "black",
+    "flake8",
+    "isort",
+    "pytest",
+]
+
+[project.scripts]
+dungeon-crawler = "dungeoncrawler.main:main"
+
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
@@ -14,3 +25,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 packages = ["dungeoncrawler"]
 include-package-data = true
+
+[tool.setuptools.package-data]
+"*" = ["data/*.json"]


### PR DESCRIPTION
## Summary
- expose `dungeon-crawler` console script and include JSON data files in the package
- add optional development dependencies
- document how to publish releases to PyPI

## Testing
- `pip install -e .`
- `dungeon-crawler --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a7553c2a483269ce47ffe23e9e38d