### PR TITLE
chore: remove unused imports in tests

### DIFF
--- a/tests/test_core_events.py
+++ b/tests/test_core_events.py
@@ -1,12 +1,10 @@
-import pytest
-
 from dungeoncrawler.core.combat import (
     resolve_attack,
     resolve_enemy_turn,
     resolve_player_action,
 )
 from dungeoncrawler.core.entity import Entity
-from dungeoncrawler.core.events import AttackResolved, StatusApplied, TileDiscovered
+from dungeoncrawler.core.events import AttackResolved, StatusApplied
 from dungeoncrawler.core.map import GameMap
 
 


### PR DESCRIPTION
## Summary
- remove unused imports from tests/test_core_events.py to satisfy flake8

## Testing
- `flake8 .`
- `pytest tests/test_core_events.py`


------
https://chatgpt.com/codex/tasks/task_e_689cfebdfd748326abc36e09b04d1e0d