### PR TITLE
Remove trailing blank line from events module

### DIFF
--- a/dungeoncrawler/core/events.py
+++ b/dungeoncrawler/core/events.py
@@ -229,4 +229,3 @@ def handle_lore_note(
 
     note = LoreNote(text, effect)
     return note.interact(player)
-


### PR DESCRIPTION
## Summary
- delete extra trailing blank line in `events.py` to appease flake8 W391

## Testing
- `flake8 .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d287427608326a832c809eb8ee315