### PR TITLE
Load floor configs from data file

### DIFF
--- a/data/floors.json
+++ b/data/floors.json
@@ -1,0 +1,418 @@
+{
+  "1": {
+    "size": [
+      8,
+      8
+    ],
+    "enemies": [
+      "Goblin",
+      "Skeleton",
+      "Bandit"
+    ],
+    "bosses": [
+      "Bone Tyrant"
+    ],
+    "places": {
+      "Trap": 2,
+      "Treasure": 2,
+      "Enchantment": 1,
+      "Sanctuary": 1,
+      "Blacksmith": 1
+    }
+  },
+  "2": {
+    "size": [
+      9,
+      9
+    ],
+    "enemies": [
+      "Orc",
+      "Cultist",
+      "Ghoul",
+      "Bandit"
+    ],
+    "bosses": [
+      "Inferno Golem",
+      "Frost Warden"
+    ],
+    "places": {
+      "Trap": 3,
+      "Treasure": 3,
+      "Enchantment": 1,
+      "Sanctuary": 1,
+      "Blacksmith": 1
+    }
+  },
+  "3": {
+    "size": [
+      10,
+      10
+    ],
+    "enemies": [
+      "Vampire",
+      "Warlock",
+      "Wraith",
+      "Werewolf"
+    ],
+    "bosses": [
+      "Shadow Reaver",
+      "Doom Bringer"
+    ],
+    "places": {
+      "Trap": 3,
+      "Treasure": 4,
+      "Enchantment": 2,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "4": {
+    "size": [
+      11,
+      11
+    ],
+    "enemies": [
+      "Basilisk",
+      "Gargoyle",
+      "Troll",
+      "Lich"
+    ],
+    "bosses": [
+      "Void Serpent",
+      "Ember Lord",
+      "Glacier Fiend"
+    ],
+    "places": {
+      "Trap": 4,
+      "Treasure": 4,
+      "Enchantment": 2,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "5": {
+    "size": [
+      12,
+      12
+    ],
+    "enemies": [
+      "Phoenix",
+      "Hydra",
+      "Revenant",
+      "Beholder"
+    ],
+    "bosses": [
+      "Grave Monarch",
+      "Storm Reaper"
+    ],
+    "places": {
+      "Trap": 4,
+      "Treasure": 5,
+      "Enchantment": 2,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "6": {
+    "size": [
+      13,
+      13
+    ],
+    "enemies": [
+      "Minotaur",
+      "Demon",
+      "Harpy",
+      "Shade"
+    ],
+    "bosses": [
+      "Bone Tyrant",
+      "Inferno Golem"
+    ],
+    "places": {
+      "Trap": 5,
+      "Treasure": 5,
+      "Enchantment": 2,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "7": {
+    "size": [
+      14,
+      14
+    ],
+    "enemies": [
+      "Giant Spider",
+      "Slime King",
+      "Zombie",
+      "Gargoyle"
+    ],
+    "bosses": [
+      "Frost Warden",
+      "Shadow Reaver"
+    ],
+    "places": {
+      "Trap": 5,
+      "Treasure": 6,
+      "Enchantment": 2,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "8": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Dark Knight",
+      "Cyclops",
+      "Basilisk",
+      "Werewolf"
+    ],
+    "bosses": [
+      "Doom Bringer",
+      "Void Serpent"
+    ],
+    "places": {
+      "Trap": 5,
+      "Treasure": 6,
+      "Enchantment": 3,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "9": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Hydra",
+      "Beholder",
+      "Revenant",
+      "Warlock"
+    ],
+    "bosses": [
+      "Ember Lord",
+      "Glacier Fiend"
+    ],
+    "places": {
+      "Trap": 6,
+      "Treasure": 6,
+      "Enchantment": 3,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "10": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Phoenix",
+      "Dark Knight",
+      "Cyclops",
+      "Minotaur"
+    ],
+    "bosses": [
+      "Grave Monarch",
+      "Storm Reaper"
+    ],
+    "places": {
+      "Trap": 6,
+      "Treasure": 7,
+      "Enchantment": 3,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "11": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Astral Dragon",
+      "Demon",
+      "Harpy",
+      "Shade"
+    ],
+    "bosses": [
+      "Bone Tyrant",
+      "Inferno Golem",
+      "Frost Warden"
+    ],
+    "places": {
+      "Trap": 7,
+      "Treasure": 7,
+      "Enchantment": 3,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "12": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Giant Spider",
+      "Slime King",
+      "Zombie",
+      "Warlock"
+    ],
+    "bosses": [
+      "Shadow Reaver",
+      "Doom Bringer",
+      "Void Serpent"
+    ],
+    "places": {
+      "Trap": 7,
+      "Treasure": 8,
+      "Enchantment": 4,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "13": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Basilisk",
+      "Gargoyle",
+      "Troll",
+      "Lich"
+    ],
+    "bosses": [
+      "Ember Lord",
+      "Glacier Fiend",
+      "Grave Monarch"
+    ],
+    "places": {
+      "Trap": 8,
+      "Treasure": 8,
+      "Enchantment": 4,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "14": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Hydra",
+      "Beholder",
+      "Revenant",
+      "Dark Knight"
+    ],
+    "bosses": [
+      "Storm Reaper"
+    ],
+    "places": {
+      "Trap": 8,
+      "Treasure": 9,
+      "Enchantment": 4,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "15": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Cyclops",
+      "Astral Dragon",
+      "Phoenix",
+      "Minotaur"
+    ],
+    "bosses": [
+      "Doom Bringer",
+      "Void Serpent"
+    ],
+    "places": {
+      "Trap": 9,
+      "Treasure": 9,
+      "Enchantment": 5,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "16": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Demon",
+      "Harpy",
+      "Shade",
+      "Giant Spider"
+    ],
+    "bosses": [
+      "Ember Lord",
+      "Glacier Fiend"
+    ],
+    "places": {
+      "Trap": 9,
+      "Treasure": 10,
+      "Enchantment": 5,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "17": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Slime King",
+      "Zombie",
+      "Gargoyle",
+      "Warlock"
+    ],
+    "bosses": [
+      "Grave Monarch",
+      "Storm Reaper"
+    ],
+    "places": {
+      "Trap": 9,
+      "Treasure": 10,
+      "Enchantment": 5,
+      "Sanctuary": 4,
+      "Blacksmith": 1
+    }
+  },
+  "18": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Hydra",
+      "Beholder",
+      "Astral Dragon",
+      "Dark Knight"
+    ],
+    "bosses": [
+      "Bone Tyrant",
+      "Doom Bringer",
+      "Void Serpent"
+    ],
+    "places": {
+      "Trap": 10,
+      "Treasure": 10,
+      "Enchantment": 6,
+      "Sanctuary": 4,
+      "Blacksmith": 1
+    }
+  }
+}

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -123,231 +123,28 @@ def floor_size(floor):
     return (size, size)
 
 
-# Floor specific configuration
-FLOOR_CONFIGS = {
-    1: {
-        "size": floor_size(1),
-        "enemies": ["Goblin", "Skeleton", "Bandit"],
-        "bosses": ["Bone Tyrant"],
-        "places": {
-            "Trap": 2,
-            "Treasure": 2,
-            "Enchantment": 1,
-            "Sanctuary": 1,
-            "Blacksmith": 1,
-        },
-    },
-    2: {
-        "size": floor_size(2),
-        "enemies": ["Orc", "Cultist", "Ghoul", "Bandit"],
-        "bosses": ["Inferno Golem", "Frost Warden"],
-        "places": {
-            "Trap": 3,
-            "Treasure": 3,
-            "Enchantment": 1,
-            "Sanctuary": 1,
-            "Blacksmith": 1,
-        },
-    },
-    3: {
-        "size": floor_size(3),
-        "enemies": ["Vampire", "Warlock", "Wraith", "Werewolf"],
-        "bosses": ["Shadow Reaver", "Doom Bringer"],
-        "places": {
-            "Trap": 3,
-            "Treasure": 4,
-            "Enchantment": 2,
-            "Sanctuary": 2,
-            "Blacksmith": 1,
-        },
-    },
-    4: {
-        "size": floor_size(4),
-        "enemies": ["Basilisk", "Gargoyle", "Troll", "Lich"],
-        "bosses": ["Void Serpent", "Ember Lord", "Glacier Fiend"],
-        "places": {
-            "Trap": 4,
-            "Treasure": 4,
-            "Enchantment": 2,
-            "Sanctuary": 2,
-            "Blacksmith": 1,
-        },
-    },
-    5: {
-        "size": floor_size(5),
-        "enemies": ["Phoenix", "Hydra", "Revenant", "Beholder"],
-        "bosses": ["Grave Monarch", "Storm Reaper"],
-        "places": {
-            "Trap": 4,
-            "Treasure": 5,
-            "Enchantment": 2,
-            "Sanctuary": 2,
-            "Blacksmith": 1,
-        },
-    },
-    6: {
-        "size": floor_size(6),
-        "enemies": ["Minotaur", "Demon", "Harpy", "Shade"],
-        "bosses": ["Bone Tyrant", "Inferno Golem"],
-        "places": {
-            "Trap": 5,
-            "Treasure": 5,
-            "Enchantment": 2,
-            "Sanctuary": 2,
-            "Blacksmith": 1,
-        },
-    },
-    7: {
-        "size": floor_size(7),
-        "enemies": ["Giant Spider", "Slime King", "Zombie", "Gargoyle"],
-        "bosses": ["Frost Warden", "Shadow Reaver"],
-        "places": {
-            "Trap": 5,
-            "Treasure": 6,
-            "Enchantment": 2,
-            "Sanctuary": 2,
-            "Blacksmith": 1,
-        },
-    },
-    8: {
-        "size": floor_size(8),
-        "enemies": ["Dark Knight", "Cyclops", "Basilisk", "Werewolf"],
-        "bosses": ["Doom Bringer", "Void Serpent"],
-        "places": {
-            "Trap": 5,
-            "Treasure": 6,
-            "Enchantment": 3,
-            "Sanctuary": 2,
-            "Blacksmith": 1,
-        },
-    },
-    9: {
-        "size": floor_size(9),
-        "enemies": ["Hydra", "Beholder", "Revenant", "Warlock"],
-        "bosses": ["Ember Lord", "Glacier Fiend"],
-        "places": {
-            "Trap": 6,
-            "Treasure": 6,
-            "Enchantment": 3,
-            "Sanctuary": 2,
-            "Blacksmith": 1,
-        },
-    },
-    10: {
-        "size": floor_size(10),
-        "enemies": ["Phoenix", "Dark Knight", "Cyclops", "Minotaur"],
-        "bosses": ["Grave Monarch", "Storm Reaper"],
-        "places": {
-            "Trap": 6,
-            "Treasure": 7,
-            "Enchantment": 3,
-            "Sanctuary": 3,
-            "Blacksmith": 1,
-        },
-    },
-    11: {
-        "size": floor_size(11),
-        "enemies": ["Astral Dragon", "Demon", "Harpy", "Shade"],
-        "bosses": ["Bone Tyrant", "Inferno Golem", "Frost Warden"],
-        "places": {
-            "Trap": 7,
-            "Treasure": 7,
-            "Enchantment": 3,
-            "Sanctuary": 3,
-            "Blacksmith": 1,
-        },
-    },
-    12: {
-        "size": floor_size(12),
-        "enemies": ["Giant Spider", "Slime King", "Zombie", "Warlock"],
-        "bosses": ["Shadow Reaver", "Doom Bringer", "Void Serpent"],
-        "places": {
-            "Trap": 7,
-            "Treasure": 8,
-            "Enchantment": 4,
-            "Sanctuary": 3,
-            "Blacksmith": 1,
-        },
-    },
-    13: {
-        "size": floor_size(13),
-        "enemies": ["Basilisk", "Gargoyle", "Troll", "Lich"],
-        "bosses": ["Ember Lord", "Glacier Fiend", "Grave Monarch"],
-        "places": {
-            "Trap": 8,
-            "Treasure": 8,
-            "Enchantment": 4,
-            "Sanctuary": 3,
-            "Blacksmith": 1,
-        },
-    },
-    14: {
-        "size": floor_size(14),
-        "enemies": ["Hydra", "Beholder", "Revenant", "Dark Knight"],
-        "bosses": ["Storm Reaper"],
-        "places": {
-            "Trap": 8,
-            "Treasure": 9,
-            "Enchantment": 4,
-            "Sanctuary": 3,
-            "Blacksmith": 1,
-        },
-    },
-    15: {
-        "size": floor_size(15),
-        "enemies": ["Cyclops", "Astral Dragon", "Phoenix", "Minotaur"],
-        "bosses": ["Doom Bringer", "Void Serpent"],
-        "places": {
-            "Trap": 9,
-            "Treasure": 9,
-            "Enchantment": 5,
-            "Sanctuary": 3,
-            "Blacksmith": 1,
-        },
-    },
-    16: {
-        "size": floor_size(16),
-        "enemies": ["Demon", "Harpy", "Shade", "Giant Spider"],
-        "bosses": ["Ember Lord", "Glacier Fiend"],
-        "places": {
-            "Trap": 9,
-            "Treasure": 10,
-            "Enchantment": 5,
-            "Sanctuary": 3,
-            "Blacksmith": 1,
-        },
-    },
-    17: {
-        "size": floor_size(17),
-        "enemies": ["Slime King", "Zombie", "Gargoyle", "Warlock"],
-        "bosses": ["Grave Monarch", "Storm Reaper"],
-        "places": {
-            "Trap": 9,
-            "Treasure": 10,
-            "Enchantment": 5,
-            "Sanctuary": 4,
-            "Blacksmith": 1,
-        },
-    },
-    18: {
-        "size": floor_size(18),
-        "enemies": ["Hydra", "Beholder", "Astral Dragon", "Dark Knight"],
-        "bosses": ["Bone Tyrant", "Doom Bringer", "Void Serpent"],
-        "places": {
-            "Trap": 10,
-            "Treasure": 10,
-            "Enchantment": 6,
-            "Sanctuary": 4,
-            "Blacksmith": 1,
-        },
-    },
-}
+# Floor specific configuration loaded from data/floors.json
 
-
-# Register default event types for each floor configuration
 EVENT_TYPES = [MerchantEvent, PuzzleEvent, TrapEvent]
-for cfg in FLOOR_CONFIGS.values():
-    cfg.setdefault("events", EVENT_TYPES)
+
+
+@lru_cache(maxsize=None)
+def load_floor_configs():
+    """Load per-floor configuration from ``floors.json``."""
+    path = DATA_DIR / "floors.json"
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    configs = {}
+    for floor, cfg in data.items():
+        floor = int(floor)
+        cfg.setdefault("size", floor_size(floor))
+        cfg["size"] = tuple(cfg["size"])
+        cfg.setdefault("events", EVENT_TYPES)
+        configs[floor] = cfg
+    return configs
+
+
+FLOOR_CONFIGS = load_floor_configs()
 
 
 class DungeonBase:

--- a/tests/test_dungeon_generation.py
+++ b/tests/test_dungeon_generation.py
@@ -5,12 +5,13 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from dungeoncrawler import map as dungeon_map
-from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.dungeon import DungeonBase, load_floor_configs
 from dungeoncrawler.entities import Enemy, Player
 
 
 def test_generate_dungeon_size_and_population():
     random.seed(0)
+    load_floor_configs()
     dungeon = DungeonBase(1, 1)
     dungeon.player = Player("Tester")
     dungeon_map.generate_dungeon(dungeon, floor=1)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,12 +4,13 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.dungeon import DungeonBase, load_floor_configs
 from dungeoncrawler.entities import Player
 from dungeoncrawler.events import MerchantEvent, PuzzleEvent, TrapEvent
 
 
 def setup_game():
+    load_floor_configs()
     game = DungeonBase(5, 5)
     game.player = Player("hero")
     return game

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -5,12 +5,13 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from dungeoncrawler import map as dungeon_map
-from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.dungeon import DungeonBase, load_floor_configs
 from dungeoncrawler.entities import Player
 
 
 def test_render_map_snapshot():
     random.seed(0)
+    load_floor_configs()
     game = DungeonBase(1, 1)
     game.player = Player("Tester")
     dungeon_map.generate_dungeon(game, floor=1)


### PR DESCRIPTION
## Summary
- move floor configuration to new data/floors.json
- load floor config data at runtime and expose loader
- adjust tests to initialize game with loaded floor data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a8fcb7144832695cc5ae43a36203d