### PR TITLE
Expose map rendering functions to fix flake8 F401

### DIFF
--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -18,6 +18,14 @@ from .items import Item
 from .quests import EscortNPC
 from .rendering import render_map, render_map_string  # re-exported for compatibility
 
+__all__ = [
+    "compute_visibility",
+    "update_visibility",
+    "generate_dungeon",
+    "render_map",
+    "render_map_string",
+]
+
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from .dungeon import DungeonBase
 


### PR DESCRIPTION
## Summary
- Declare `render_map` and `render_map_string` in `dungeoncrawler.map`'s `__all__` to mark them as re-exported

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c29646c2c8326a92a4f048602c1b8