### PR TITLE
feat: telegraph enemy intent each round

### DIFF
--- a/dungeoncrawler/ai.py
+++ b/dungeoncrawler/ai.py
@@ -37,7 +37,7 @@ class IntentAI:
 
     TELEGRAPHS = {
         "Goblin": {
-            "aggressive": "Goblin steadies a heavy strike…",
+            "aggressive": "Goblin winds up a heavy strike…",
             "defensive": "Goblin raises its guard.",
             "unpredictable": "The Goblin grins wildly, unpredictable…",
         },

--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -29,6 +29,13 @@ def enemy_turn(enemy: "Enemy", player: "Player") -> None:
         skip = enemy.apply_status_effects()
         if enemy.is_alive() and not skip:
             enemy.take_turn(player)
+        if enemy.ai and hasattr(enemy.ai, "choose_intent"):
+            enemy.next_action, enemy.intent_message = enemy.ai.choose_intent(enemy, player)
+        else:
+            enemy.next_action = None
+            enemy.intent_message = ""
+        if enemy.heavy_cd > 0:
+            enemy.heavy_cd -= 1
 
 
 def battle(game: "DungeonBase", enemy: "Enemy") -> None:

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -613,13 +613,6 @@ class Enemy(Entity):
             self.attack(player)
         else:
             self.attack(player)
-        if self.ai and hasattr(self.ai, "choose_intent"):
-            self.next_action, self.intent_message = self.ai.choose_intent(self, player)
-        else:
-            self.next_action = None
-            self.intent_message = ""
-        if self.heavy_cd > 0:
-            self.heavy_cd -= 1
 
     def attack(self, player):
         hit_chance = 60


### PR DESCRIPTION
## Summary
- plan enemy actions ahead each round and store a telegraphed intent message
- display enemy intent before the player's menu
- add sample telegraphs for Goblin and Beetle enemies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c21e511208326a790bffd08455fde