### PR TITLE
Add visibility test for walls and discovery

### DIFF
--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -1,0 +1,26 @@
+"""Visibility and discovery handling tests."""
+
+from dungeoncrawler.core.map import GameMap
+
+
+def test_visibility_and_discovery_on_small_map():
+    """Ensure walls block vision and discovered matches visible tiles."""
+
+    # 3x3 map with walls (None) blocking horizontal movement
+    grid = [
+        [1, 1, 1],
+        [None, 1, None],
+        [1, 1, 1],
+    ]
+    gm = GameMap(grid)
+
+    gm.update_visibility(1, 1, 2)
+
+    expected = [
+        [True, True, True],
+        [False, True, False],
+        [True, True, True],
+    ]
+
+    assert gm.visible == expected
+    assert gm.discovered == expected


### PR DESCRIPTION
## Summary
- add test ensuring walls block visibility and discovered tiles match visible ones

## Testing
- `pytest tests/test_visibility.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d149659408326a290d074dc50ba29