### PR TITLE
Add lore codex and note buffs

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -292,6 +292,7 @@ class DungeonBase:
                 "companions": [
                     {"name": c.name, "effect": c.effect} for c in self.player.companions
                 ],
+                "codex": self.player.codex,
             },
         }
         try:
@@ -353,6 +354,7 @@ class DungeonBase:
 
             for comp_data in p.get("companions", []):
                 self.player.companions.append(Companion(comp_data["name"], comp_data["effect"]))
+            self.player.codex = p.get("codex", [])
 
             return data.get("floor", 1)
         return 1
@@ -755,9 +757,19 @@ class DungeonBase:
             self.render_map()
         elif choice == "9":
             self.view_leaderboard()
+        elif choice == ":codex":
+            self.show_codex()
         else:
             print(_(INVALID_KEY_MSG))
         return True
+
+    def show_codex(self, output_func=print):
+        if not self.player.codex:
+            output_func(_("Codex is empty."))
+            return
+        output_func(_("Codex:"))
+        for entry in self.player.codex:
+            output_func(f"- {entry}")
 
     def process_turn(self, floor: int):
         """Handle end-of-turn effects and floor completion checks.

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -40,6 +40,8 @@ class Player(Entity):
         self.companions = []
         self.guild = None
         self.race = None
+        # Record collected lore notes
+        self.codex = []
         # Stamina based skill system
         self.max_stamina = 100
         self.stamina = 100
@@ -192,6 +194,8 @@ class Player(Entity):
             hit_chance += 10
         if "cursed" in self.status_effects:
             hit_chance -= 5
+        if "beetle_bane" in self.status_effects and "beetle" in enemy.name.lower():
+            hit_chance += 5
         roll = random.randint(1, 100)
         base = self.calculate_damage()
         str_bonus = getattr(self, "temp_strength", 0)

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -125,11 +125,23 @@ class LoreNoteEvent(BaseEvent):
 
     def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
         notes = [
-            _("The walls whisper of an ancient battle."),
-            _("Scrawled handwriting reads: 'Beware the shadows.'"),
-            _("A faded map hints at deeper treasures."),
+            {"text": _("The walls whisper of an ancient battle.")},
+            {"text": _("Scrawled handwriting reads: 'Beware the shadows.'")},
+            {"text": _("A faded map hints at deeper treasures.")},
+            {
+                "text": _(
+                    "A margin scribble reveals beetle weak points (+5% hit vs beetles for 10 turns)."
+                ),
+                "effect": ("beetle_bane", 10),
+            },
         ]
-        output_func(random.choice(notes))
+        note = random.choice(notes)
+        output_func(note["text"])
+        if note["text"] not in game.player.codex:
+            game.player.codex.append(note["text"])
+        if "effect" in note:
+            effect, duration = note["effect"]
+            add_status_effect(game.player, effect, duration)
 
 
 class ShrineEvent(BaseEvent):

--- a/dungeoncrawler/status_effects.py
+++ b/dungeoncrawler/status_effects.py
@@ -14,6 +14,7 @@ EFFECT_INFO = {
     "stagger": "-20% hit.",
     "blessed": "+10% hit chance.",
     "cursed": "-5% hit chance.",
+    "beetle_bane": "+5% hit chance vs beetles.",
 }
 
 
@@ -207,6 +208,23 @@ def _handle_cursed(entity, effects, is_player, name):
     return False
 
 
+def _handle_beetle_bane(entity, effects, is_player, name):
+    effects["beetle_bane"] -= 1
+    remaining = effects.get("beetle_bane", 0)
+    if remaining > 0:
+        if is_player:
+            print(_(f"Beetle Bane ({remaining} turns left)."))
+        else:
+            print(_(f"The {name} studies beetle weaknesses ({remaining} turns left)."))
+    if effects.get("beetle_bane", 0) <= 0:
+        del effects["beetle_bane"]
+        if is_player:
+            print(_("Your beetle lore fades."))
+        else:
+            print(_(f"The {name}'s beetle lore fades."))
+    return False
+
+
 STATUS_EFFECT_HANDLERS = {
     "poison": _handle_poison,
     "burn": _handle_burn,
@@ -217,6 +235,7 @@ STATUS_EFFECT_HANDLERS = {
     "inspire": _handle_inspire,
     "blessed": _handle_blessed,
     "cursed": _handle_cursed,
+    "beetle_bane": _handle_beetle_bane,
 }
 
 

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1,0 +1,54 @@
+import random
+from dungeoncrawler.events import LoreNoteEvent
+from dungeoncrawler.entities import Player, Enemy
+from dungeoncrawler.dungeon import DungeonBase
+
+
+def test_lore_note_event_buff(monkeypatch):
+    player = Player("Hero")
+    class Game:
+        pass
+    game = Game()
+    game.player = player
+    event = LoreNoteEvent()
+    def fake_choice(seq):
+        return seq[-1]
+    monkeypatch.setattr(random, "choice", fake_choice)
+    event.trigger(game, output_func=lambda _ : None)
+    assert player.codex
+    assert "beetle_bane" in player.status_effects
+    assert player.status_effects["beetle_bane"] == 10
+
+
+def test_codex_command(capsys):
+    game = DungeonBase(5, 5)
+    game.player = Player("Hero")
+    game.player.codex = ["Note A", "Note B"]
+    assert game.handle_input(":codex")
+    out = capsys.readouterr().out
+    assert "Note A" in out and "Note B" in out
+
+
+def test_codex_persistence(tmp_path, monkeypatch):
+    save_path = tmp_path / "save.json"
+    monkeypatch.setattr("dungeoncrawler.dungeon.SAVE_FILE", save_path)
+    monkeypatch.setattr("dungeoncrawler.constants.SAVE_FILE", save_path)
+    game = DungeonBase(5, 5)
+    game.player = Player("Hero")
+    game.player.codex.append("Ancient note")
+    game.save_game(1)
+    new_game = DungeonBase(5, 5)
+    floor = new_game.load_game()
+    assert new_game.player.codex == ["Ancient note"]
+    assert floor == 1
+
+
+def test_beetle_bane_attack_bonus(monkeypatch):
+    player = Player("Hero")
+    enemy = Enemy("Giant Beetle", 5, 1, 0, 0)
+    player.status_effects["beetle_bane"] = 1
+    player.calculate_damage = lambda: 1
+    monkeypatch.setattr(random, "randint", lambda a, b: 86)
+    player.attack(enemy)
+    assert enemy.health == 4
+


### PR DESCRIPTION
## Summary
- Add player codex to track discovered lore notes
- Lore notes can grant temporary beetle-bane status effects
- Expose :codex command and persist codex to saves

## Testing
- `pytest tests/test_floor_events.py tests/test_dungeon_generation.py tests/test_map.py tests/test_shop.py tests/test_save.py tests/test_temp_buffs.py tests/test_config.py tests/test_leaderboard.py tests/test_save_load.py tests/test_tutorial.py tests/test_dungeon_helpers.py tests/test_plugins.py tests/test_stamina_skills.py tests/test_events.py tests/test_riddles.py tests/test_status_effects.py` *(failed: pytest: reading from stdin while output is captured)*


------
https://chatgpt.com/codex/tasks/task_e_689bbf1143f083268d8e66d8d2ca8bcf