### PR TITLE
Add Rich renderer, Textual UI skeleton, and config toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Available configuration options:
 | `trap_chance` | float | `0.1` | Probability that a room contains a trap; higher values favor healing fountains on early floors. |
 | `loot_multiplier` | float | `1.0` | Multiplies the amount of loot found; higher values favor treasure caches on early floors. |
 | `verbose_combat` | bool | `false` | Log additional combat details. |
+| `slow_messages` | bool | `false` | Introduce a short delay between message prints. |
+| `key_repeat_delay` | float | `0.5` | Time in seconds before held keys repeat. |
+| `colorblind_mode` | bool | `false` | Use an alternative palette for improved contrast. |
 | `enable_debug` | bool | `false` | Toggle extra debug output. |
 
 ## Running the Game

--- a/config.example.json
+++ b/config.example.json
@@ -5,6 +5,9 @@
   "screen_width": 10,
   "screen_height": 10,
   "verbose_combat": false,
+  "slow_messages": false,
+  "key_repeat_delay": 0.5,
+  "colorblind_mode": false,
   "trap_chance": 0.1,
   "loot_multiplier": 1.0,
   "enable_debug": false

--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -25,6 +25,9 @@ class Config:
     screen_width: int = 10
     screen_height: int = 10
     verbose_combat: bool = False
+    slow_messages: bool = False
+    key_repeat_delay: float = 0.5
+    colorblind_mode: bool = False
     trap_chance: float = 0.1
     loot_multiplier: float = 1.0
     enable_debug: bool = False
@@ -70,7 +73,7 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
                 elif key in {"save_file", "score_file"}:
                     if not isinstance(value, str):
                         raise ValueError(f"{key} must be a string, got {type(value).__name__}")
-                elif key in {"verbose_combat", "enable_debug"}:
+                elif key in {"verbose_combat", "enable_debug", "slow_messages", "colorblind_mode"}:
                     if not isinstance(value, bool):
                         raise ValueError(f"{key} must be a boolean, got {type(value).__name__}")
                 elif key == "trap_chance":
@@ -84,6 +87,12 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
                         raise ValueError(f"{key} must be a number, got {type(value).__name__}")
                     if float(value) <= 0:
                         raise ValueError(f"{key} must be greater than 0, got {value}")
+                    value = float(value)
+                elif key == "key_repeat_delay":
+                    if not isinstance(value, (int, float)):
+                        raise ValueError(f"{key} must be a number, got {type(value).__name__}")
+                    if float(value) < 0:
+                        raise ValueError(f"{key} must be greater than or equal to 0, got {value}")
                     value = float(value)
                 setattr(cfg, key, value)
             else:

--- a/dungeoncrawler/ui/__init__.py
+++ b/dungeoncrawler/ui/__init__.py
@@ -1,5 +1,6 @@
 """User interface utilities for terminal based front ends."""
 
 from .terminal import Renderer
+from .textual_app import DungeonApp
 
-__all__ = ["Renderer"]
+__all__ = ["Renderer", "DungeonApp"]

--- a/dungeoncrawler/ui/terminal.py
+++ b/dungeoncrawler/ui/terminal.py
@@ -9,10 +9,20 @@ printed using the provided ``output_func``.
 
 from __future__ import annotations
 
+import time
 from gettext import gettext as _
 from typing import Callable
 
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
+
+from ..config import config
 from ..core.events import Event
+
+# Basic palettes for map rendering
+DEFAULT_PALETTE = {"@": "green", "E": "red", ".": "white", "·": "grey70", "#": "grey50"}
+COLORBLIND_PALETTE = {"@": "cyan", "E": "magenta", ".": "white", "·": "grey70", "#": "grey50"}
 
 
 class Renderer:
@@ -32,7 +42,9 @@ class Renderer:
 
     def __init__(self, event_bus: object | None = None, output_func: Callable[[str], None] = print):
         self.output_func = output_func
+        self.console = Console()
         self.lines: list[str] = []
+        self.palette = COLORBLIND_PALETTE if config.colorblind_mode else DEFAULT_PALETTE
         if event_bus is not None and hasattr(event_bus, "subscribe"):
             event_bus.subscribe(self.handle_event)
 
@@ -47,27 +59,47 @@ class Renderer:
     # ------------------------------------------------------------------
     # Basic message helpers
     # ------------------------------------------------------------------
-    def show_message(self, text: str) -> None:
+    def show_message(self, text: str, style: str | None = None) -> None:
         """Display ``text`` to the user and store it in ``lines``."""
 
         self.lines.append(text)
-        self.output_func(text)
+        self.console.print(text, style=style)
+        if config.slow_messages:
+            time.sleep(config.key_repeat_delay)
+        if self.output_func is not print:
+            self.output_func(text)
 
     def show_status(self, game_state) -> None:
         """Render a summary of the current ``game_state``."""
 
         player = game_state.player
+        table = Table(box=None, show_header=False)
+        table.add_row("Health", f"[green]{player.health}/{player.max_health}")
+        table.add_row("STA", f"{player.stamina}/{player.max_stamina}")
+        table.add_row("XP", str(player.xp))
+        table.add_row("Gold", str(player.gold))
+        table.add_row("Level", str(player.level))
+        table.add_row("Floor", str(game_state.current_floor))
+        self.console.print(table)
         status = _(
             f"Health: {player.health}/{player.max_health} | STA: {player.stamina}/{player.max_stamina} | "
             f"XP: {player.xp} | Gold: {player.gold} | Level: {player.level} | Floor: {game_state.current_floor}"
         )
-        self.show_message(status)
+        if self.output_func is not print:
+            self.output_func(status)
+        self.lines.append(status)
 
     def draw_map(self, map_string: str) -> None:
         """Render ``map_string`` representing the dungeon layout."""
 
         for line in map_string.split("\n"):
-            self.show_message(line)
+            text = Text()
+            for char in line:
+                text.append(char, style=self.palette.get(char, ""))
+            self.console.print(text)
+            if self.output_func is not print:
+                self.output_func(line)
+            self.lines.append(line)
 
 
 # Public API

--- a/dungeoncrawler/ui/textual_app.py
+++ b/dungeoncrawler/ui/textual_app.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from textual.app import App, ComposeResult
+from textual.containers import Grid
+from textual.widgets import Static
+
+
+class MapPanel(Static):
+    """Panel displaying the dungeon map."""
+
+
+class StatsPanel(Static):
+    """Panel showing player statistics."""
+
+
+class LogPanel(Static):
+    """Panel containing recent messages."""
+
+
+class ActionsPanel(Static):
+    """Panel listing available actions."""
+
+
+class DungeonApp(App):
+    """Textual interface composed of resizable panels."""
+
+    CSS = ".grid {grid-size: 2 2; grid-columns: 2fr 1fr; grid-rows: 3fr 1fr;}\n" \
+          "#map {grid-column: 1; grid-row: 1 / span 2;}\n" \
+          "#stats {grid-column: 2; grid-row: 1;}\n" \
+          "#log {grid-column: 2; grid-row: 2;}\n" \
+          "#actions {grid-column: 1; grid-row: 2;}\n"
+
+    def compose(self) -> ComposeResult:
+        with Grid(classes="grid"):
+            yield MapPanel("Map", id="map")
+            yield StatsPanel("Stats", id="stats")
+            yield LogPanel("Log", id="log")
+            yield ActionsPanel("Actions", id="actions")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ black==25.1.0
 flake8==7.3.0
 isort==6.0.1
 pytest==8.4.1
+rich==13.7.1
+textual==0.64.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,6 +66,9 @@ def test_new_keys_default(tmp_path):
     assert cfg.trap_chance == 0.1
     assert cfg.loot_multiplier == 1.0
     assert cfg.verbose_combat is False
+    assert cfg.slow_messages is False
+    assert cfg.key_repeat_delay == 0.5
+    assert cfg.colorblind_mode is False
     assert cfg.enable_debug is False
 
 
@@ -74,3 +77,23 @@ def test_unknown_keys_preserved(tmp_path):
     cfg_file.write_text(json.dumps({"future_option": 42}))
     cfg = load_config(cfg_file)
     assert cfg.extras["future_option"] == 42
+
+
+def test_key_repeat_delay_validation(tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"key_repeat_delay": -1}))
+    with pytest.raises(ValueError):
+        load_config(cfg_file)
+    cfg_file.write_text(json.dumps({"key_repeat_delay": "fast"}))
+    with pytest.raises(ValueError):
+        load_config(cfg_file)
+
+
+def test_bool_toggle_validation(tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"slow_messages": "yes"}))
+    with pytest.raises(ValueError):
+        load_config(cfg_file)
+    cfg_file.write_text(json.dumps({"colorblind_mode": "no"}))
+    with pytest.raises(ValueError):
+        load_config(cfg_file)


### PR DESCRIPTION
## Summary
- Integrate Rich into the terminal renderer with colorblind-friendly palette and slow message option
- Provide a resizable Textual app skeleton with map, stats, log, and actions panels
- Expand configuration: new slow message and key repeat options, colorblind mode, updated documentation and tests

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d15fadaec83268c3bc140904c57b7