### PR TITLE
Add combat, movement, and trap event tests

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,3 +5,10 @@ Pull requests are welcome. For major changes, please open an issue first to disc
 
 Make sure to run the test suite with ``pytest`` and update documentation as needed.
 
+Testing
+-------
+Run the full suite with::
+
+    pytest
+
+The tests include combat math, movement, and trap event scenarios and rely on shared fixtures in ``tests/conftest.py``.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from dungeoncrawler.dungeon import DungeonBase, load_floor_configs
+from dungeoncrawler.entities import Player
+
+
+@pytest.fixture
+def player() -> Player:
+    p = Player("hero")
+    p.x = 1
+    p.y = 1
+    return p
+
+
+@pytest.fixture
+def game(player: Player) -> DungeonBase:
+    load_floor_configs()
+    game = DungeonBase(3, 3)
+    game.current_floor = 1
+    game.player = player
+    # initialize simple empty grid so movement works
+    game.rooms = [[[] for _ in range(game.width)] for _ in range(game.height)]
+    game.room_names = [[None for _ in range(game.width)] for _ in range(game.height)]
+    game.discovered = [[False for _ in range(game.width)] for _ in range(game.height)]
+    game.visible = [[False for _ in range(game.width)] for _ in range(game.height)]
+    game.rooms[player.y][player.x] = player
+    return game

--- a/tests/test_combat_math.py
+++ b/tests/test_combat_math.py
@@ -1,0 +1,18 @@
+import random
+from dungeoncrawler.entities import Enemy
+from dungeoncrawler.items import Weapon
+
+
+def test_calculate_damage_seeded(player):
+    player.attack_power = 10
+    random.seed(1)
+    assert player.calculate_damage() == 6
+
+
+def test_attack_applies_status_effect(player):
+    enemy = Enemy("goblin", 20, 5, 0, 0)
+    player.weapon = Weapon("Poisoned Blade", "", 5, 10, effect="poison")
+    random.seed(0)
+    player.attack(enemy)
+    assert enemy.health == 12
+    assert enemy.status_effects.get("poison") == 3

--- a/tests/test_movement.py
+++ b/tests/test_movement.py
@@ -1,0 +1,23 @@
+from dungeoncrawler import map as map_module
+
+
+def test_move_player_blocks_out_of_bounds(game):
+    game.player.x = 0
+    game.player.y = 0
+    game.rooms[0][0] = game.player
+    msg = map_module.move_player(game, "left")
+    assert msg == "You can't move that way."
+    assert (game.player.x, game.player.y) == (0, 0)
+
+
+def test_move_player_updates_visibility(game):
+    game.player.x = 1
+    game.player.y = 1
+    game.rooms[1][1] = game.player
+    game.rooms[1][2] = []
+    game.visible = [[False for _ in range(game.width)] for _ in range(game.height)]
+    game.discovered = [[False for _ in range(game.width)] for _ in range(game.height)]
+    map_module.move_player(game, "right")
+    assert (game.player.x, game.player.y) == (2, 1)
+    assert game.visible[1][2]
+    assert game.discovered[1][2]

--- a/tests/test_trap_event.py
+++ b/tests/test_trap_event.py
@@ -1,0 +1,26 @@
+from unittest.mock import Mock, patch
+from dungeoncrawler.events import TrapEvent
+
+
+def test_trap_event_disarm(game):
+    event = TrapEvent()
+    input_mock = Mock(return_value="d")
+    output_mock = Mock()
+    with patch("dungeoncrawler.events.random.random", return_value=0.0):
+        event.trigger(game, input_func=input_mock, output_func=output_mock)
+    assert game.player.stamina == 100 - event.disarm_cost
+    output_mock.assert_any_call("You carefully disarm the trap.")
+    assert (game.player.x, game.player.y) in game.visited_rooms
+
+
+def test_trap_event_damage_and_bleed(game):
+    event = TrapEvent()
+    output_mock = Mock()
+    with (
+        patch("dungeoncrawler.events.random.randint", return_value=7),
+        patch("dungeoncrawler.events.random.random", side_effect=[0.99, 0.0]),
+    ):
+        event.trigger(game, input_func=lambda _: "", output_func=output_mock)
+    assert game.player.health == 100 - 7
+    assert "bleed" in game.player.status_effects
+    output_mock.assert_any_call("A trap is sprung! You take 7 damage.")


### PR DESCRIPTION
## Summary
- add reusable DungeonBase and Player fixtures for tests
- test combat math damage and weapon effects with seeded randomness
- cover movement boundaries/visibility and trap event outcomes
- document running the test suite in contributing guide

## Testing
- `pytest tests/test_combat_math.py tests/test_movement.py tests/test_trap_event.py`


------
https://chatgpt.com/codex/tasks/task_e_689bea20219c8326ac02f2a56f6879e8