### PR TITLE
Add coverage badge generation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev] coverage
+          pip install .[dev] coverage coverage-badge
       - name: Run flake8
         run: flake8 .
       - name: Run tests
         run: |
           coverage run -m pytest
           coverage report
+      - name: Generate coverage badge
+        run: coverage-badge -f -o coverage.svg

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dungeon Crawler
 
 [![CI](https://github.com/ttc24/Dungeon-Crawler/actions/workflows/ci.yml/badge.svg)](https://github.com/ttc24/Dungeon-Crawler/actions/workflows/ci.yml)
-[![Coverage](coverage.svg)](https://github.com/ttc24/Dungeon-Crawler/actions/workflows/ci.yml)
+![Coverage](coverage.svg)
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://ttc24.github.io/Dungeon-Crawler/)
 
 Dungeon Crawler is a small text-based adventure that borrows the core ideas of the *Dungeon Crawler Carl* where you guide your hero through procedurally generated floors filled with monsters, treasure, and meaningful character choices.


### PR DESCRIPTION
## Summary
- install coverage-badge and generate coverage.svg in CI
- show CI and coverage badges in README

## Testing
- `flake8 .`
- `coverage run -m pytest`
- `coverage report`


------
https://chatgpt.com/codex/tasks/task_e_689c31562c888326b695807495333b05