### PR TITLE
Add flee mechanic with speed-based escape chance

### DIFF
--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -69,7 +69,9 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
                 f"Enemy Health: {enemy.health} {format_status_tags(enemy.status_effects)}"
             )
         )
-        print(_("1. Attack\n2. Defend\n3. Use Health Potion\n4. Use Skill"))
+        print(
+            _("1. Attack\n2. Defend\n3. Use Health Potion\n4. Use Skill\n5. Flee")
+        )
         choice = input(_("Choose action: "))
         if choice == "1":
             player.attack(enemy)
@@ -84,6 +86,11 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
         elif choice == "4":
             player.use_skill(enemy)
             game.announce(_("Special skill unleashed!"))
+            enemy_turn(enemy, player)
+        elif choice == "5":
+            if player.flee(enemy):
+                game.announce(f"{player.name} flees from {enemy.name}!")
+                break
             enemy_turn(enemy, player)
         else:
             print(_(INVALID_KEY_MSG))

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -108,3 +108,26 @@ def test_enemy_damage_range(player):
     enemy.attack(player)
     damage = start - player.health
     assert 10 <= damage <= 20
+
+
+def test_player_flee_success():
+    player = Player("Hero")
+    enemy = Enemy("Goblin", 10, 0, 0, 0, speed=5)
+    player.speed = 20
+    random.seed(0)
+    assert player.flee(enemy) is True
+    assert "advantage" not in enemy.status_effects
+
+
+def test_player_flee_failure_gives_enemy_advantage():
+    player = Player("Hero")
+    enemy = Enemy("Goblin", 10, 5, 0, 0, speed=10)
+    player.speed = 10
+    random.seed(0)
+    assert player.flee(enemy) is False
+    assert enemy.status_effects.get("advantage") == 1
+    random.seed(30)
+    before = player.health
+    enemy.attack(player)
+    assert player.health < before
+    assert "advantage" not in enemy.status_effects


### PR DESCRIPTION
## Summary
- Introduce speed stat and `flee` action for players to escape combat with chance based on speed difference
- Give enemies advantage (+15% hit chance) when a flee attempt fails
- Add battle menu option for fleeing and accompanying tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b6921b4c883268a5f35100e83c18b