### PR TITLE
Enhance combat feedback and death reporting

### DIFF
--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -6,6 +6,9 @@ import random
 from gettext import gettext as _
 from typing import TYPE_CHECKING
 
+from .constants import INVALID_KEY_MSG
+from .status_effects import format_status_tags
+
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .dungeon import DungeonBase
     from .entities import Enemy, Player
@@ -56,8 +59,8 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
             enemy_turn(enemy, player)
             continue
 
-        print(_(f"Player Health: {player.health}"))
-        print(_(f"Enemy Health: {enemy.health}"))
+        print(_(f"Player Health: {player.health} {format_status_tags(player.status_effects)}"))
+        print(_(f"Enemy Health: {enemy.health} {format_status_tags(enemy.status_effects)}"))
         print(_("1. Attack\n2. Defend\n3. Use Health Potion\n4. Use Skill"))
         choice = input(_("Choose action: "))
         if choice == "1":
@@ -75,7 +78,7 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
             game.announce(_("Special skill unleashed!"))
             enemy_turn(enemy, player)
         else:
-            print(_("Invalid choice!"))
+            print(_(INVALID_KEY_MSG))
         player.decrement_cooldowns()
 
     if not enemy.is_alive():

--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -59,8 +59,16 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
             enemy_turn(enemy, player)
             continue
 
-        print(_(f"Player Health: {player.health} {format_status_tags(player.status_effects)}"))
-        print(_(f"Enemy Health: {enemy.health} {format_status_tags(enemy.status_effects)}"))
+        print(
+            _(
+                f"Player Health: {player.health} {format_status_tags(player.status_effects)}"
+            )
+        )
+        print(
+            _(
+                f"Enemy Health: {enemy.health} {format_status_tags(enemy.status_effects)}"
+            )
+        )
         print(_("1. Attack\n2. Defend\n3. Use Health Potion\n4. Use Skill"))
         choice = input(_("Choose action: "))
         if choice == "1":

--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -21,6 +21,7 @@ class Config:
     max_floors: int = 18
     screen_width: int = 10
     screen_height: int = 10
+    verbose_combat: bool = False
 
 
 def load_config(path: Path = CONFIG_PATH) -> Config:
@@ -65,6 +66,11 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
                     if not isinstance(value, str):
                         raise ValueError(
                             f"{key} must be a string, got {type(value).__name__}"
+                        )
+                elif key == "verbose_combat":
+                    if not isinstance(value, bool):
+                        raise ValueError(
+                            f"{key} must be a boolean, got {type(value).__name__}"
                         )
                 setattr(cfg, key, value)
     return cfg

--- a/dungeoncrawler/constants.py
+++ b/dungeoncrawler/constants.py
@@ -19,6 +19,7 @@ SCORE_FILE = BASE_DIR / config.score_file
 MAX_FLOORS = config.max_floors
 SCREEN_WIDTH = config.screen_width
 SCREEN_HEIGHT = config.screen_height
+INVALID_KEY_MSG = "Unknown key. Try [WASD] to move, [F] to defend, [G] to grab."
 ANNOUNCER_LINES = [
     "A decisive blow!",
     "You fight with determination.",

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -315,7 +315,9 @@ class DungeonBase:
                 records = []
 
         duration = time.time() - self.run_start if self.run_start else 0
-        epitaph = f"Fell on Floor {floor} to '{self.player.cause_of_death or 'Unknown'}'"
+        epitaph = (
+            f"Fell on Floor {floor} to '{self.player.cause_of_death or 'Unknown'}'"
+        )
         records.append(
             {
                 "player_name": self.player.name,
@@ -356,7 +358,7 @@ class DungeonBase:
                 _(
                     f"{r.get('player_name', '?')}: {r.get('score', 0)} "
                     f"(Floor {r.get('floor_reached', '?')}, {r.get('run_duration', 0):.0f}s, Seed {r.get('seed', '?')}) "
-                    f"{r.get('epitaph', '')}" 
+                    f"{r.get('epitaph', '')}"
                 )
             )
 
@@ -541,7 +543,9 @@ class DungeonBase:
                     break
 
         print(_("You have died. Game Over!"))
-        print(_(f"Fell on Floor {floor} to '{self.player.cause_of_death or 'Unknown'}'"))
+        print(
+            _(f"Fell on Floor {floor} to '{self.player.cause_of_death or 'Unknown'}'")
+        )
         print(_(f"Final Score: {self.player.get_score()}"))
         self.record_score(floor)
         if os.path.exists(SAVE_FILE):

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -9,7 +9,13 @@ from pathlib import Path
 from . import combat as combat_module
 from . import map as map_module
 from . import shop as shop_module
-from .constants import ANNOUNCER_LINES, RIDDLES, SAVE_FILE, SCORE_FILE
+from .constants import (
+    ANNOUNCER_LINES,
+    INVALID_KEY_MSG,
+    RIDDLES,
+    SAVE_FILE,
+    SCORE_FILE,
+)
 from .entities import Companion, Player
 from .events import MerchantEvent, PuzzleEvent, TrapEvent
 from .items import Item, Weapon
@@ -309,6 +315,7 @@ class DungeonBase:
                 records = []
 
         duration = time.time() - self.run_start if self.run_start else 0
+        epitaph = f"Fell on Floor {floor} to '{self.player.cause_of_death or 'Unknown'}'"
         records.append(
             {
                 "player_name": self.player.name,
@@ -316,6 +323,7 @@ class DungeonBase:
                 "floor_reached": floor,
                 "run_duration": duration,
                 "seed": self.seed,
+                "epitaph": epitaph,
             }
         )
         records = sorted(records, key=lambda x: x["score"], reverse=True)[:10]
@@ -347,7 +355,8 @@ class DungeonBase:
             print(
                 _(
                     f"{r.get('player_name', '?')}: {r.get('score', 0)} "
-                    f"(Floor {r.get('floor_reached', '?')}, {r.get('run_duration', 0):.0f}s, Seed {r.get('seed', '?')})"
+                    f"(Floor {r.get('floor_reached', '?')}, {r.get('run_duration', 0):.0f}s, Seed {r.get('seed', '?')}) "
+                    f"{r.get('epitaph', '')}" 
                 )
             )
 
@@ -379,7 +388,7 @@ class DungeonBase:
         while choice not in classes:
             choice = input(_("Class: "))
             if choice not in classes:
-                print(_("Invalid choice. Please try again."))
+                print(_(INVALID_KEY_MSG))
         self.player.choose_class(classes[choice])
 
     def offer_guild(self):
@@ -532,6 +541,7 @@ class DungeonBase:
                     break
 
         print(_("You have died. Game Over!"))
+        print(_(f"Fell on Floor {floor} to '{self.player.cause_of_death or 'Unknown'}'"))
         print(_(f"Final Score: {self.player.get_score()}"))
         self.record_score(floor)
         if os.path.exists(SAVE_FILE):
@@ -567,7 +577,7 @@ class DungeonBase:
         elif choice == "9":
             self.view_leaderboard()
         else:
-            print(_("Invalid choice!"))
+            print(_(INVALID_KEY_MSG))
         return True
 
     def process_turn(self, floor: int):
@@ -636,7 +646,7 @@ class DungeonBase:
                 self.announce(f"{self.player.name} gains a helpful item!")
             else:
                 damage = random.randint(5, 15)
-                self.player.take_damage(damage)
+                self.player.take_damage(damage, source="Audience Gift")
                 print(_(f"Uh-oh! It explodes and deals {damage} damage."))
                 self.announce("The crowd loves a good prank!")
 

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import random
 from gettext import gettext as _
 
+from .config import config
 from .constants import ANNOUNCER_LINES
 from .items import Item, Weapon
-from .status_effects import apply_status_effects as apply_effects
+from .status_effects import add_status_effect, apply_status_effects as apply_effects
 
 
 class Entity:
@@ -41,6 +42,8 @@ class Player(Entity):
         self.race = None
         self.x = 0
         self.y = 0
+        self.inventory_limit = 8
+        self.cause_of_death = ""
         # Start as an untrained crawler. Specific classes can be chosen later
         # via ``choose_class``.
         self.choose_class(class_type, announce=False)
@@ -105,7 +108,11 @@ class Player(Entity):
         return self.health > 0
 
     def collect_item(self, item):
+        if len(self.inventory) >= self.inventory_limit:
+            print(_(f"Backpack full ({self.inventory_limit}/{self.inventory_limit}). Drop something with [D]."))
+            return False
         self.inventory.append(item)
+        return True
 
     def has_item(self, name):
         return any(item.name == name for item in self.inventory)
@@ -133,12 +140,34 @@ class Player(Entity):
         Applies any weapon effects and awards experience and gold if the enemy
         is defeated.
         """
-        damage: int = self.calculate_damage()
-        self.apply_weapon_effect(enemy)
-        print(_(f"You attacked the {enemy.name} and dealt {damage} damage!"))
-        enemy.take_damage(damage)
-        if not enemy.is_alive():
-            self.process_enemy_defeat(enemy)
+        hit_chance = 85
+        roll = random.randint(1, 100)
+        base = self.calculate_damage()
+        str_bonus = 0
+        damage = base + str_bonus
+        if roll <= hit_chance:
+            self.apply_weapon_effect(enemy)
+            enemy.take_damage(damage)
+            if config.verbose_combat:
+                print(
+                    _(
+                        f"You swing ({hit_chance}% to hit): roll {roll} → HIT. Damage {damage} ({base} base +{str_bonus} STR)."
+                    )
+                )
+            else:
+                print(_(f"You hit the {enemy.name} for {damage} damage."))
+            if not enemy.is_alive():
+                self.process_enemy_defeat(enemy)
+        else:
+            if config.verbose_combat:
+                reason = "It slipped on the wet stone!"
+                print(
+                    _(
+                        f"You swing ({hit_chance}% to hit): roll {roll} → MISS. {reason}"
+                    )
+                )
+            else:
+                print(_(f"You missed the {enemy.name}."))
 
     def calculate_damage(self) -> int:
         """Return the damage dealt by the player's current attack."""
@@ -148,11 +177,8 @@ class Player(Entity):
 
     def apply_weapon_effect(self, enemy: Enemy) -> None:
         """Apply the equipped weapon's status effect to ``enemy`` if present."""
-        if self.weapon and hasattr(self.weapon, "effect") and self.weapon.effect:
-            effect = self.weapon.effect
-            enemy.status_effects = getattr(enemy, "status_effects", {})
-            enemy.status_effects[effect] = 3
-            print(_(f"Your weapon inflicts {effect} on the {enemy.name}!"))
+        if self.weapon and getattr(self.weapon, "effect", None):
+            add_status_effect(enemy, self.weapon.effect, 3)
 
     def process_enemy_defeat(self, enemy: Enemy) -> None:
         """Handle rewards for defeating ``enemy`` such as XP and gold."""
@@ -169,14 +195,16 @@ class Player(Entity):
 
     def defend(self, enemy):
         damage = max(0, enemy.attack_power - 5)
-        self.health -= damage
+        self.take_damage(damage, source=enemy.name)
         print(_(f"The {enemy.name} attacked you and dealt {damage} damage."))
 
-    def take_damage(self, damage):
+    def take_damage(self, damage, source=None):
         if "shield" in self.status_effects:
             damage = max(0, damage - 5)
             print(_("Your shield absorbs 5 damage!"))
         self.health = max(0, self.health - damage)
+        if self.health <= 0:
+            self.cause_of_death = source or "unknown"
 
     def apply_status_effects(self):
         """Delegate to the shared status effect helper."""
@@ -196,8 +224,7 @@ class Player(Entity):
         damage = self.attack_power + random.randint(10, 15)
         print(_(f"You cast Fireball dealing {damage} damage!"))
         enemy.take_damage(damage)
-        enemy.status_effects = getattr(enemy, "status_effects", {})
-        enemy.status_effects["burn"] = 3
+        add_status_effect(enemy, "burn", 3)
 
     def _skill_rogue(self, enemy):
         damage = self.attack_power + random.randint(5, 10)
@@ -220,7 +247,7 @@ class Player(Entity):
 
     def _skill_bard(self, enemy):
         print(_("You play an inspiring tune, bolstering your spirit!"))
-        self.status_effects["inspire"] = 3
+        add_status_effect(self, "inspire", 3)
 
     def _skill_barbarian(self, enemy):
         damage = self.attack_power + random.randint(8, 12)
@@ -232,8 +259,7 @@ class Player(Entity):
     def _skill_druid(self, enemy):
         damage = self.attack_power + random.randint(5, 10)
         enemy.take_damage(damage)
-        enemy.status_effects = getattr(enemy, "status_effects", {})
-        enemy.status_effects["freeze"] = 1
+        add_status_effect(enemy, "freeze", 1)
         heal = min(5, self.max_health - self.health)
         self.health += heal
         print(_(f"Nature's wrath deals {damage} damage and restores {heal} health!"))
@@ -241,15 +267,13 @@ class Player(Entity):
     def _skill_ranger(self, enemy):
         damage = self.attack_power + random.randint(6, 12)
         enemy.take_damage(damage)
-        enemy.status_effects = getattr(enemy, "status_effects", {})
-        enemy.status_effects["poison"] = 3
+        add_status_effect(enemy, "poison", 3)
         print(_(f"A volley of arrows hits for {damage} damage and poisons the foe!"))
 
     def _skill_sorcerer(self, enemy):
         damage = self.attack_power + random.randint(12, 18)
         enemy.take_damage(damage)
-        enemy.status_effects = getattr(enemy, "status_effects", {})
-        enemy.status_effects["burn"] = 3
+        add_status_effect(enemy, "burn", 3)
         print(_(f"You unleash Arcane Blast for {damage} damage!"))
 
     def _skill_monk(self, enemy):
@@ -282,8 +306,7 @@ class Player(Entity):
     def _skill_alchemist(self, enemy):
         damage = self.attack_power + random.randint(8, 12)
         enemy.take_damage(damage)
-        enemy.status_effects = getattr(enemy, "status_effects", {})
-        enemy.status_effects["burn"] = 3
+        add_status_effect(enemy, "burn", 3)
         print(
             _(f"An explosive flask bursts for {damage} damage and sets the foe ablaze!")
         )
@@ -441,7 +464,7 @@ class Enemy(Entity):
         return apply_effects(self)
 
     def defend(self):
-        self.status_effects["shield"] = 1
+        add_status_effect(self, "shield", 1)
         print(_(f"The {self.name} raises its guard!"))
 
     def take_turn(self, player):
@@ -454,27 +477,45 @@ class Enemy(Entity):
             self.attack(player)
 
     def attack(self, player):
+        hit_chance = 60
+        roll = random.randint(1, 100)
         damage = random.randint(self.attack_power // 2, self.attack_power)
-        if self.ability == "lifesteal":
-            self.health += damage // 3
-            print(_(f"The {self.name} drains life and heals for {damage // 3}!"))
-        elif self.ability == "poison":
-            player.status_effects["poison"] = 3
-        elif self.ability == "burn":
-            player.status_effects["burn"] = 3
-        elif self.ability == "stun":
-            player.status_effects["stun"] = 1
-            print(_(f"The {self.name} stuns you!"))
-        elif self.ability == "bleed":
-            player.status_effects["bleed"] = 3
-        elif self.ability == "freeze":
-            player.status_effects["freeze"] = 1
-            print(_(f"The {self.name} freezes you for 1 turns!"))
-        elif self.ability == "double_strike" and random.random() < 0.25:
-            print(_(f"The {self.name} strikes twice!"))
-            player.take_damage(damage)
-        player.take_damage(damage)
-        print(_(f"The {self.name} attacked you and dealt {damage} damage."))
+        if roll <= hit_chance:
+            if self.ability == "lifesteal":
+                self.health += damage // 3
+                print(_(f"The {self.name} drains life and heals for {damage // 3}!"))
+            elif self.ability == "poison":
+                add_status_effect(player, "poison", 3)
+            elif self.ability == "burn":
+                add_status_effect(player, "burn", 3)
+            elif self.ability == "stun":
+                add_status_effect(player, "stun", 1)
+            elif self.ability == "bleed":
+                add_status_effect(player, "bleed", 3)
+            elif self.ability == "freeze":
+                add_status_effect(player, "freeze", 1)
+            elif self.ability == "double_strike" and random.random() < 0.25:
+                print(_(f"The {self.name} strikes twice!"))
+                player.take_damage(damage, source=self.name)
+            player.take_damage(damage, source=self.name)
+            if config.verbose_combat:
+                print(
+                    _(
+                        f"{self.name} attacks ({hit_chance}%): roll {roll} → HIT. Damage {damage}."
+                    )
+                )
+            else:
+                print(_(f"The {self.name} attacked you and dealt {damage} damage."))
+        else:
+            if config.verbose_combat:
+                reason = "It slipped on the wet stone!"
+                print(
+                    _(
+                        f"{self.name} attacks ({hit_chance}%): roll {roll} → MISS. {reason}"
+                    )
+                )
+            else:
+                print(_(f"The {self.name}'s attack missed."))
 
 
 class Companion(Entity):

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -109,7 +109,11 @@ class Player(Entity):
 
     def collect_item(self, item):
         if len(self.inventory) >= self.inventory_limit:
-            print(_(f"Backpack full ({self.inventory_limit}/{self.inventory_limit}). Drop something with [D]."))
+            print(
+                _(
+                    f"Backpack full ({self.inventory_limit}/{self.inventory_limit}). Drop something with [D]."
+                )
+            )
             return False
         self.inventory.append(item)
         return True
@@ -162,9 +166,7 @@ class Player(Entity):
             if config.verbose_combat:
                 reason = "It slipped on the wet stone!"
                 print(
-                    _(
-                        f"You swing ({hit_chance}% to hit): roll {roll} → MISS. {reason}"
-                    )
+                    _(f"You swing ({hit_chance}% to hit): roll {roll} → MISS. {reason}")
                 )
             else:
                 print(_(f"You missed the {enemy.name}."))

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -46,5 +46,5 @@ class TrapEvent(BaseEvent):
 
     def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
         damage = random.randint(5, 20)
-        game.player.take_damage(damage)
+        game.player.take_damage(damage, source="The Tripwire")
         output_func(_(f"A trap is sprung! You take {damage} damage."))

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -338,7 +338,7 @@ def handle_room(game: "DungeonBase", x: int, y: int) -> None:
             game.announce(_("Brilliant puzzle solving!"))
         else:
             damage = random.randint(10, 30)
-            game.player.take_damage(damage)
+            game.player.take_damage(damage, source="The Trap")
             print(_(f"Wrong answer! You take {damage} damage."))
         game.rooms[y][x] = None
         game.room_names[y][x] = "Booby-Trapped Passage"

--- a/dungeoncrawler/shop.py
+++ b/dungeoncrawler/shop.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from gettext import gettext as _
 from typing import TYPE_CHECKING
 
+from .constants import INVALID_KEY_MSG
 from .items import Item, Weapon
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
@@ -45,9 +46,9 @@ def shop(
         elif choice == exit_option:
             output_func(_("Leaving the shop."))
         else:
-            output_func(_("Invalid choice."))
+            output_func(_(INVALID_KEY_MSG))
     else:
-        output_func(_("Invalid input."))
+        output_func(_(INVALID_KEY_MSG))
 
 
 def get_sale_price(item):
@@ -100,9 +101,9 @@ def sell_items(
         elif choice == len(game.player.inventory) + 1:
             return
         else:
-            output_func(_("Invalid choice."))
+            output_func(_(INVALID_KEY_MSG))
     else:
-        output_func(_("Invalid input."))
+        output_func(_(INVALID_KEY_MSG))
 
 
 def show_inventory(
@@ -133,4 +134,4 @@ def show_inventory(
             else:
                 output_func(_("You can only equip weapons."))
         else:
-            output_func(_("Invalid selection."))
+            output_func(_(INVALID_KEY_MSG))

--- a/dungeoncrawler/status_effects.py
+++ b/dungeoncrawler/status_effects.py
@@ -39,9 +39,7 @@ def _handle_poison(entity, effects, is_player, name):
     if effects["poison"] > 0:
         entity.health -= 3
         remaining = effects["poison"] - 1
-        msg = _(
-            f"Poison -3 HP ({remaining} turns left)."
-        )
+        msg = _(f"Poison -3 HP ({remaining} turns left).")
         if is_player:
             print(msg)
         else:
@@ -60,9 +58,7 @@ def _handle_burn(entity, effects, is_player, name):
     if effects["burn"] > 0:
         entity.health -= 4
         remaining = effects["burn"] - 1
-        msg = _(
-            f"Burn -4 HP ({remaining} turns left)."
-        )
+        msg = _(f"Burn -4 HP ({remaining} turns left).")
         if is_player:
             print(msg)
         else:
@@ -81,9 +77,7 @@ def _handle_bleed(entity, effects, is_player, name):
     if effects["bleed"] > 0:
         entity.health -= 2
         remaining = effects["bleed"] - 1
-        msg = _(
-            f"Bleeding -2 HP ({remaining} turns left)."
-        )
+        msg = _(f"Bleeding -2 HP ({remaining} turns left).")
         if is_player:
             print(msg)
         else:
@@ -102,9 +96,7 @@ def _handle_freeze(entity, effects, is_player, name):
     skip_turn = False
     if effects["freeze"] > 0:
         remaining = effects["freeze"] - 1
-        msg = _(
-            f"Frozen ({remaining} turns left)."
-        )
+        msg = _(f"Frozen ({remaining} turns left).")
         if is_player:
             print(msg)
         else:
@@ -124,9 +116,7 @@ def _handle_stun(entity, effects, is_player, name):
     skip_turn = False
     if effects["stun"] > 0:
         remaining = effects["stun"] - 1
-        msg = _(
-            f"Stunned ({remaining} turns left)."
-        )
+        msg = _(f"Stunned ({remaining} turns left).")
         if is_player:
             print(msg)
         else:

--- a/dungeoncrawler/status_effects.py
+++ b/dungeoncrawler/status_effects.py
@@ -3,75 +3,153 @@ from __future__ import annotations
 from gettext import gettext as _
 
 
+EFFECT_INFO = {
+    "poison": "Lose 3 HP/turn.",
+    "burn": "Lose 4 HP/turn.",
+    "bleed": "Lose 2 HP/turn.",
+    "freeze": "Cannot act.",
+    "stun": "Cannot act.",
+    "shield": "Block 5 damage.",
+    "inspire": "+3 attack.",
+}
+
+
+def add_status_effect(entity, effect: str, duration: int) -> None:
+    """Apply ``effect`` to ``entity`` and announce it."""
+
+    effects = getattr(entity, "status_effects", {})
+    effects[effect] = duration
+    is_player = entity.__class__.__name__ == "Player"
+    desc = EFFECT_INFO.get(effect, "")
+    name = getattr(entity, "name", "")
+    tag = effect.capitalize()
+    if is_player:
+        print(_(f"You are {tag} ({duration} turns). {desc}"))
+    else:
+        print(_(f"The {name} is {tag} ({duration} turns). {desc}"))
+
+
+def format_status_tags(effects: dict) -> str:
+    """Return a compact string of status effect tags."""
+
+    return " ".join(f"[{k.capitalize()}:{v}]" for k, v in effects.items())
+
+
 def _handle_poison(entity, effects, is_player, name):
     if effects["poison"] > 0:
         entity.health -= 3
+        remaining = effects["poison"] - 1
+        msg = _(
+            f"Poison -3 HP ({remaining} turns left)."
+        )
         if is_player:
-            print(_("You take 3 poison damage!"))
+            print(msg)
         else:
-            print(_(f"The {name} takes 3 poison damage!"))
+            print(_(f"The {name} {msg.lower()}"))
         effects["poison"] -= 1
     if effects["poison"] <= 0:
         del effects["poison"]
+        if is_player:
+            print(_("Poison faded."))
+        else:
+            print(_(f"The {name}'s poison faded."))
     return False
 
 
 def _handle_burn(entity, effects, is_player, name):
     if effects["burn"] > 0:
         entity.health -= 4
+        remaining = effects["burn"] - 1
+        msg = _(
+            f"Burn -4 HP ({remaining} turns left)."
+        )
         if is_player:
-            print(_("You suffer 4 burn damage!"))
+            print(msg)
         else:
-            print(_(f"The {name} suffers 4 burn damage!"))
+            print(_(f"The {name} {msg.lower()}"))
         effects["burn"] -= 1
     if effects["burn"] <= 0:
         del effects["burn"]
+        if is_player:
+            print(_("Burn ended."))
+        else:
+            print(_(f"The {name}'s burn ended."))
     return False
 
 
 def _handle_bleed(entity, effects, is_player, name):
     if effects["bleed"] > 0:
         entity.health -= 2
+        remaining = effects["bleed"] - 1
+        msg = _(
+            f"Bleeding -2 HP ({remaining} turns left)."
+        )
         if is_player:
-            print(_("You bleed for 2 damage!"))
+            print(msg)
         else:
-            print(_(f"The {name} bleeds for 2 damage!"))
+            print(_(f"The {name} {msg.lower()}"))
         effects["bleed"] -= 1
     if effects["bleed"] <= 0:
         del effects["bleed"]
+        if is_player:
+            print(_("Bleeding stopped."))
+        else:
+            print(_(f"The {name}'s bleeding stopped."))
     return False
 
 
 def _handle_freeze(entity, effects, is_player, name):
     skip_turn = False
     if effects["freeze"] > 0:
+        remaining = effects["freeze"] - 1
+        msg = _(
+            f"Frozen ({remaining} turns left)."
+        )
         if is_player:
-            print(_("You're frozen and lose your turn!"))
+            print(msg)
         else:
-            print(_(f"The {name} is frozen and can't move!"))
+            print(_(f"The {name} is {msg[0].lower() + msg[1:]}"))
         effects["freeze"] -= 1
         skip_turn = True
     if effects["freeze"] <= 0:
         del effects["freeze"]
+        if is_player:
+            print(_("You thaw out."))
+        else:
+            print(_(f"The {name} thaws out."))
     return skip_turn
 
 
 def _handle_stun(entity, effects, is_player, name):
     skip_turn = False
     if effects["stun"] > 0:
+        remaining = effects["stun"] - 1
+        msg = _(
+            f"Stunned ({remaining} turns left)."
+        )
         if is_player:
-            print(_("You're stunned and can't move!"))
+            print(msg)
         else:
-            print(_(f"The {name} is stunned and can't move!"))
+            print(_(f"The {name} is {msg[0].lower() + msg[1:]}"))
         effects["stun"] -= 1
         skip_turn = True
     if effects["stun"] <= 0:
         del effects["stun"]
+        if is_player:
+            print(_("You recover from the stun."))
+        else:
+            print(_(f"The {name} recovers from the stun."))
     return skip_turn
 
 
 def _handle_shield(entity, effects, is_player, name):
     effects["shield"] -= 1
+    remaining = effects.get("shield", 0)
+    if remaining > 0:
+        if is_player:
+            print(_(f"Shield ({remaining} turns left)."))
+        else:
+            print(_(f"The {name}'s shield ({remaining} turns left)."))
     if effects["shield"] <= 0:
         if is_player:
             print(_("Your shield fades."))
@@ -85,10 +163,20 @@ def _handle_inspire(entity, effects, is_player, name):
     if effects["inspire"] == 3 and hasattr(entity, "attack_power"):
         entity.attack_power += 3
     effects["inspire"] -= 1
-    if effects["inspire"] <= 0:
+    remaining = effects.get("inspire", 0)
+    if remaining > 0:
+        if is_player:
+            print(_(f"Inspire ({remaining} turns left)."))
+        else:
+            print(_(f"The {name} is inspired ({remaining} turns left)."))
+    if effects.get("inspire", 0) <= 0:
         if hasattr(entity, "attack_power"):
             entity.attack_power -= 3
         del effects["inspire"]
+        if is_player:
+            print(_("Inspiration fades."))
+        else:
+            print(_(f"The {name}'s inspiration fades."))
     return False
 
 

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -25,6 +25,7 @@ def test_record_score_persistence(tmp_path, monkeypatch):
     assert data[0]["floor_reached"] == 5
     assert data[0]["seed"] == 1234
     assert data[0]["run_duration"] == 10
+    assert "epitaph" in data[0]
 
 
 def test_view_leaderboard_display(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- add `verbose_combat` config flag and new combat breakdown messaging
- show status-effect HUD tags and detailed apply/tick messages
- record cause-of-death epitaphs and improve invalid input hints

## Testing
- `PYTHONPATH=. pytest tests/test_config.py -q`
- `pytest tests/test_floor_events.py -q`
- `pytest tests/test_leaderboard.py tests/test_map.py tests/test_plugins.py tests/test_riddles.py tests/test_save.py tests/test_save_load.py tests/test_shop.py tests/test_skills.py tests/test_status_effects.py tests/test_tutorial.py -q`
- `PYTHONPATH=. pytest tests/test_dungeon_helpers.py tests/test_boss_loot.py tests/test_build_character.py tests/test_combat.py tests/test_companions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ab23d6010832694b618757dab8843