### PR TITLE
Add trap and loot settings to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ no custom configuration is supplied. When providing your own configuration,
 ensure numeric values like `screen_width`, `screen_height`, and `max_floors`
 are positive integers—invalid entries will raise a `ValueError` at start-up.
 
+Available configuration options:
+
+| Key | Type | Default | Description |
+| --- | ---- | ------- | ----------- |
+| `save_file` | string | `"savegame.json"` | Location of the saved game file. |
+| `score_file` | string | `"scores.json"` | Path to the leaderboard data. |
+| `max_floors` | int | `18` | Number of dungeon floors to generate. |
+| `screen_width` | int | `10` | Width of each dungeon floor in rooms. |
+| `screen_height` | int | `10` | Height of each dungeon floor in rooms. |
+| `trap_chance` | float | `0.1` | Probability that a room contains a trap. |
+| `loot_multiplier` | float | `1.0` | Multiplies the amount of loot found. |
+| `verbose_combat` | bool | `false` | Log additional combat details. |
+| `enable_debug` | bool | `false` | Toggle extra debug output. |
+
 ## Running the Game
 
 When launching the game you start by entering a name. Your class is chosen on

--- a/config.example.json
+++ b/config.example.json
@@ -4,5 +4,7 @@
   "max_floors": 18,
   "screen_width": 10,
   "screen_height": 10,
+  "trap_chance": 0.1,
+  "loot_multiplier": 1.0,
   "enable_debug": false
 }

--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -22,7 +22,10 @@ class Config:
     screen_width: int = 10
     screen_height: int = 10
     verbose_combat: bool = False
+    trap_chance: float = 0.1
+    loot_multiplier: float = 1.0
     enable_debug: bool = False
+    extras: dict[str, Any] = field(default_factory=dict)
 
 
 def load_config(path: Path = CONFIG_PATH) -> Config:
@@ -67,7 +70,21 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
                 elif key in {"verbose_combat", "enable_debug"}:
                     if not isinstance(value, bool):
                         raise ValueError(f"{key} must be a boolean, got {type(value).__name__}")
+                elif key == "trap_chance":
+                    if not isinstance(value, (int, float)):
+                        raise ValueError(f"{key} must be a number, got {type(value).__name__}")
+                    if not 0 <= float(value) <= 1:
+                        raise ValueError(f"{key} must be between 0 and 1, got {value}")
+                    value = float(value)
+                elif key == "loot_multiplier":
+                    if not isinstance(value, (int, float)):
+                        raise ValueError(f"{key} must be a number, got {type(value).__name__}")
+                    if float(value) <= 0:
+                        raise ValueError(f"{key} must be greater than 0, got {value}")
+                    value = float(value)
                 setattr(cfg, key, value)
+            else:
+                cfg.extras[key] = value
     return cfg
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,3 +26,19 @@ def test_load_config_invalid_range(tmp_path):
     cfg_file.write_text(json.dumps({"screen_height": 0}))
     with pytest.raises(ValueError):
         load_config(cfg_file)
+
+
+def test_new_keys_default(tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text("{}")
+    cfg = load_config(cfg_file)
+    assert cfg.trap_chance == 0.1
+    assert cfg.loot_multiplier == 1.0
+    assert cfg.enable_debug is False
+
+
+def test_unknown_keys_preserved(tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"future_option": 42}))
+    cfg = load_config(cfg_file)
+    assert cfg.extras["future_option"] == 42


### PR DESCRIPTION
## Summary
- add trap and loot options to config examples and dataclass
- document all available configuration keys
- record unknown config keys for future use and test defaults

## Testing
- `pytest tests/test_config.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf222b608832691d4eee408fe6361