### PR TITLE
Add shrine choice buffs and floor reset

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -282,6 +282,8 @@ class DungeonBase:
                 "gold": self.player.gold,
                 "class": self.player.class_type,
                 "stamina": self.player.stamina,
+                "temp_strength": getattr(self.player, "temp_strength", 0),
+                "temp_intelligence": getattr(self.player, "temp_intelligence", 0),
                 "skill_cooldowns": {k: v["cooldown"] for k, v in self.player.skills.items()},
                 "guild": self.player.guild,
                 "race": self.player.race,
@@ -315,6 +317,8 @@ class DungeonBase:
             self.player.xp = p["xp"]
             self.player.gold = p["gold"]
             self.player.stamina = p.get("stamina", self.player.max_stamina)
+            self.player.temp_strength = p.get("temp_strength", 0)
+            self.player.temp_intelligence = p.get("temp_intelligence", 0)
             cooldowns = p.get("skill_cooldowns", {})
             for k, v in cooldowns.items():
                 if k in self.player.skills:
@@ -783,6 +787,9 @@ class DungeonBase:
             proceed = input(_("Would you like to descend to the next floor? (y/n): ")).lower()
             if proceed == "y":
                 floor += 1
+                # Reset temporary floor buffs
+                self.player.temp_strength = 0
+                self.player.temp_intelligence = 0
                 self.save_game(floor)
                 return floor, False
             print(_("You chose to exit the dungeon."))

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -75,6 +75,9 @@ class Player(Entity):
         # Temporary combat modifiers for the defend action
         self.guard_damage = False
         self.guard_attack = False
+        # Floor-scoped temporary buffs
+        self.temp_strength = 0
+        self.temp_intelligence = 0
         # Start as an untrained crawler. Specific classes can be chosen later
         # via ``choose_class``.
         self.choose_class(class_type, announce=False)
@@ -191,7 +194,7 @@ class Player(Entity):
             hit_chance -= 5
         roll = random.randint(1, 100)
         base = self.calculate_damage()
-        str_bonus = 0
+        str_bonus = getattr(self, "temp_strength", 0)
         damage = base + str_bonus
         if roll <= hit_chance:
             self.apply_weapon_effect(enemy)

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -117,12 +117,37 @@ class LoreNoteEvent(BaseEvent):
 
 
 class ShrineEvent(BaseEvent):
-    """Heal the player at a shrine."""
+    """Offer blessings or curses at a shrine."""
 
-    def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
-        heal = random.randint(8, 12)
-        game.player.health = min(game.player.max_health, game.player.health + heal)
-        output_func(_(f"A serene shrine restores {heal} health."))
+    def trigger(
+        self, game: "DungeonBase", input_func=input, output_func=print
+    ) -> None:
+        output_func(_("You discover a tranquil shrine with two altars."))
+        output_func(_("[V] Altar of Valor (+1 STR until next floor)"))
+        output_func(_("[W] Altar of Wisdom (+1 INT until next floor)"))
+        output_func(_("[P] Pray (60% boon / 40% curse)"))
+        choice = input_func(_("Choice: ")).strip().lower()
+        if choice == "v":
+            game.player.temp_strength += 1
+            output_func(_("A surge of might flows through you."))
+        elif choice == "w":
+            game.player.temp_intelligence += 1
+            output_func(_("Your mind feels momentarily sharper."))
+        elif choice == "p":
+            output_func(_("You kneel and whisper a prayer..."))
+            output_func("    _\\/_")
+            output_func("     /\\")
+            if random.random() < 0.6:
+                heal = random.randint(8, 12)
+                game.player.health = min(
+                    game.player.max_health, game.player.health + heal
+                )
+                output_func(_(f"A warm light restores {heal} health."))
+            else:
+                add_status_effect(game.player, "cursed", 30)
+                output_func(_("A dark chill leaves you cursed."))
+        else:
+            output_func(_("You leave the shrine undisturbed."))
 
 
 class MiniQuestHookEvent(BaseEvent):

--- a/tests/test_temp_buffs.py
+++ b/tests/test_temp_buffs.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+from dungeoncrawler.items import Item
+
+
+class DummyDungeon(DungeonBase):
+    def __init__(self):
+        super().__init__(1, 1)
+        self.player = Player("Tester")
+        self.exit_coords = (0, 0)
+
+
+def test_temp_buffs_reset_on_descend(monkeypatch):
+    dungeon = DummyDungeon()
+    dungeon.player.temp_strength = 2
+    dungeon.player.temp_intelligence = 3
+    dungeon.player.collect_item(Item("Key", ""))
+
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    dungeon.save_game = lambda f: None
+    floor, cont = dungeon.check_floor_completion(1)
+
+    assert (floor, cont) == (2, False)
+    assert dungeon.player.temp_strength == 0
+    assert dungeon.player.temp_intelligence == 0


### PR DESCRIPTION
## Summary
- Replace heal-only shrine with Valor/Wisdom altars or risky prayer
- Track temporary STR/INT buffs on player and reset when descending floors
- Persist and test temporary buffs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689bb0837e008326a65465be52812f88