### PR TITLE
Add terminal renderer and input mapping

### DIFF
--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -10,13 +10,14 @@ from .constants import INVALID_KEY_MSG
 from .core.combat import resolve_enemy_turn, resolve_player_action
 from .core.entity import Entity as CoreEntity
 from .status_effects import format_status_tags
+from .ui.terminal import Renderer
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .dungeon import DungeonBase
     from .entities import Enemy, Player
 
 
-def enemy_turn(enemy: "Enemy", player: "Player") -> None:
+def enemy_turn(enemy: "Enemy", player: "Player", renderer: Renderer | None = None) -> None:
     """Handle the enemy's turn by applying status effects and attacking.
 
     Parameters
@@ -27,6 +28,7 @@ def enemy_turn(enemy: "Enemy", player: "Player") -> None:
         The player being targeted.
     """
 
+    renderer = renderer or Renderer()
     if enemy.is_alive():
         skip = enemy.apply_status_effects()
         if enemy.is_alive() and not skip:
@@ -46,7 +48,7 @@ def enemy_turn(enemy: "Enemy", player: "Player") -> None:
             enemy.health = enemy_entity.stats["health"]
             player.health = player_entity.stats["health"]
             for event in events:
-                print(_(event.message))
+                renderer.handle_event(event)
         if enemy.ai and hasattr(enemy.ai, "choose_intent"):
             enemy.next_action, enemy.intent_message = enemy.ai.choose_intent(enemy, player)
         else:
@@ -56,7 +58,7 @@ def enemy_turn(enemy: "Enemy", player: "Player") -> None:
             enemy.heavy_cd -= 1
 
 
-def battle(game: "DungeonBase", enemy: "Enemy") -> None:
+def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
     """Run a battle between the player and ``enemy``.
 
     Parameters
@@ -67,9 +69,12 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
         The enemy the player is fighting.
     """
 
+    if input_func is None:
+        input_func = input
     player = game.player
     game.stats_logger.battle_start()
-    print(
+    renderer = getattr(game, "renderer", Renderer())
+    renderer.show_message(
         _(
             f"You encountered a {enemy.name}! {enemy.ability.capitalize() if enemy.ability else ''} Boss incoming!"
         )
@@ -84,16 +89,20 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
         if not enemy.is_alive():
             break
         if skip_player:
-            enemy_turn(enemy, player)
+            enemy_turn(enemy, player, renderer)
             continue
 
-        print(_(f"Player Health: {player.health} {format_status_tags(player.status_effects)}"))
-        print(_(f"Enemy Health: {enemy.health} {format_status_tags(enemy.status_effects)}"))
+        renderer.show_message(
+            _(f"Player Health: {player.health} {format_status_tags(player.status_effects)}")
+        )
+        renderer.show_message(
+            _(f"Enemy Health: {enemy.health} {format_status_tags(enemy.status_effects)}")
+        )
         if enemy.intent_message:
-            print(_(enemy.intent_message))
-        print(_(f"Stamina: {player.stamina}/{player.max_stamina}"))
-        print(_("1. Attack\n2. Defend\n3. Use Health Potion\n4. Use Skill\n5. Flee"))
-        choice = input(_("Choose action: "))
+            renderer.show_message(_(enemy.intent_message))
+        renderer.show_message(_(f"Stamina: {player.stamina}/{player.max_stamina}"))
+        renderer.show_message(_("1. Attack\n2. Defend\n3. Use Health Potion\n4. Use Skill\n5. Flee"))
+        choice = input_func(_("Choose action: "))
         if choice == "1":
             p_entity = CoreEntity(
                 player.name,
@@ -117,9 +126,9 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
             player.health = p_entity.stats["health"]
             enemy.health = e_entity.stats["health"]
             for event in events:
-                print(_(event.message))
+                renderer.handle_event(event)
             game.announce(_("A fierce attack lands!"))
-            enemy_turn(enemy, player)
+            enemy_turn(enemy, player, renderer)
         elif choice == "2":
             p_entity = CoreEntity(
                 player.name,
@@ -143,15 +152,15 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
             player.health = p_entity.stats["health"]
             enemy.health = e_entity.stats["health"]
             for event in events:
-                print(_(event.message))
-            enemy_turn(enemy, player)
+                renderer.handle_event(event)
+            enemy_turn(enemy, player, renderer)
         elif choice == "3":
             player.use_health_potion()
-            enemy_turn(enemy, player)
+            enemy_turn(enemy, player, renderer)
         elif choice == "4":
             player.use_skill(enemy)
             game.announce(_("Special skill unleashed!"))
-            enemy_turn(enemy, player)
+            enemy_turn(enemy, player, renderer)
         elif choice == "5":
             p_entity = CoreEntity(
                 player.name,
@@ -173,13 +182,13 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
             )
             events = resolve_player_action(p_entity, e_entity, "flee")
             for event in events:
-                print(_(event.message))
+                renderer.handle_event(event)
             if events[-1].data.get("success"):
                 game.announce(f"{player.name} flees from {enemy.name}!")
                 break
-            enemy_turn(enemy, player)
+            enemy_turn(enemy, player, renderer)
         else:
-            print(_(INVALID_KEY_MSG))
+            renderer.show_message(_(INVALID_KEY_MSG))
         player.decrement_cooldowns()
 
     if not enemy.is_alive():
@@ -187,7 +196,7 @@ def battle(game: "DungeonBase", enemy: "Enemy") -> None:
         if enemy.name in game.boss_loot:
             loot = random.choice(game.boss_loot[enemy.name])
             player.collect_item(loot)
-            print(_(f"The {enemy.name} dropped {loot.name}!"))
+            renderer.show_message(_(f"The {enemy.name} dropped {loot.name}!"))
             game.announce(_(f"{player.name} obtains {loot.name}!"))
     game.stats_logger.battle_end(player.is_alive(), enemy.name)
     game.check_quest_progress()

--- a/dungeoncrawler/input/__init__.py
+++ b/dungeoncrawler/input/__init__.py
@@ -1,0 +1,6 @@
+"""Input handling utilities."""
+
+from .keys import Action, get_action
+
+__all__ = ["Action", "get_action"]
+

--- a/dungeoncrawler/input/keys.py
+++ b/dungeoncrawler/input/keys.py
@@ -1,0 +1,52 @@
+"""Map raw keystrokes to high level action enums."""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+
+
+class Action(Enum):
+    """Enumeration of high level player actions."""
+
+    MOVE_W = auto()
+    MOVE_E = auto()
+    MOVE_N = auto()
+    MOVE_S = auto()
+    DEFEND = auto()
+    USE_ITEM = auto()
+    SHOW_MAP = auto()
+    SHOW_STATUS = auto()
+    SHOW_HELP = auto()
+    QUIT = auto()
+    UNKNOWN = auto()
+
+
+# Default key bindings for a minimal terminal interface.  These bindings are
+# intentionally tiny – front ends are free to provide their own mapping layer if
+# required.
+KEY_BINDINGS = {
+    "1": Action.MOVE_W,
+    "2": Action.MOVE_E,
+    "3": Action.MOVE_N,
+    "4": Action.MOVE_S,
+    "5": Action.DEFEND,
+    "6": Action.USE_ITEM,
+    "7": Action.SHOW_MAP,
+    "8": Action.SHOW_STATUS,
+    "?": Action.SHOW_HELP,
+    "q": Action.QUIT,
+}
+
+
+def get_action(key: str) -> Action:
+    """Return the :class:`Action` associated with ``key``.
+
+    Unrecognised keys return :data:`Action.UNKNOWN` which allows callers to
+    handle invalid input consistently.
+    """
+
+    return KEY_BINDINGS.get(key, Action.UNKNOWN)
+
+
+__all__ = ["Action", "get_action", "KEY_BINDINGS"]
+

--- a/dungeoncrawler/rendering.py
+++ b/dungeoncrawler/rendering.py
@@ -1,53 +1,14 @@
-"""Rendering helpers and UI abstractions.
+"""Legacy rendering helpers.
 
-This module centralises all user interface interactions.  Game logic
-modules interact with :class:`Renderer` instead of printing directly so the
-core game remains easy to test.
+This module previously housed the :class:`Renderer` implementation used by the
+tests.  The class has now moved to :mod:`dungeoncrawler.ui.terminal` but is
+re-exported here for backwards compatibility.  The map rendering utilities
+remain in this module.
 """
 
 from __future__ import annotations
 
-from gettext import gettext as _
-
-
-class Renderer:
-    """Minimal text based renderer used by the test-suite.
-
-    Real front ends may subclass this and provide richer implementations but
-    the methods here are purposely tiny – they simply forward output to the
-    supplied ``output_func`` which defaults to :func:`print`.
-    """
-
-    def __init__(self, output_func=print):
-        self.output_func = output_func
-
-    # ------------------------------------------------------------------
-    # Basic message helpers
-    # ------------------------------------------------------------------
-    def show_message(self, text: str) -> None:
-        """Display ``text`` to the user."""
-
-        self.output_func(text)
-
-    def show_status(self, game_state) -> None:
-        """Render a summary of the current ``game_state``.
-
-        Only a few core stats are shown which keeps the method independent of
-        any particular front end.  Additional data can be appended by callers
-        if desired.
-        """
-
-        player = game_state.player
-        status = _(
-            f"Health: {player.health}/{player.max_health} | STA: {player.stamina}/{player.max_stamina} | "
-            f"XP: {player.xp} | Gold: {player.gold} | Level: {player.level} | Floor: {game_state.current_floor}"
-        )
-        self.output_func(status)
-
-    def draw_map(self, map_string: str) -> None:
-        """Render ``map_string`` representing the dungeon layout."""
-
-        self.output_func(map_string)
+from .ui.terminal import Renderer  # re-export for existing imports
 
 
 # ----------------------------------------------------------------------
@@ -82,3 +43,7 @@ def render_map(game) -> None:
 
     renderer = getattr(game, "renderer", Renderer())
     renderer.draw_map(render_map_string(game))
+
+
+__all__ = ["Renderer", "render_map", "render_map_string"]
+

--- a/dungeoncrawler/tutorial.py
+++ b/dungeoncrawler/tutorial.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from gettext import gettext as _
 
+from .input.keys import Action, get_action
+from .ui.terminal import Renderer
 
-def run(game) -> None:
+
+def run(game, input_func=input, renderer: Renderer | None = None) -> None:
     """Run the tutorial sequence.
 
     The tutorial walks the player through movement, combat and
@@ -14,32 +17,36 @@ def run(game) -> None:
     the next section.
     """
 
-    print(_("=== Welcome to the Dungeon Crawler tutorial! ==="))
-    print(_("Let's begin with movement. Use '1' (left), '2' (right), '3' (up) or '4' (down)."))
+    renderer = renderer or getattr(game, "renderer", Renderer())
+    renderer.show_message(_("=== Welcome to the Dungeon Crawler tutorial! ==="))
+    renderer.show_message(
+        _("Let's begin with movement. Use '1' (left), '2' (right), '3' (up) or '4' (down).")
+    )
     while True:
-        move = input(_("Move: ")).strip()
-        if move in {"1", "2", "3", "4"}:
-            print(_("Good job! You can navigate the dungeon using those keys."))
+        move = input_func(_("Move: ")).strip()
+        action = get_action(move)
+        if action in {Action.MOVE_W, Action.MOVE_E, Action.MOVE_N, Action.MOVE_S}:
+            renderer.show_message(_("Good job! You can navigate the dungeon using those keys."))
             break
-        print(_("Please use one of 1, 2, 3 or 4 to move."))
+        renderer.show_message(_("Please use one of 1, 2, 3 or 4 to move."))
 
-    print(_("Now let's practice combat. Type 'attack' to strike the training dummy."))
+    renderer.show_message(_("Now let's practice combat. Type 'attack' to strike the training dummy."))
     while True:
-        action = input(_("Action: ")).strip().lower()
+        action = input_func(_("Action: ")).strip().lower()
         if action == "attack":
-            print(_("The dummy falls apart. A solid hit!"))
+            renderer.show_message(_("The dummy falls apart. A solid hit!"))
             break
-        print(_("Type 'attack' to perform an attack."))
+        renderer.show_message(_("Type 'attack' to perform an attack."))
 
-    print(_("Finally, open your inventory by typing 'inventory'."))
+    renderer.show_message(_("Finally, open your inventory by typing 'inventory'."))
     while True:
-        action = input(_("Command: ")).strip().lower()
+        action = input_func(_("Command: ")).strip().lower()
         if action == "inventory":
-            print(_("Your empty bag opens. You'll fill it with loot soon enough."))
+            renderer.show_message(_("Your empty bag opens. You'll fill it with loot soon enough."))
             break
-        print(_("Type 'inventory' to check your belongings."))
+        renderer.show_message(_("Type 'inventory' to check your belongings."))
 
-    print(_("That's it for the basics. Good luck in the dungeon!"))
+    renderer.show_message(_("That's it for the basics. Good luck in the dungeon!"))
     game.tutorial_complete = True
 
 

--- a/dungeoncrawler/ui/__init__.py
+++ b/dungeoncrawler/ui/__init__.py
@@ -1,0 +1,6 @@
+"""User interface utilities for terminal based front ends."""
+
+from .terminal import Renderer
+
+__all__ = ["Renderer"]
+

--- a/dungeoncrawler/ui/terminal.py
+++ b/dungeoncrawler/ui/terminal.py
@@ -1,0 +1,74 @@
+"""Simple terminal based renderer for the dungeon crawler.
+
+The renderer is intentionally lightweight – it only knows how to display text
+messages and is completely agnostic of game logic.  It can subscribe to the
+core event stream by being passed an ``event_bus`` object that exposes a
+``subscribe`` method.  When events are received their ``message`` attribute is
+printed using the provided ``output_func``.
+"""
+
+from __future__ import annotations
+
+from gettext import gettext as _
+from typing import Callable
+
+from ..core.events import Event
+
+
+class Renderer:
+    """Minimal text based renderer used by the test-suite.
+
+    Parameters
+    ----------
+    event_bus:
+        Optional object supporting a ``subscribe`` method.  If provided the
+        renderer will register its :meth:`handle_event` callback to automatically
+        display events as they are published.
+    output_func:
+        Callable used to output text. Defaults to :func:`print` making the
+        renderer suitable for CLI based interfaces and for capturing output in
+        tests.
+    """
+
+    def __init__(self, event_bus: object | None = None, output_func: Callable[[str], None] = print):
+        self.output_func = output_func
+        self.lines: list[str] = []
+        if event_bus is not None and hasattr(event_bus, "subscribe"):
+            event_bus.subscribe(self.handle_event)
+
+    # ------------------------------------------------------------------
+    # Event handling
+    # ------------------------------------------------------------------
+    def handle_event(self, event: Event) -> None:
+        """Display a core event."""
+
+        self.show_message(_(event.message))
+
+    # ------------------------------------------------------------------
+    # Basic message helpers
+    # ------------------------------------------------------------------
+    def show_message(self, text: str) -> None:
+        """Display ``text`` to the user and store it in ``lines``."""
+
+        self.lines.append(text)
+        self.output_func(text)
+
+    def show_status(self, game_state) -> None:
+        """Render a summary of the current ``game_state``."""
+
+        player = game_state.player
+        status = _(
+            f"Health: {player.health}/{player.max_health} | STA: {player.stamina}/{player.max_stamina} | "
+            f"XP: {player.xp} | Gold: {player.gold} | Level: {player.level} | Floor: {game_state.current_floor}"
+        )
+        self.show_message(status)
+
+    def draw_map(self, map_string: str) -> None:
+        """Render ``map_string`` representing the dungeon layout."""
+
+        for line in map_string.split("\n"):
+            self.show_message(line)
+
+
+__all__ = ["Renderer"]
+


### PR DESCRIPTION
## Summary
- Add terminal-based Renderer that prints subscribed core events
- Provide key-to-action mapping for simple input handling
- Use renderer and input helpers within tutorial and combat loops

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d09783004832699c2280d3d6d5f37