### PR TITLE
Add new enemies and items

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -347,5 +347,43 @@
     ],
     "ai": {},
     "traits": []
+  },
+  {
+    "name": "Spectral Rat",
+    "stats": [
+      40,
+      60,
+      5,
+      12,
+      2
+    ],
+    "ai": {},
+    "traits": ["ethereal"],
+    "ability": "phase"
+  },
+  {
+    "name": "Clockwork Guard",
+    "stats": [
+      120,
+      160,
+      14,
+      24,
+      8
+    ],
+    "ai": {"aggressive": 2, "defensive": 2},
+    "traits": ["mechanical"],
+    "ability": "stun"
+  },
+  {
+    "name": "Fungal Brute",
+    "stats": [
+      150,
+      190,
+      18,
+      26,
+      7
+    ],
+    "ai": {},
+    "traits": ["poisonous"]
   }
 ]

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -233,6 +233,26 @@ class DungeonBase:
         self.tutorial_complete = False
         self.shop_items, self.rare_loot = load_items()
         apply_item_plugins(self.shop_items)
+        self.shop_items.extend(
+            [
+                Weapon("Rusty Pike", "Barely holds together", 3, 6, 5),
+                Item("Mystic Orb", "Glimmers with arcane energy"),
+                Weapon("Iron Staff", "Heavy but reliable", 5, 9, 12),
+            ]
+        )
+        self.rare_loot.extend(
+            [
+                Weapon(
+                    "Phantom Blade",
+                    "Slices through spirit and bone",
+                    12,
+                    18,
+                    120,
+                    "bleed",
+                ),
+                Item("Elixir of Insight", "Reveals hidden paths"),
+            ]
+        )
         (
             self.random_events,
             self.random_event_weights,


### PR DESCRIPTION
## Summary
- expand enemy roster with spectral, clockwork, and fungal foes
- stock dungeon shops and rare loot with extra weapons and trinkets

## Testing
- `pytest` *(fails: test_random_events_reflect_json_change, test_record_score_persistence, test_view_leaderboard_display, test_render_map_snapshot, test_riddles_loaded_and_used)*

------
https://chatgpt.com/codex/tasks/task_e_689bf8982f2c8326b7dbc335cd2469fd