### PR TITLE
docs: add local documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Dungeon Crawler is a small text-based adventure that borrows the core ideas of the *Dungeon Crawler Carl* where you guide your hero through procedurally generated floors filled with monsters, treasure, and meaningful character choices.
 
-Full documentation is available at [ttc24.github.io/Dungeon-Crawler](https://ttc24.github.io/Dungeon-Crawler/).
+Full documentation is available in [docs/README.md](docs/README.md).
 
 ## Quickstart
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Documentation
+
+This directory contains the project's documentation built with Sphinx.
+
+- The main entry point is [index.rst](index.rst).
+- See [installation.rst](installation.rst) to get started.
+- For an overview of gameplay, read [gameplay_guide.rst](gameplay_guide.rst).
+


### PR DESCRIPTION
## Summary
- point README to docs/README.md instead of external site
- add docs/README.md with overview and links to key docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c2f9018888326bc6ac3f5bbb17a2f