### PR TITLE
Add versioned JSON save/load helpers

### DIFF
--- a/dungeoncrawler/core/__init__.py
+++ b/dungeoncrawler/core/__init__.py
@@ -2,5 +2,6 @@
 
 from .map import GameMap
 from .state import GameState
+from .save import load_game, save_game
 
-__all__ = ["GameMap", "GameState"]
+__all__ = ["GameMap", "GameState", "save_game", "load_game"]

--- a/dungeoncrawler/core/save.py
+++ b/dungeoncrawler/core/save.py
@@ -1,0 +1,51 @@
+"""Helpers for persisting and restoring game state."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+SCHEMA_VERSION = 1
+SAVE_FILE = Path.home() / ".dungeon_crawler" / "saves" / "savegame.json"
+
+
+def save_game(state: Any) -> None:
+    """Persist ``state`` to :data:`SAVE_FILE` using JSON.
+
+    The object is serialised using :func:`dataclasses.asdict` when applicable and
+    wrapped together with a schema version number allowing future migrations.
+    """
+
+    SAVE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if is_dataclass(state):
+        payload: Dict[str, Any] = asdict(state)
+    else:
+        payload = state  # type: ignore[assignment]
+
+    data = {"version": SCHEMA_VERSION, "state": payload}
+    with SAVE_FILE.open("w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def load_game() -> Optional[Dict[str, Any]]:
+    """Return previously saved state if the schema version matches.
+
+    ``None`` is returned when the file does not exist, is unreadable or the
+    schema version is missing or outdated.
+    """
+
+    try:
+        with SAVE_FILE.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if data.get("version") != SCHEMA_VERSION:
+        return None
+
+    state = data.get("state")
+    if not isinstance(state, dict):
+        return None
+    return state


### PR DESCRIPTION
## Summary
- expose save_game and load_game from dungeoncrawler.core
- implement versioned JSON game state persistence under ~/.dungeon_crawler/saves

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cb46143ac83268bddd191dc89f4d2