### PR TITLE
Refactor status effects to use handler registry

### DIFF
--- a/dungeoncrawler/status_effects.py
+++ b/dungeoncrawler/status_effects.py
@@ -3,94 +3,117 @@ from __future__ import annotations
 from gettext import gettext as _
 
 
+def _handle_poison(entity, effects, is_player, name):
+    if effects["poison"] > 0:
+        entity.health -= 3
+        if is_player:
+            print(_("You take 3 poison damage!"))
+        else:
+            print(_(f"The {name} takes 3 poison damage!"))
+        effects["poison"] -= 1
+    if effects["poison"] <= 0:
+        del effects["poison"]
+    return False
+
+
+def _handle_burn(entity, effects, is_player, name):
+    if effects["burn"] > 0:
+        entity.health -= 4
+        if is_player:
+            print(_("You suffer 4 burn damage!"))
+        else:
+            print(_(f"The {name} suffers 4 burn damage!"))
+        effects["burn"] -= 1
+    if effects["burn"] <= 0:
+        del effects["burn"]
+    return False
+
+
+def _handle_bleed(entity, effects, is_player, name):
+    if effects["bleed"] > 0:
+        entity.health -= 2
+        if is_player:
+            print(_("You bleed for 2 damage!"))
+        else:
+            print(_(f"The {name} bleeds for 2 damage!"))
+        effects["bleed"] -= 1
+    if effects["bleed"] <= 0:
+        del effects["bleed"]
+    return False
+
+
+def _handle_freeze(entity, effects, is_player, name):
+    skip_turn = False
+    if effects["freeze"] > 0:
+        if is_player:
+            print(_("You're frozen and lose your turn!"))
+        else:
+            print(_(f"The {name} is frozen and can't move!"))
+        effects["freeze"] -= 1
+        skip_turn = True
+    if effects["freeze"] <= 0:
+        del effects["freeze"]
+    return skip_turn
+
+
+def _handle_stun(entity, effects, is_player, name):
+    skip_turn = False
+    if effects["stun"] > 0:
+        if is_player:
+            print(_("You're stunned and can't move!"))
+        else:
+            print(_(f"The {name} is stunned and can't move!"))
+        effects["stun"] -= 1
+        skip_turn = True
+    if effects["stun"] <= 0:
+        del effects["stun"]
+    return skip_turn
+
+
+def _handle_shield(entity, effects, is_player, name):
+    effects["shield"] -= 1
+    if effects["shield"] <= 0:
+        if is_player:
+            print(_("Your shield fades."))
+        else:
+            print(_(f"The {name}'s shield fades."))
+        del effects["shield"]
+    return False
+
+
+def _handle_inspire(entity, effects, is_player, name):
+    if effects["inspire"] == 3 and hasattr(entity, "attack_power"):
+        entity.attack_power += 3
+    effects["inspire"] -= 1
+    if effects["inspire"] <= 0:
+        if hasattr(entity, "attack_power"):
+            entity.attack_power -= 3
+        del effects["inspire"]
+    return False
+
+
+STATUS_EFFECT_HANDLERS = {
+    "poison": _handle_poison,
+    "burn": _handle_burn,
+    "bleed": _handle_bleed,
+    "freeze": _handle_freeze,
+    "stun": _handle_stun,
+    "shield": _handle_shield,
+    "inspire": _handle_inspire,
+}
+
+
 def apply_status_effects(entity) -> bool:
-    """Update ``entity`` based on active status effects.
+    """Update ``entity`` based on active status effects."""
 
-    Parameters
-    ----------
-    entity: Any object with ``status_effects`` and ``health`` attributes.
-
-    Returns
-    -------
-    bool
-        ``True`` if the entity's turn should be skipped due to an effect.
-    """
     effects = getattr(entity, "status_effects", {})
     skip_turn = False
     is_player = entity.__class__.__name__ == "Player"
     name = entity.name if hasattr(entity, "name") else ""
 
-    if "poison" in effects:
-        if effects["poison"] > 0:
-            entity.health -= 3
-            if is_player:
-                print(_("You take 3 poison damage!"))
-            else:
-                print(_(f"The {name} takes 3 poison damage!"))
-            effects["poison"] -= 1
-        if effects["poison"] <= 0:
-            del effects["poison"]
-
-    if "burn" in effects:
-        if effects["burn"] > 0:
-            entity.health -= 4
-            if is_player:
-                print(_("You suffer 4 burn damage!"))
-            else:
-                print(_(f"The {name} suffers 4 burn damage!"))
-            effects["burn"] -= 1
-        if effects["burn"] <= 0:
-            del effects["burn"]
-
-    if "bleed" in effects:
-        if effects["bleed"] > 0:
-            entity.health -= 2
-            if is_player:
-                print(_("You bleed for 2 damage!"))
-            else:
-                print(_(f"The {name} bleeds for 2 damage!"))
-            effects["bleed"] -= 1
-        if effects["bleed"] <= 0:
-            del effects["bleed"]
-
-    if "freeze" in effects:
-        if effects["freeze"] > 0:
-            if is_player:
-                print(_("You're frozen and lose your turn!"))
-            else:
-                print(_(f"The {name} is frozen and can't move!"))
-            effects["freeze"] -= 1
-            skip_turn = True
-        if effects["freeze"] <= 0:
-            del effects["freeze"]
-
-    if "stun" in effects:
-        if effects["stun"] > 0:
-            if is_player:
-                print(_("You're stunned and can't move!"))
-            else:
-                print(_(f"The {name} is stunned and can't move!"))
-            effects["stun"] -= 1
-            skip_turn = True
-        if effects["stun"] <= 0:
-            del effects["stun"]
-
-    if "shield" in effects:
-        effects["shield"] -= 1
-        if effects["shield"] <= 0:
-            if is_player:
-                print(_("Your shield fades."))
-            else:
-                print(_(f"The {name}'s shield fades."))
-            del effects["shield"]
-
-    if "inspire" in effects:
-        if effects["inspire"] == 3 and hasattr(entity, "attack_power"):
-            entity.attack_power += 3
-        effects["inspire"] -= 1
-        if effects["inspire"] <= 0:
-            if hasattr(entity, "attack_power"):
-                entity.attack_power -= 3
-            del effects["inspire"]
+    for effect in list(effects.keys()):
+        handler = STATUS_EFFECT_HANDLERS.get(effect)
+        if handler:
+            skip_turn = handler(entity, effects, is_player, name) or skip_turn
 
     return skip_turn

--- a/tests/test_status_effects.py
+++ b/tests/test_status_effects.py
@@ -1,0 +1,67 @@
+import pytest
+
+from dungeoncrawler.status_effects import (
+    STATUS_EFFECT_HANDLERS,
+    apply_status_effects,
+)
+
+
+class Player:
+    """Simple entity used for status effect tests."""
+
+    def __init__(self, health=10, attack_power=5, status_effects=None):
+        self.health = health
+        self.attack_power = attack_power
+        self.status_effects = status_effects or {}
+        self.name = "hero"
+
+
+@pytest.mark.parametrize(
+    "effect,damage",
+    [
+        ("poison", 3),
+        ("burn", 4),
+        ("bleed", 2),
+    ],
+)
+def test_damage_effects(effect, damage):
+    player = Player(status_effects={effect: 1})
+    apply_status_effects(player)
+    assert player.health == 10 - damage
+    assert effect not in player.status_effects
+
+
+@pytest.mark.parametrize("effect", ["freeze", "stun"])
+def test_skip_turn_effects(effect):
+    player = Player(status_effects={effect: 1})
+    assert apply_status_effects(player) is True
+    assert effect not in player.status_effects
+
+
+def test_shield_expires():
+    player = Player(status_effects={"shield": 1})
+    assert apply_status_effects(player) is False
+    assert "shield" not in player.status_effects
+
+
+def test_inspire_temporarily_boosts_attack():
+    player = Player(attack_power=5, status_effects={"inspire": 3})
+    apply_status_effects(player)
+    assert player.attack_power == 8
+    apply_status_effects(player)
+    apply_status_effects(player)
+    assert player.attack_power == 5
+    assert "inspire" not in player.status_effects
+
+
+def test_custom_effect_via_registry(monkeypatch):
+    def handler(entity, effects, is_player, name):
+        entity.health += 5
+        del effects["heal"]
+        return False
+
+    monkeypatch.setitem(STATUS_EFFECT_HANDLERS, "heal", handler)
+    player = Player(health=5, status_effects={"heal": 1})
+    apply_status_effects(player)
+    assert player.health == 10
+    assert "heal" not in player.status_effects


### PR DESCRIPTION
## Summary
- Centralize individual status effect logic behind dedicated handler functions
- Iterate over a status effect registry to apply effects, reducing duplication
- Add comprehensive tests for status effect behavior and registry extensibility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aa54f7154832693adb64a7b4f9773