### PR TITLE
feat: introduce core event dataclasses

### DIFF
--- a/dungeoncrawler/core/combat.py
+++ b/dungeoncrawler/core/combat.py
@@ -1,39 +1,30 @@
 """Deterministic combat resolution helpers.
 
 The functions defined here operate on :class:`~dungeoncrawler.core.entity.Entity`
-instances and return lightweight event objects describing the outcome of an
-action.  No printing or random number generation occurs which makes the module
-suitable for unit testing and simulations.
+instances and return typed event objects describing the outcome of an action.
+No printing or random number generation occurs which makes the module suitable
+for unit testing and simulations.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import List
 
 from .entity import Entity
-
-
-@dataclass
-class CombatEvent:
-    """Container describing the result of a combat action."""
-
-    type: str
-    message: str
-    data: Dict[str, int] = field(default_factory=dict)
+from .events import AttackResolved, Event, StatusApplied
 
 
 # ---------------------------------------------------------------------------
 # Core resolvers
 # ---------------------------------------------------------------------------
 
-def resolve_attack(attacker: Entity, defender: Entity) -> CombatEvent:
+def resolve_attack(attacker: Entity, defender: Entity) -> AttackResolved:
     """Resolve a basic attack from ``attacker`` to ``defender``.
 
     Damage is computed deterministically from the ``attack`` and ``defense``
     stats. The defender's ``health`` stat is reduced in-place.  The returned
-    :class:`CombatEvent` contains the amount of damage dealt and whether the
-    defender was defeated.
+    :class:`AttackResolved` event contains the amount of damage dealt and whether
+    the defender was defeated.
     """
 
     attack = attacker.stats.get("attack", 0)
@@ -44,10 +35,10 @@ def resolve_attack(attacker: Entity, defender: Entity) -> CombatEvent:
     msg = f"{attacker.name} hits {defender.name} for {damage} damage."
     if defeated:
         msg += f" {defender.name} is defeated."
-    return CombatEvent("attack", msg, {"damage": damage, "defeated": defeated})
+    return AttackResolved(msg, attacker.name, defender.name, damage, defeated)
 
 
-def resolve_player_action(player: Entity, enemy: Entity, action: str) -> List[CombatEvent]:
+def resolve_player_action(player: Entity, enemy: Entity, action: str) -> List[Event]:
     """Resolve a player's ``action`` against ``enemy``.
 
     Parameters
@@ -61,12 +52,12 @@ def resolve_player_action(player: Entity, enemy: Entity, action: str) -> List[Co
         ``"use_health_potion"`` and ``"flee"``.
     """
 
-    events: List[CombatEvent] = []
+    events: List[Event] = []
     if action == "attack":
         events.append(resolve_attack(player, enemy))
     elif action == "defend":
         player.status.append("defending")
-        events.append(CombatEvent("defend", f"{player.name} defends.", {}))
+        events.append(StatusApplied(f"{player.name} defends.", player.name, "defending", 1))
     elif action == "use_health_potion":
         if "potion" in player.inventory:
             player.inventory.remove("potion")
@@ -75,30 +66,36 @@ def resolve_player_action(player: Entity, enemy: Entity, action: str) -> List[Co
             new_hp = min(max_hp, player.stats.get("health", 0) + heal)
             player.stats["health"] = new_hp
             events.append(
-                CombatEvent(
-                    "heal", f"{player.name} uses a health potion and heals {heal} health.", {"heal": heal}
+                StatusApplied(
+                    f"{player.name} uses a health potion and heals {heal} health.",
+                    player.name,
+                    "healed",
+                    0,
+                    value=heal,
                 )
             )
         else:
-            events.append(CombatEvent("heal_failed", f"{player.name} has no potion.", {}))
+            events.append(
+                StatusApplied(f"{player.name} has no potion.", player.name, "heal_failed", 0)
+            )
     elif action == "flee":
         success = int(player.stats.get("speed", 0) > enemy.stats.get("speed", 0))
         if success:
             msg = f"{player.name} flees from {enemy.name}."
         else:
             msg = f"{player.name} fails to flee from {enemy.name}."
-        events.append(CombatEvent("flee", msg, {"success": success}))
+        events.append(StatusApplied(msg, player.name, "flee", 0, value=success))
     else:
-        events.append(CombatEvent("unknown", "Unknown action.", {}))
+        events.append(StatusApplied("Unknown action.", player.name, "unknown", 0))
     return events
 
 
-def resolve_enemy_turn(enemy: Entity, player: Entity) -> List[CombatEvent]:
+def resolve_enemy_turn(enemy: Entity, player: Entity) -> List[Event]:
     """Resolve the enemy's turn against ``player``.
 
     Currently this simply performs a basic attack if the enemy is alive.
     """
 
     if not enemy.is_alive():
-        return [CombatEvent("noop", f"{enemy.name} is defeated and cannot act.", {})]
+        return [StatusApplied(f"{enemy.name} is defeated and cannot act.", enemy.name, "defeated", 0)]
     return [resolve_attack(enemy, player)]

--- a/dungeoncrawler/core/events.py
+++ b/dungeoncrawler/core/events.py
@@ -1,0 +1,49 @@
+"""Typed event objects produced by core game mechanics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Event:
+    """Base class for all core events."""
+
+    message: str
+
+
+@dataclass
+class AttackResolved(Event):
+    """Result of a combat attack action."""
+
+    attacker: str
+    defender: str
+    damage: int
+    defeated: bool
+
+
+@dataclass
+class StatusApplied(Event):
+    """A temporary status was applied to an entity."""
+
+    target: str
+    status: str
+    duration: int
+    value: int = 0
+
+
+@dataclass
+class TileDiscovered(Event):
+    """A new map tile has been revealed to the player."""
+
+    x: int
+    y: int
+
+
+@dataclass
+class ItemGained(Event):
+    """An item was added to an entity's inventory."""
+
+    owner: str
+    item: str
+    amount: int = 1

--- a/tests/test_core_events.py
+++ b/tests/test_core_events.py
@@ -1,0 +1,54 @@
+import pytest
+
+from dungeoncrawler.core.combat import (
+    resolve_attack,
+    resolve_enemy_turn,
+    resolve_player_action,
+)
+from dungeoncrawler.core.entity import Entity
+from dungeoncrawler.core.events import AttackResolved, StatusApplied, TileDiscovered
+from dungeoncrawler.core.map import GameMap
+
+
+def test_attack_returns_event():
+    attacker = Entity("A", {"health": 10, "attack": 5})
+    defender = Entity("D", {"health": 8, "defense": 1})
+    event = resolve_attack(attacker, defender)
+    assert isinstance(event, AttackResolved)
+    assert event.damage == 4
+    assert event.defeated == 0
+
+
+def test_player_action_defend_event():
+    player = Entity("Hero", {"health": 10})
+    enemy = Entity("Gob", {"health": 5})
+    events = resolve_player_action(player, enemy, "defend")
+    assert isinstance(events[0], StatusApplied)
+    assert events[0].status == "defending"
+
+
+def test_use_potion_event():
+    player = Entity("Hero", {"health": 5, "potion_heal": 5, "max_health": 10})
+    player.inventory = ["potion"]
+    enemy = Entity("Gob", {"health": 5})
+    events = resolve_player_action(player, enemy, "use_health_potion")
+    assert isinstance(events[0], StatusApplied)
+    assert events[0].status == "healed"
+    assert events[0].value == 5
+
+
+def test_enemy_turn_returns_attack_event():
+    player = Entity("Hero", {"health": 10})
+    enemy = Entity("Gob", {"health": 5, "attack": 3})
+    events = resolve_enemy_turn(enemy, player)
+    assert isinstance(events[0], AttackResolved)
+
+
+def test_update_visibility_yields_events():
+    grid = [[1, 1], [1, 1]]
+    gm = GameMap(grid)
+    events = gm.update_visibility(0, 0, 1)
+    coords = {(e.x, e.y) for e in events}
+    assert coords == {(0, 0), (1, 0), (0, 1)}
+    # calling again should yield no new events
+    assert gm.update_visibility(0, 0, 1) == []


### PR DESCRIPTION
## Summary
- add typed event dataclasses for combat, status, tile discovery, and inventory changes
- emit event objects from combat and map helpers for UI consumption
- cover new events with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cb2d7a5048326a2f960f3e44948d1