### PR TITLE
Handle missing plugins during discovery

### DIFF
--- a/dungeoncrawler/plugins.py
+++ b/dungeoncrawler/plugins.py
@@ -1,6 +1,7 @@
 import importlib
 import json
 import pkgutil
+import logging
 from pathlib import Path
 
 from .items import Item, Weapon
@@ -12,10 +13,13 @@ def discover_plugins():
     """Return imported plugin modules found under :mod:`mods` package."""
     if not MODS_DIR.exists():
         return []
-    return [
-        importlib.import_module(f"mods.{m.name}")
-        for m in pkgutil.iter_modules([str(MODS_DIR)])
-    ]
+    modules = []
+    for m in pkgutil.iter_modules([str(MODS_DIR)]):
+        try:
+            modules.append(importlib.import_module(f"mods.{m.name}"))
+        except ImportError:
+            logging.warning("Failed to import plugin '%s'", m.name)
+    return modules
 
 
 def _load_json_from_mod(mod, filename):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import types
+import logging
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler import plugins as plugins_module
+
+
+def test_discover_plugins_skips_faulty(monkeypatch, tmp_path, caplog):
+    # create temporary mods package
+    (tmp_path / "__init__.py").write_text("")
+    (tmp_path / "good.py").write_text("")
+    (tmp_path / "bad.py").write_text("raise ImportError('boom')")
+
+    mod_pkg = types.ModuleType("mods")
+    mod_pkg.__path__ = [str(tmp_path)]
+    monkeypatch.setitem(sys.modules, "mods", mod_pkg)
+    monkeypatch.setattr(plugins_module, "MODS_DIR", tmp_path)
+
+    caplog.set_level(logging.WARNING)
+    modules = plugins_module.discover_plugins()
+
+    assert any(m.__name__ == "mods.good" for m in modules)
+    assert all(m.__name__ != "mods.bad" for m in modules)
+    assert "bad" in caplog.text


### PR DESCRIPTION
## Summary
- handle ImportError when discovering mods and log a warning instead of failing
- add test ensuring faulty plugins are skipped without crashing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a92b7e32c8326b1ccc147db3d96a5