### PR TITLE
docs: correct repo path in quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Full documentation is available at [ttc24.github.io/Dungeon-Crawler](https://ttc
 Clone the repository and start the game with Python 3:
 
 ```bash
-git clone https://github.com/ttc24/dungeoncrawler.git
-cd dungeoncrawler
+git clone https://github.com/ttc24/Dungeon-Crawler.git
+cd Dungeon-Crawler
 python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 python -m dungeoncrawler


### PR DESCRIPTION
## Summary
- fix Quickstart instructions to use the proper repository URL and directory name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c2ecc31a88326a0a12ccd21dd6ec7