### PR TITLE
Refactor map/visibility logic into core modules

### DIFF
--- a/dungeoncrawler/core/__init__.py
+++ b/dungeoncrawler/core/__init__.py
@@ -1,0 +1,6 @@
+"""Core infrastructure components for dungeon crawler."""
+
+from .map import GameMap
+from .state import GameState
+
+__all__ = ["GameMap", "GameState"]

--- a/dungeoncrawler/core/state.py
+++ b/dungeoncrawler/core/state.py
@@ -1,0 +1,40 @@
+"""Game state container for dungeon crawler."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, TYPE_CHECKING
+
+from .map import GameMap
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from ..entities import Player
+
+
+@dataclass
+class GameState:
+    """Lightweight container storing the current game state.
+
+    Attributes
+    ----------
+    seed:
+        RNG seed used for deterministic behaviour.
+    current_floor:
+        The active dungeon floor number.
+    player:
+        The player entity exploring the dungeon.
+    game_map:
+        Map data including grid layout and visibility arrays.
+    log:
+        In-memory buffer of game messages.
+    """
+
+    seed: int
+    current_floor: int
+    player: Optional["Player"]
+    game_map: GameMap
+    log: List[str] = field(default_factory=list)
+
+    def queue_message(self, message: str) -> None:
+        """Append ``message`` to the log buffer."""
+        self.log.append(message)

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import random
-from collections import deque
 from gettext import gettext as _
 from typing import TYPE_CHECKING
 
 from .ai import IntentAI
 from .combat import battle
 from .config import config
+from .core.map import compute_visibility, update_visibility
 from .data import load_companions
 from .entities import Companion, Enemy
 from .events import BaseEvent, CacheEvent, FountainEvent
@@ -28,37 +28,6 @@ __all__ = [
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from .dungeon import DungeonBase
-
-
-def compute_visibility(grid, px, py, radius):
-    """Return set of visible tiles using BFS from ``(px, py)``."""
-
-    height = len(grid)
-    width = len(grid[0]) if height else 0
-    visited = set()
-    queue = deque([(px, py, 0)])
-    while queue:
-        x, y, dist = queue.popleft()
-        if (x, y) in visited:
-            continue
-        visited.add((x, y))
-        if dist >= radius:
-            continue
-        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
-            nx, ny = x + dx, y + dy
-            if 0 <= nx < width and 0 <= ny < height and grid[ny][nx] is not None:
-                queue.append((nx, ny, dist + 1))
-    return visited
-
-
-def update_visibility(game: "DungeonBase") -> None:
-    """Recompute visible and discovered tiles for ``game``."""
-
-    game.visible = [[False for __ in range(game.width)] for __ in range(game.height)]
-    radius = 6 if game.current_floor == 1 else 3 + game.current_floor // 2
-    for x, y in compute_visibility(game.rooms, game.player.x, game.player.y, radius):
-        game.visible[y][x] = True
-        game.discovered[y][x] = True
 
 
 def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:


### PR DESCRIPTION
## Summary
- Add lightweight `GameState` container for seed, floor, player, map, and log
- Introduce `GameMap` with visibility arrays and BFS-based fog-of-war helpers
- Delegate visibility helpers in `dungeoncrawler.map` to the new core module

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c330979bc83268561b20d61138e84