### PR TITLE
feat: dynamic room flavor text and event intros

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -25,9 +25,7 @@ from .events import (
     FountainEvent,
     HazardEvent,
     LoreNoteEvent,
-    MerchantEvent,
     MiniQuestHookEvent,
-    PuzzleEvent,
     ShrineEvent,
     TrapEvent,
 )
@@ -567,40 +565,18 @@ class DungeonBase:
         self.player.choose_race(race)
 
     def generate_room_name(self, room_type=None):
-        lore = {
-            "Treasure": (
-                "Glittering Vault",
-                "The air shimmers with unseen magic. Ancient riches may lie within.",
-            ),
-            "Trap": (
-                "Booby-Trapped Passage",
-                "This corridor is riddled with pressure plates and crumbled bones.",
-            ),
-            "Enemy": (
-                "Cursed Hall",
-                "The shadows shift... something watches from the dark.",
-            ),
-            "Exit": (
-                "Sealed Gate",
-                "Massive stone doors sealed by arcane runes. It might be the only way out.",
-            ),
-            "Key": (
-                "Hidden Niche",
-                "A hollow carved into the wall, forgotten by time. Something valuable glints inside.",
-            ),
-            "Sanctuary": (
-                "Sacred Sanctuary",
-                "A calm aura fills this room, soothing your wounds.",
-            ),
-            "Empty": (
-                "Silent Chamber",
-                "Dust covers everything. It appears long abandoned.",
-            ),
-            "default": (None, None),
+        names = {
+            "Treasure": "Glittering Vault",
+            "Trap": "Booby-Trapped Passage",
+            "Enemy": "Cursed Hall",
+            "Exit": "Sealed Gate",
+            "Key": "Hidden Niche",
+            "Sanctuary": "Sacred Sanctuary",
+            "Empty": "Silent Chamber",
         }
 
-        if room_type in lore:
-            return lore[room_type][0]
+        if room_type in names:
+            return names[room_type]
 
         return f"{random.choice(ROOM_NAME_ADJECTIVES)} {random.choice(ROOM_NAME_NOUNS)}"
 
@@ -1010,13 +986,13 @@ class DungeonBase:
     def _floor_two_event(self):
         self.offer_guild()
         options = [CacheEvent, TrapEvent, LoreNoteEvent]
-        for _ in range(random.randint(1, 2)):
+        for __ in range(random.randint(1, 2)):
             random.choice(options)().trigger(self)
 
     def _floor_three_event(self):
         self.offer_race()
         options = [ShrineEvent, MiniQuestHookEvent, HazardEvent]
-        for _ in range(2):
+        for __ in range(2):
             random.choice(options)().trigger(self)
 
     def _floor_five_event(self):

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -71,6 +71,13 @@ class TrapEvent(BaseEvent):
         self.bleed_chance = cfg.get("bleed_chance", 0.3)
 
     def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
+        intros = [
+            _("A chill runs down your spine."),
+            _("The corridor ahead feels oddly dangerous."),
+            _("Your instincts warn of hidden snares."),
+        ]
+        output_func(random.choice(intros))
+
         speed = getattr(game.player, "speed", 0)
         perception = getattr(game.player, "perception", 0)
         detect_chance = self.detect_base + (speed + perception) * 0.05
@@ -113,8 +120,14 @@ class FountainEvent(BaseEvent):
         if self.remaining_uses <= 0:
             output_func(_("The fountain is dry."))
             return
+        intros = [
+            _("You find a cracked fountain. The water shimmers."),
+            _("An ancient fountain trickles invitingly."),
+            _("A mystical fountain bubbles softly."),
+        ]
+        output_func(random.choice(intros))
+
         while self.remaining_uses > 0:
-            output_func(_("You find a cracked fountain. The water shimmers."))
             output_func(_("Drink (D) / Bottle (B) / Leave (any other key)"))
             choice = input_func(_("Choice: ")).strip().lower()
             if choice in ("d", "q"):
@@ -143,6 +156,12 @@ class CacheEvent(BaseEvent):
     """Hidden cache that rewards gold."""
 
     def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
+        intros = [
+            _("A loose stone reveals a hidden cache."),
+            _("Behind a crumbled wall lies a secret stash."),
+            _("You notice a small cache tucked away."),
+        ]
+        output_func(random.choice(intros))
         gold = random.randint(15, 30)
         game.player.gold += gold
         output_func(_(f"You discover a hidden cache containing {gold} gold."))

--- a/dungeoncrawler/flavor.py
+++ b/dungeoncrawler/flavor.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import random
+from gettext import gettext as _
+from typing import Dict, List
+
+# Word pools used to generate flavor text for special room types.
+# Having the data in a dedicated module makes it easy to localize
+# or expand in the future without touching game logic.
+ROOM_FLAVOR_POOLS: Dict[str, Dict[str, List[str]]] = {
+    "Glittering Vault": {
+        "adjectives": ["glittering", "shimmering", "dusty"],
+        "nouns": ["vault", "chamber", "cache"],
+        "verbs": [
+            "beckons with ancient riches",
+            "gleams with forgotten coins",
+            "radiates a faint glow",
+        ],
+    },
+    "Booby-Trapped Passage": {
+        "adjectives": ["narrow", "foreboding", "cramped"],
+        "nouns": ["passage", "corridor", "hallway"],
+        "verbs": [
+            "is littered with suspicious mechanisms",
+            "hides pressure plates",
+            "promises peril at every step",
+        ],
+    },
+    "Cursed Hall": {
+        "adjectives": ["shadowy", "gloomy", "whispering"],
+        "nouns": ["hall", "chamber", "gallery"],
+        "verbs": [
+            "seems alive with malevolent intent",
+            "echoes with unseen whispers",
+            "makes your skin crawl",
+        ],
+    },
+    "Sealed Gate": {
+        "adjectives": ["massive", "ancient", "rune-covered"],
+        "nouns": ["gate", "door", "portal"],
+        "verbs": [
+            "bars your path",
+            "hums with dormant power",
+            "looms immovably",
+        ],
+    },
+    "Hidden Niche": {
+        "adjectives": ["small", "dusty", "concealed"],
+        "nouns": ["niche", "alcove", "hollow"],
+        "verbs": [
+            "hides something of value",
+            "holds a faint glimmer",
+            "beckons the curious",
+        ],
+    },
+    "Silent Chamber": {
+        "adjectives": ["silent", "dusty", "forgotten"],
+        "nouns": ["chamber", "room", "space"],
+        "verbs": [
+            "lies untouched by time",
+            "echoes with your footsteps",
+            "breathes an eerie calm",
+        ],
+    },
+    "Sacred Sanctuary": {
+        "adjectives": ["serene", "peaceful", "hallowed"],
+        "nouns": ["sanctuary", "shrine", "haven"],
+        "verbs": [
+            "radiates soothing warmth",
+            "fills you with calm",
+            "offers respite",
+        ],
+    },
+}
+
+
+def generate_room_flavor(room_type: str) -> str:
+    """Return a short, randomized description for ``room_type``."""
+    pools = ROOM_FLAVOR_POOLS.get(room_type)
+    if not pools:
+        return ""
+    adjective = random.choice(pools["adjectives"])
+    noun = random.choice(pools["nouns"])
+    verb = random.choice(pools["verbs"])
+    return _(f"The {adjective} {noun} {verb}.")

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import random
 from collections import deque
 from gettext import gettext as _
+
+from .flavor import generate_room_flavor
 from typing import TYPE_CHECKING
 
 from .ai import IntentAI
@@ -216,17 +218,9 @@ def handle_room(game: "DungeonBase", x: int, y: int) -> None:
 
     room = game.rooms[y][x]
     name = game.room_names[y][x]
-    lore = {
-        "Glittering Vault": "The air shimmers with unseen magic. Ancient riches may lie within.",
-        "Booby-Trapped Passage": "This corridor is riddled with pressure plates and crumbled bones.",
-        "Cursed Hall": "The shadows shift... something watches from the dark.",
-        "Sealed Gate": "Massive stone doors sealed by arcane runes. It might be the only way out.",
-        "Hidden Niche": "A hollow carved into the wall, forgotten by time. Something valuable glints inside.",
-        "Silent Chamber": "Dust covers everything. It appears long abandoned.",
-        "Sacred Sanctuary": "A peaceful place that heals weary adventurers.",
-    }
-    if name in lore:
-        game.queue_message(_(f"{lore[name]}"))
+    flavor = generate_room_flavor(name)
+    if flavor:
+        game.queue_message(flavor)
 
     if isinstance(room, list):
         for obj in list(room):

--- a/dungeoncrawler/quests.py
+++ b/dungeoncrawler/quests.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import random
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Tuple
 
 from .entities import Enemy
 from .items import Item

--- a/tests/test_god_mode.py
+++ b/tests/test_god_mode.py
@@ -1,5 +1,3 @@
-import pytest
-
 from dungeoncrawler.config import config
 
 


### PR DESCRIPTION
## Summary
- add flavor module to generate randomized room descriptions
- vary intro lines for trap, fountain, and cache events
- streamline room naming and cleanup unused imports

## Testing
- `flake8`
- `pytest -q` *(timeout, manually interrupted after ~38m with 23 tests passing)*

------
https://chatgpt.com/codex/tasks/task_e_689bfccdce288326a854ac578580b8e9