### PR TITLE
Prepare project for initial release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "dungeoncrawler"
-version = "0.9.0b1"
+version = "0.0.0"
 description = "Dungeon Crawler game"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [{ name = "Dungeon Crawler Team" }]
 dependencies = []
 


### PR DESCRIPTION
## Summary
- set project version to 0.0.0 and require Python 3.10+
- ensure CLI entry point uses main()

## Testing
- `pytest` *(fails: AttributeError: module 'dungeoncrawler.map' has no attribute 'render_map_string')*


------
https://chatgpt.com/codex/tasks/task_e_689c1be017008326bbbc6cc3135bd2a7