### PR TITLE
Load runtime content from JSON files

### DIFF
--- a/data/companions.json
+++ b/data/companions.json
@@ -1,0 +1,4 @@
+[
+  {"name": "Battle Priest", "effect": "heal", "heal_amount": 5},
+  {"name": "Hired Blade", "effect": "attack", "attack_power": 5}
+]

--- a/data/events_extended.json
+++ b/data/events_extended.json
@@ -1,0 +1,20 @@
+{
+  "random": {
+    "MerchantEvent": 1.0,
+    "PuzzleEvent": 1.0,
+    "TrapEvent": 1.0,
+    "FountainEvent": 1.0,
+    "CacheEvent": 1.0,
+    "LoreNoteEvent": 1.0,
+    "ShrineEvent": 1.0,
+    "MiniQuestHookEvent": 1.0,
+    "HazardEvent": 1.0
+  },
+  "dungeon": {
+    "Trap": 3,
+    "Treasure": 3,
+    "Enchantment": 2,
+    "Sanctuary": 2,
+    "Blacksmith": 1
+  }
+}

--- a/data/items.json
+++ b/data/items.json
@@ -1,0 +1,18 @@
+{
+  "shop": [
+    {"type": "Item", "name": "Health Potion", "description": "Restores 20 health"},
+    {"type": "Weapon", "name": "Sword", "description": "A sharp sword", "min_damage": 10, "max_damage": 15, "price": 40},
+    {"type": "Weapon", "name": "Axe", "description": "A heavy axe", "min_damage": 12, "max_damage": 18, "price": 65},
+    {"type": "Weapon", "name": "Dagger", "description": "A quick dagger", "min_damage": 8, "max_damage": 12, "price": 35},
+    {"type": "Weapon", "name": "Warhammer", "description": "Crushes armor and bone", "min_damage": 14, "max_damage": 22, "price": 85},
+    {"type": "Weapon", "name": "Rapier", "description": "A slender, piercing blade", "min_damage": 9, "max_damage": 17, "price": 50},
+    {"type": "Weapon", "name": "Flame Blade", "description": "Glows with searing heat", "min_damage": 13, "max_damage": 20, "price": 95},
+    {"type": "Weapon", "name": "Crossbow", "description": "Ranged attack with bolts", "min_damage": 11, "max_damage": 19, "price": 60}
+  ],
+  "rare": [
+    {"type": "Weapon", "name": "Elven Longbow", "description": "Bow of unmatched accuracy.", "min_damage": 15, "max_damage": 25, "price": 0},
+    {"type": "Item", "name": "Blessed Charm", "description": "Said to bring good fortune."},
+    {"type": "Weapon", "name": "Dwarven Waraxe", "description": "Forged in the deep halls.", "min_damage": 12, "max_damage": 20, "price": 0},
+    {"type": "Item", "name": "Shadow Cloak", "description": "Grants an air of mystery"}
+  ]
+}

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -12,6 +12,7 @@ from .combat import battle
 from .entities import Companion, Enemy
 from .events import BaseEvent, CacheEvent, FountainEvent
 from .items import Item
+from .data import load_companions
 from .quests import EscortNPC
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
@@ -177,22 +178,12 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
         place(loot)
 
     place(Item("Key", "A magical key dropped by the boss"))
-    companion_options = [
-        Companion("Battle Priest", "heal"),
-        Companion("Hired Blade", "attack"),
-    ]
+    companion_options = load_companions()
     place(random.choice(companion_options))
     if floor <= 3:
         place(FountainEvent())
         place(CacheEvent())
-    default_places = {
-        "Trap": 3,
-        "Treasure": 3,
-        "Enchantment": 2,
-        "Sanctuary": 2,
-        "Blacksmith": 1,
-    }
-    place_counts = default_places.copy()
+    place_counts = game.default_place_counts.copy()
     place_counts.update(cfg.get("places", {}))
     for pname, count in place_counts.items():
         for __ in range(count):

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+
+import dungeoncrawler.data as data_module
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.events import MerchantEvent
+
+
+def test_shop_items_reflect_json_change(tmp_path):
+    items_path = Path(__file__).resolve().parents[1] / "data" / "items.json"
+    original = items_path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(original)
+        payload["shop"].append(
+            {"type": "Item", "name": "UnitTest Trinket", "description": "Tmp"}
+        )
+        items_path.write_text(json.dumps(payload), encoding="utf-8")
+        data_module.load_items.cache_clear()
+        game = DungeonBase(4, 4)
+        assert any(i.name == "UnitTest Trinket" for i in game.shop_items)
+    finally:
+        items_path.write_text(original, encoding="utf-8")
+        data_module.load_items.cache_clear()
+
+
+def test_random_events_reflect_json_change(monkeypatch):
+    events_path = Path(__file__).resolve().parents[1] / "data" / "events_extended.json"
+    original = events_path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(original)
+        payload["random"] = {"MerchantEvent": 1.0}
+        payload["dungeon"] = {}
+        events_path.write_text(json.dumps(payload), encoding="utf-8")
+        data_module.load_event_defs.cache_clear()
+        game = DungeonBase(4, 4)
+        called = {}
+
+        def fake_trigger(self, game, input_func=input, output_func=print):
+            called["cls"] = self.__class__.__name__
+
+        monkeypatch.setattr(MerchantEvent, "trigger", fake_trigger)
+        game.trigger_random_event(1)
+        assert called["cls"] == "MerchantEvent"
+    finally:
+        events_path.write_text(original, encoding="utf-8")
+        data_module.load_event_defs.cache_clear()


### PR DESCRIPTION
## Summary
- Introduce JSON files for items, events and companions
- Implement cached data loaders for items, events and companions
- Drive dungeon setup and map generation from loaded data rather than hard-coded lists
- Add regression tests ensuring JSON content changes are picked up at runtime

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689be4c781988326a9c2d5b14193300f