### PR TITLE
feat: introduce enemy intent AI with telegraphed actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Enemies now select weighted combat intents (Aggressive, Defensive or Unpredictable) and telegraph their actions to the player.
+
 ## [0.9.0b1] - 2025-08-11
 ### Added
 - Pre-release package for beta testing.

--- a/docs/gameplay_guide.rst
+++ b/docs/gameplay_guide.rst
@@ -17,3 +17,15 @@ As you explore, floors can trigger random events:
 
 These events add variety and can occur on any floor.
 
+Enemy Intents
+-------------
+Foes now telegraph their behaviour each round.  Every enemy rolls one of
+three intents—Aggressive, Defensive or Unpredictable—weighted by its
+archetype.  The selected intent is announced before the action resolves,
+for example::
+
+    Goblin steadies a heavy strike…
+    Beetle curls into its shell.
+
+Pay attention to these tells to decide when to Defend or attempt a Feint.
+

--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -48,6 +48,8 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
             f"You encountered a {enemy.name}! {enemy.ability.capitalize() if enemy.ability else ''} Boss incoming!"
         )
     )
+    if enemy.ai and hasattr(enemy.ai, "plan_next"):
+        enemy.next_action, enemy.intent_message = enemy.ai.plan_next(enemy, player)
     game.announce(f"{player.name} engages {enemy.name}!")
     while player.is_alive() and enemy.is_alive():
         skip_player = player.apply_status_effects()
@@ -69,6 +71,8 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
                 f"Enemy Health: {enemy.health} {format_status_tags(enemy.status_effects)}"
             )
         )
+        if enemy.intent_message:
+            print(_(enemy.intent_message))
         print(
             _(
                 f"[1] Power [2] Feint [3] Bandage STA: {player.stamina}/{player.max_stamina}"

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from .combat import battle
 from .entities import Companion, Enemy
+from .ai import IntentAI, ARCHETYPES
 from .items import Item
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
@@ -114,7 +115,9 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
         gold = random.randint(15 + early_game_bonus + floor, 30 + floor * 2)
 
         ability = game.enemy_abilities.get(name)
-        enemy = Enemy(name, health, attack, defense, gold, ability)
+        weights = ARCHETYPES.get(name)
+        ai = IntentAI(**weights) if weights else None
+        enemy = Enemy(name, health, attack, defense, gold, ability, ai)
         enemy.xp = max(5, (health + attack + defense) // 15)
 
         place(enemy)
@@ -123,6 +126,8 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
     name = random.choice(boss_names)
     hp, atk, dfs, gold, ability = game.boss_stats[name]
     print(_(f"A powerful boss guards this floor! The {name} lurks nearby..."))
+    boss_weights = ARCHETYPES.get(name)
+    boss_ai = IntentAI(**boss_weights) if boss_weights else None
     boss = Enemy(
         name,
         hp + floor * 10,
@@ -130,6 +135,7 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
         dfs + floor // 2,
         gold + floor * 5,
         ability=ability,
+        ai=boss_ai,
     )
     place(boss)
     boss_drop = game.boss_loot.get(name, [])


### PR DESCRIPTION
## Summary
- add `IntentAI` for weighted aggressive, defensive, and unpredictable enemy intents
- telegraph upcoming enemy actions and support heavy/wild attacks
- document new intent system in gameplay guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b7f6a05988326a2853de1416bb612