### PR TITLE
Fix lore notes without player and reset floor configs

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import random
@@ -267,7 +268,7 @@ class DungeonBase:
         # Load a fresh copy of the floor configuration for each game instance
         # so tests that mutate the underlying JSON can observe the changes
         # without leaking state between runs.
-        self.floor_configs = load_floor_configs()
+        self.floor_configs = copy.deepcopy(load_floor_configs())
         for cfg in self.floor_configs.values():
             cfg.setdefault("events", self.random_events)
             for ev, weight in zip(self.random_events, self.random_event_weights):

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -185,11 +185,13 @@ class LoreNoteEvent(BaseEvent):
         ]
         note = random.choice(notes)
         output_func(note["text"])
-        if note["text"] not in game.player.codex:
-            game.player.codex.append(note["text"])
-        if "effect" in note:
+
+        player = game.player
+        if player and note["text"] not in player.codex:
+            player.codex.append(note["text"])
+        if player and "effect" in note:
             effect, duration = note["effect"]
-            add_status_effect(game.player, effect, duration)
+            add_status_effect(player, effect, duration)
 
 
 class ShrineEvent(BaseEvent):

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -15,7 +15,6 @@ from .events import BaseEvent, CacheEvent, FountainEvent
 from .flavor import generate_room_flavor
 from .items import Item
 from .quests import EscortNPC
-from .rendering import render_map_string
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from .dungeon import DungeonBase


### PR DESCRIPTION
## Summary
- Avoid AttributeError in `LoreNoteEvent` when no player exists
- Deep copy floor configs each game to prevent stale event data
- Clean up unused import in map module

## Testing
- `pytest`
- `flake8`
- `black --check .`
- `isort --check-only .`

------
https://chatgpt.com/codex/tasks/task_e_689c1308799083268c1e70e0496b3c83