### PR TITLE
Add test for deterministic combat resolver

### DIFF
--- a/tests/test_combat_resolver_determinism.py
+++ b/tests/test_combat_resolver_determinism.py
@@ -1,0 +1,21 @@
+import random
+from dungeoncrawler.core.combat import resolve_player_action, resolve_enemy_turn
+from dungeoncrawler.core.entity import Entity
+
+
+def test_combat_resolver_deterministic_with_seed():
+    player1 = Entity("Hero", {"health": 10, "attack": 4})
+    enemy1 = Entity("Goblin", {"health": 6, "attack": 3})
+    random.seed(123)
+    events1 = []
+    events1.extend(resolve_player_action(player1, enemy1, "attack"))
+    events1.extend(resolve_enemy_turn(enemy1, player1))
+
+    player2 = Entity("Hero", {"health": 10, "attack": 4})
+    enemy2 = Entity("Goblin", {"health": 6, "attack": 3})
+    random.seed(123)
+    events2 = []
+    events2.extend(resolve_player_action(player2, enemy2, "attack"))
+    events2.extend(resolve_enemy_turn(enemy2, player2))
+
+    assert events1 == events2


### PR DESCRIPTION
## Summary
- test combat resolver emits identical event sequences when RNG is seeded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d13df07e4832693ede5afa59dedb4