### PR TITLE
Add guard-based defend action

### DIFF
--- a/dungeoncrawler/status_effects.py
+++ b/dungeoncrawler/status_effects.py
@@ -10,6 +10,7 @@ EFFECT_INFO = {
     "stun": "Cannot act.",
     "shield": "Block 5 damage.",
     "inspire": "+3 attack.",
+    "guard": "Incoming damage -40%. Next attack +10% hit.",
 }
 
 


### PR DESCRIPTION
## Summary
- Introduce Guard status triggered by Defend: next hit takes 40% less damage and next attack gains +10% accuracy
- Track guard state on the player and display it as a status effect

## Testing
- `pytest tests/test_combat.py::test_player_attack_defeats_enemy tests/test_combat.py::test_defensive_ai_defends tests/test_companions.py::test_attack_companion_deals_damage`


------
https://chatgpt.com/codex/tasks/task_e_689ae3f554d88326865d8f9808040086