### PR TITLE
Re-export map rendering helpers

### DIFF
--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -15,6 +15,7 @@ from .events import BaseEvent, CacheEvent, FountainEvent
 from .flavor import generate_room_flavor
 from .items import Item
 from .quests import EscortNPC
+from .rendering import render_map_string, render_map  # re-exported for compatibility
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from .dungeon import DungeonBase


### PR DESCRIPTION
## Summary
- expose `render_map_string` (and `render_map`) from `dungeoncrawler.map`
- resolve AttributeError when tests expect `render_map_string` on map module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c1f581ea8832686a4e12e79d95971