### PR TITLE
Add fountain use tracking and blessing/curse effects

### DIFF
--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -135,19 +135,22 @@ class Player(Entity):
         return any(item.name == name for item in self.inventory)
 
     def use_health_potion(self):
-        potion = next(
-            (
-                item
-                for item in self.inventory
-                if isinstance(item, Item) and item.name == "Health Potion"
-            ),
-            None,
-        )
+        potion = None
+        heal = 0
+        for item in self.inventory:
+            if isinstance(item, Item) and item.name == "Health Potion":
+                potion = item
+                heal = 20
+                break
+            if isinstance(item, Item) and item.name == "Fountain Water":
+                potion = item
+                heal = random.randint(4, 6)
+                break
         if potion:
             self.inventory.remove(potion)
-            healed_amount = min(20, self.max_health - self.health)
+            healed_amount = min(heal, self.max_health - self.health)
             self.health += healed_amount
-            print(_(f"You used a Health Potion and gained {healed_amount} health."))
+            print(_(f"You used a {potion.name} and gained {healed_amount} health."))
         else:
             print(_("You don't have a Health Potion to use."))
 
@@ -182,6 +185,10 @@ class Player(Entity):
             self.status_effects.pop("guard", None)
         if getattr(self, "novice_luck_active", False):
             hit_chance += 10
+        if "blessed" in self.status_effects:
+            hit_chance += 10
+        if "cursed" in self.status_effects:
+            hit_chance -= 5
         roll = random.randint(1, 100)
         base = self.calculate_damage()
         str_bonus = 0
@@ -615,6 +622,10 @@ class Enemy(Entity):
             wild = True
         else:
             wild = False
+        if "blessed" in self.status_effects:
+            hit_chance += 10
+        if "cursed" in self.status_effects:
+            hit_chance -= 5
         roll = random.randint(1, 100)
         damage = random.randint(self.attack_power // 2, self.attack_power)
         if self.status_effects.pop("heavy", 0):

--- a/dungeoncrawler/status_effects.py
+++ b/dungeoncrawler/status_effects.py
@@ -12,6 +12,8 @@ EFFECT_INFO = {
     "inspire": "+3 attack.",
     "guard": "Incoming damage -40%. Next attack +10% hit.",
     "stagger": "-20% hit.",
+    "blessed": "+10% hit chance.",
+    "cursed": "-5% hit chance.",
 }
 
 
@@ -171,6 +173,40 @@ def _handle_inspire(entity, effects, is_player, name):
     return False
 
 
+def _handle_blessed(entity, effects, is_player, name):
+    effects["blessed"] -= 1
+    remaining = effects.get("blessed", 0)
+    if remaining > 0:
+        if is_player:
+            print(_(f"Blessed ({remaining} turns left)."))
+        else:
+            print(_(f"The {name} is blessed ({remaining} turns left)."))
+    if effects["blessed"] <= 0:
+        del effects["blessed"]
+        if is_player:
+            print(_("Blessing fades."))
+        else:
+            print(_(f"The {name}'s blessing fades."))
+    return False
+
+
+def _handle_cursed(entity, effects, is_player, name):
+    effects["cursed"] -= 1
+    remaining = effects.get("cursed", 0)
+    if remaining > 0:
+        if is_player:
+            print(_(f"Cursed ({remaining} turns left)."))
+        else:
+            print(_(f"The {name} is cursed ({remaining} turns left)."))
+    if effects["cursed"] <= 0:
+        del effects["cursed"]
+        if is_player:
+            print(_("Curse fades."))
+        else:
+            print(_(f"The {name}'s curse fades."))
+    return False
+
+
 STATUS_EFFECT_HANDLERS = {
     "poison": _handle_poison,
     "burn": _handle_burn,
@@ -179,6 +215,8 @@ STATUS_EFFECT_HANDLERS = {
     "stun": _handle_stun,
     "shield": _handle_shield,
     "inspire": _handle_inspire,
+    "blessed": _handle_blessed,
+    "cursed": _handle_cursed,
 }
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -55,13 +55,31 @@ def test_fountain_event_drink_heals():
     game = setup_game()
     game.player.health = 50
     event = FountainEvent()
-    with patch("dungeoncrawler.events.random.randint", return_value=8):
+    inputs = iter(["d", "x"])
+    with (
+        patch("dungeoncrawler.events.random.randint", return_value=8),
+        patch("dungeoncrawler.events.random.random", return_value=0.5),
+    ):
         event.trigger(
             game,
-            input_func=lambda _: "q",
+            input_func=lambda _: next(inputs),
             output_func=lambda _msg: None,
         )
     assert game.player.health == 58
+    assert event.remaining_uses == 1
+
+
+def test_fountain_event_bottle_adds_item():
+    game = setup_game()
+    event = FountainEvent()
+    inputs = iter(["b", "x"])
+    event.trigger(
+        game,
+        input_func=lambda _: next(inputs),
+        output_func=lambda _msg: None,
+    )
+    assert any(item.name == "Fountain Water" for item in game.player.inventory)
+    assert event.remaining_uses == 1
 
 
 def test_random_event_selection_from_floor_config():

--- a/tests/test_status_effects.py
+++ b/tests/test_status_effects.py
@@ -65,3 +65,13 @@ def test_custom_effect_via_registry(monkeypatch):
     apply_status_effects(player)
     assert player.health == 10
     assert "heal" not in player.status_effects
+
+
+def test_blessed_and_cursed_expire():
+    player = Player(status_effects={"blessed": 2, "cursed": 2})
+    apply_status_effects(player)
+    assert player.status_effects["blessed"] == 1
+    assert player.status_effects["cursed"] == 1
+    apply_status_effects(player)
+    assert "blessed" not in player.status_effects
+    assert "cursed" not in player.status_effects


### PR DESCRIPTION
## Summary
- expand fountain event with limited uses, blessing/curse chances, and bottling
- introduce blessed and cursed status effects with hit modifiers
- allow small fountain potion and adjust attacks for new effects

## Testing
- `pytest tests/test_events.py tests/test_status_effects.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba47c11ac83268d70e977668d94da