### PR TITLE
Weight early-floor events by config and spawn near start

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Available configuration options:
 | `max_floors` | int | `18` | Number of dungeon floors to generate. |
 | `screen_width` | int | `10` | Width of each dungeon floor in rooms. |
 | `screen_height` | int | `10` | Height of each dungeon floor in rooms. |
-| `trap_chance` | float | `0.1` | Probability that a room contains a trap. |
-| `loot_multiplier` | float | `1.0` | Multiplies the amount of loot found. |
+| `trap_chance` | float | `0.1` | Probability that a room contains a trap; higher values favor healing fountains on early floors. |
+| `loot_multiplier` | float | `1.0` | Multiplies the amount of loot found; higher values favor treasure caches on early floors. |
 | `verbose_combat` | bool | `false` | Log additional combat details. |
 | `enable_debug` | bool | `false` | Toggle extra debug output. |
 

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -14,6 +14,7 @@ from .entities import Companion, Enemy
 from .events import BaseEvent, CacheEvent, FountainEvent
 from .flavor import generate_room_flavor
 from .items import Item
+from .config import config
 from .quests import EscortNPC
 from .rendering import render_map, render_map_string  # re-exported for compatibility
 
@@ -183,8 +184,14 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
     companion_options = load_companions()
     place(random.choice(companion_options))
     if floor <= 3:
-        place(FountainEvent())
-        place(CacheEvent())
+        total = config.trap_chance + config.loot_multiplier
+        fountain_prob = config.trap_chance / total if total else 0.5
+        event_cls = FountainEvent if random.random() < fountain_prob else CacheEvent
+        event = event_cls()
+        if floor == 1:
+            place_near_start(event, 10)
+        else:
+            place(event)
     place_counts = game.default_place_counts.copy()
     place_counts.update(cfg.get("places", {}))
     for pname, count in place_counts.items():

--- a/tests/test_dungeon_generation.py
+++ b/tests/test_dungeon_generation.py
@@ -30,9 +30,16 @@ def test_generate_dungeon_size_and_population():
     # Stairs should be close to the start on the first floor
     assert abs(px - ex) + abs(py - ey) <= 4
 
-    # Early floors should always include helpful events
-    assert any(isinstance(obj, FountainEvent) for row in dungeon.rooms for obj in row)
-    assert any(isinstance(obj, CacheEvent) for row in dungeon.rooms for obj in row)
+    # Early floors should always include a helpful event near the start
+    events = [
+        (obj, x, y)
+        for y, row in enumerate(dungeon.rooms)
+        for x, obj in enumerate(row)
+        if isinstance(obj, (FountainEvent, CacheEvent))
+    ]
+    assert events
+    ev_obj, ev_x, ev_y = events[0]
+    assert abs(px - ev_x) + abs(py - ev_y) <= 10
 
     enemy_count = sum(isinstance(obj, Enemy) for row in dungeon.rooms for obj in row)
     assert 3 <= enemy_count <= 5


### PR DESCRIPTION
## Summary
- Spawn either a Fountain or Cache event on floors 1–3 based on trap chance and loot multiplier, ensuring floor-1 event is near the start
- Document how `trap_chance` and `loot_multiplier` influence early-floor events
- Test that a helpful event appears within 10 steps of spawn

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c239eaa2483269ab048039a2b89c3