### PR TITLE
Validate configuration inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ cp config.example.json config.json
 ```
 
 The defaults mirror previous hard-coded values so the game will run even if
-no custom configuration is supplied.
+no custom configuration is supplied. When providing your own configuration,
+ensure numeric values like `screen_width`, `screen_height`, and `max_floors`
+are positive integers—invalid entries will raise a `ValueError` at start-up.
 
 ## Running the Game
 

--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -37,6 +37,13 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
     Config
         A :class:`Config` instance populated with values from the JSON file or
         falling back to defaults when the file or specific keys are missing.
+
+    Raises
+    ------
+    ValueError
+        If a configuration value has an invalid type or falls outside the
+        accepted range. For example ``screen_width`` and ``screen_height`` must
+        be positive integers.
     """
 
     cfg = Config()
@@ -47,6 +54,14 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
             return cfg
         for key, value in data.items():
             if hasattr(cfg, key):
+                if key in {"screen_width", "screen_height", "max_floors"}:
+                    if not isinstance(value, int):
+                        raise ValueError(f"{key} must be an integer, got {type(value).__name__}")
+                    if value <= 0:
+                        raise ValueError(f"{key} must be greater than 0, got {value}")
+                elif key in {"save_file", "score_file"}:
+                    if not isinstance(value, str):
+                        raise ValueError(f"{key} must be a string, got {type(value).__name__}")
                 setattr(cfg, key, value)
     return cfg
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from dungeoncrawler.config import Config, load_config
+
+
+def test_load_config_valid(tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(
+        json.dumps({"screen_width": 20, "screen_height": 15, "max_floors": 5})
+    )
+    cfg = load_config(cfg_file)
+    assert cfg.screen_width == 20
+    assert cfg.screen_height == 15
+    assert cfg.max_floors == 5
+
+
+def test_load_config_invalid_type(tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"screen_width": "wide"}))
+    with pytest.raises(ValueError):
+        load_config(cfg_file)
+
+
+def test_load_config_invalid_range(tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"screen_height": 0}))
+    with pytest.raises(ValueError):
+        load_config(cfg_file)


### PR DESCRIPTION
## Summary
- add type and range validation when reading config values
- document required positive integer config fields
- test configuration loading for valid and invalid values

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aa67bf6008326bfa0519c5230ee87