### PR TITLE
Integrate JSON config loader into entry points

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -4,6 +4,7 @@
   "max_floors": 18,
   "screen_width": 10,
   "screen_height": 10,
+  "verbose_combat": false,
   "trap_chance": 0.1,
   "loot_multiplier": 1.0,
   "enable_debug": false

--- a/dungeon_crawler.py
+++ b/dungeon_crawler.py
@@ -1,4 +1,14 @@
+"""Convenience script for launching the Dungeon Crawler game.
+
+The script simply loads configuration and delegates to
+``dungeoncrawler.main.main``.  Keeping this thin wrapper allows the
+package entry point and the standalone script to share the same start-up
+logic while still supporting ``python dungeon_crawler.py``.
+"""
+
+from dungeoncrawler.config import load_config
 from dungeoncrawler.main import main
 
 if __name__ == "__main__":
-    main()
+    cfg = load_config()
+    main(cfg=cfg)

--- a/dungeoncrawler/__main__.py
+++ b/dungeoncrawler/__main__.py
@@ -1,6 +1,13 @@
-"""Allow ``python -m dungeoncrawler`` to launch the game."""
+"""Allow ``python -m dungeoncrawler`` to launch the game.
 
+This module mirrors the behaviour of the standalone ``dungeon_crawler.py``
+script by loading configuration before delegating to :func:`main`.
+"""
+
+from .config import load_config
 from .main import main
 
+
 if __name__ == "__main__":
-    main()
+    cfg = load_config()
+    main(cfg=cfg)

--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -12,7 +12,10 @@ CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.json"
 class Config:
     """Game configuration loaded from ``config.json``.
 
-    Defaults mirror the previous hard-coded constants so the game remains
+    Besides basic layout settings such as ``screen_width`` and
+    ``screen_height`` the configuration also exposes gameplay toggles like
+    ``trap_chance``, ``loot_multiplier`` and ``verbose_combat``.  Default
+    values mirror the previous hard-coded constants so the game remains
     playable even if no configuration file is provided.
     """
 
@@ -47,8 +50,8 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
     ------
     ValueError
         If a configuration value has an invalid type or falls outside the
-        accepted range. For example ``screen_width`` and ``screen_height`` must
-        be positive integers.
+        accepted range. For example ``screen_width`` and ``max_floors`` must be
+        positive integers.
     """
 
     cfg = Config()

--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -10,7 +10,7 @@ import argparse
 from gettext import gettext as _
 
 from . import tutorial
-from .config import load_config
+from .config import Config, load_config
 from .dungeon import DungeonBase
 from .entities import Player
 from .i18n import set_language
@@ -35,8 +35,19 @@ def build_character(input_func=input, output_func=print):
     return player
 
 
-def main(argv=None, input_func=input, output_func=print):
-    """Run the game with optional command line arguments."""
+def main(argv=None, input_func=input, output_func=print, cfg: Config | None = None):
+    """Run the game with optional command line arguments.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of arguments to parse instead of ``sys.argv``.
+    input_func, output_func:
+        Hooks used primarily for testing to simulate user interaction.
+    cfg:
+        Pre-loaded configuration.  When ``None`` the configuration is loaded
+        from ``config.json`` automatically.
+    """
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -49,7 +60,7 @@ def main(argv=None, input_func=input, output_func=print):
 
     set_language(args.lang)
 
-    cfg = load_config()
+    cfg = cfg or load_config()
     game = DungeonBase(cfg.screen_width, cfg.screen_height)
     cont = input_func(_("Load existing save? (y/n): ")).strip().lower()
     if cont == "y":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,7 @@ def test_new_keys_default(tmp_path):
     cfg = load_config(cfg_file)
     assert cfg.trap_chance == 0.1
     assert cfg.loot_multiplier == 1.0
+    assert cfg.verbose_combat is False
     assert cfg.enable_debug is False
 
 


### PR DESCRIPTION
## Summary
- document and expose configurable gameplay toggles (trap chance, loot multiplier, verbose combat)
- feed loaded configuration into game entry points
- include verbose_combat option in sample config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cfc2ee9e08326b28ea09c045b03b8