### PR TITLE
Configure isort and normalize imports

### DIFF
--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import random
-from typing import TYPE_CHECKING
 from gettext import gettext as _
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .dungeon import DungeonBase

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -3,17 +3,17 @@ import os
 import random
 import time
 from functools import lru_cache
-from pathlib import Path
 from gettext import gettext as _
+from pathlib import Path
 
-from .constants import ANNOUNCER_LINES, RIDDLES, SAVE_FILE, SCORE_FILE
-from .entities import Companion, Player
-from .items import Item, Weapon
-from .plugins import apply_enemy_plugins, apply_item_plugins
 from . import combat as combat_module
 from . import map as map_module
 from . import shop as shop_module
+from .constants import ANNOUNCER_LINES, RIDDLES, SAVE_FILE, SCORE_FILE
+from .entities import Companion, Player
 from .events import MerchantEvent, PuzzleEvent, TrapEvent
+from .items import Item, Weapon
+from .plugins import apply_enemy_plugins, apply_item_plugins
 
 # ---------------------------------------------------------------------------
 # Data loading utilities

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import random
-from typing import TYPE_CHECKING
 from gettext import gettext as _
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .dungeon import DungeonBase

--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -49,11 +49,11 @@ def main(argv=None):
     set_language(args.lang)
 
     global DungeonBase, Player
-    from .dungeon import DungeonBase
-    from .entities import Player
     from . import combat as combat_module  # noqa: F401
     from . import map as dungeon_map  # noqa: F401
     from . import shop as shop_module  # noqa: F401
+    from .dungeon import DungeonBase
+    from .entities import Player
 
     cfg = load_config()
     game = DungeonBase(cfg.screen_width, cfg.screen_height)

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-import random
 import curses
-from typing import TYPE_CHECKING
+import random
 from gettext import gettext as _
+from typing import TYPE_CHECKING
 
+from .combat import battle
 from .entities import Companion, Enemy
 from .items import Item, Weapon
-from .combat import battle
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from .dungeon import DungeonBase

--- a/dungeoncrawler/shop.py
+++ b/dungeoncrawler/shop.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from gettext import gettext as _
+from typing import TYPE_CHECKING
 
 from .items import Item, Weapon
 

--- a/dungeoncrawler/tutorial.py
+++ b/dungeoncrawler/tutorial.py
@@ -1,6 +1,7 @@
 """Interactive tutorial for basic game mechanics."""
 
 from __future__ import annotations
+
 from gettext import gettext as _
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,6 @@ include-package-data = true
 
 [tool.setuptools.package-data]
 "*" = ["data/*.json"]
+
+[tool.isort]
+profile = "black"

--- a/tests/test_dungeon_generation.py
+++ b/tests/test_dungeon_generation.py
@@ -4,9 +4,9 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from dungeoncrawler import map as dungeon_map
 from dungeoncrawler.dungeon import DungeonBase
 from dungeoncrawler.entities import Enemy, Player
-from dungeoncrawler import map as dungeon_map
 
 
 def test_generate_dungeon_size_and_population():

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,9 +1,6 @@
 import os
 import sys
 from unittest.mock import patch
-import os
-import sys
-from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -4,9 +4,9 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from dungeoncrawler import map as dungeon_map
 from dungeoncrawler.dungeon import DungeonBase
 from dungeoncrawler.entities import Player
-from dungeoncrawler import map as dungeon_map
 
 
 def test_render_map_snapshot():

--- a/tests/test_shop.py
+++ b/tests/test_shop.py
@@ -1,13 +1,12 @@
 import os
-import os
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from dungeoncrawler import shop as shop_module
 from dungeoncrawler.dungeon import DungeonBase
 from dungeoncrawler.entities import Player
 from dungeoncrawler.items import Item, Weapon
-from dungeoncrawler import shop as shop_module
 
 
 def test_shop_purchase(monkeypatch):

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -5,8 +5,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 import dungeoncrawler.dungeon as dungeon_module
 from dungeoncrawler import tutorial as tutorial_module
-from dungeoncrawler.main import main
 from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.main import main
 
 
 def test_tutorial_runs_once_per_save(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Configure isort to use the Black profile
- Sort imports across modules to satisfy isort formatting

## Testing
- `isort --check dungeoncrawler tests`
- `black --check dungeoncrawler tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a89d3c9cc8326a2740f95ad9d0b2d