### PR TITLE
refactor: use dataclasses for items and weapons

### DIFF
--- a/dungeoncrawler/items.py
+++ b/dungeoncrawler/items.py
@@ -1,13 +1,20 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
 class Item:
-    def __init__(self, name, description):
-        self.name = name
-        self.description = description
+    """Simple item with a name and description."""
+
+    name: str
+    description: str
 
 
+@dataclass
 class Weapon(Item):
-    def __init__(self, name, description, min_damage, max_damage, price=50):
-        super().__init__(name, description)
-        self.min_damage = min_damage
-        self.max_damage = max_damage
-        self.price = price
-        self.effect = None
+    """Weapon that can deal a range of damage and may apply an effect."""
+
+    min_damage: int
+    max_damage: int
+    price: int = 50
+    effect: Optional[str] = field(default=None)


### PR DESCRIPTION
## Summary
- convert `Item` and `Weapon` to `@dataclass`
- keep fields for damage, price and effect using dataclass defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a9782ac688326add053e3851e2d2a