### PR TITLE
docs: fix clone URL and add coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # Dungeon Crawler
 
 [![CI](https://github.com/ttc24/Dungeon-Crawler/actions/workflows/ci.yml/badge.svg)](https://github.com/ttc24/Dungeon-Crawler/actions/workflows/ci.yml)
+[![Coverage](coverage.svg)](https://github.com/ttc24/Dungeon-Crawler/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://ttc24.github.io/Dungeon-Crawler/)
 
 Dungeon Crawler is a small text-based adventure that borrows the core ideas of the *Dungeon Crawler Carl* where you guide your hero through procedurally generated floors filled with monsters, treasure, and meaningful character choices.
+
+Full documentation is available at [ttc24.github.io/Dungeon-Crawler](https://ttc24.github.io/Dungeon-Crawler/).
 
 ## Quickstart
 
 Clone the repository and start the game with Python 3:
 
 ```bash
-git clone https://github.com/ttc24/Dungeon-Crawler.git
-cd Dungeon-Crawler
+git clone https://github.com/ttc24/dungeoncrawler.git
+cd dungeoncrawler
 python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 python -m dungeoncrawler

--- a/coverage.svg
+++ b/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">76%</text>
+        <text x="80" y="14">76%</text>
+    </g>
+</svg>

--- a/dungeoncrawler/__main__.py
+++ b/dungeoncrawler/__main__.py
@@ -1,3 +1,5 @@
+"""Allow ``python -m dungeoncrawler`` to launch the game."""
+
 from .main import main
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix Quickstart clone URL and link to hosted docs
- add coverage badge and docs badge to README
- document `python -m dungeoncrawler` entry point

## Testing
- `flake8 .`
- `coverage run -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c2a1e400c8326af8b6bc6ec117b82