### PR TITLE
Use JSON data for core enemies, items, and events

### DIFF
--- a/data/core_enemies.json
+++ b/data/core_enemies.json
@@ -1,0 +1,37 @@
+{
+  "enemies": [
+    {
+      "name": "Goblin Skirm",
+      "rarity": "common",
+      "stats": {"health": 6, "attack": 3, "defense": 1, "speed": 4},
+      "intents": [
+        {"action": "attack", "message": "Goblin darts forward with a rusty blade."}
+      ]
+    },
+    {
+      "name": "Guard Beetle",
+      "rarity": "common",
+      "stats": {"health": 12, "attack": 2, "defense": 4, "speed": 2},
+      "intents": [
+        {"action": "defend", "message": "Beetle curls into its shell."},
+        {"action": "attack", "message": "Beetle snaps out with its mandibles."}
+      ]
+    },
+    {
+      "name": "Rabid Bat",
+      "rarity": "common",
+      "stats": {"health": 5, "attack": 2, "defense": 0, "speed": 6},
+      "intents": [
+        {"action": "attack", "message": "Bat screeches and dives."}
+      ]
+    },
+    {
+      "name": "Cult Acolyte",
+      "rarity": "rare",
+      "stats": {"health": 8, "attack": 4, "defense": 1, "speed": 3},
+      "intents": [
+        {"action": "attack", "message": "Acolyte begins channeling dark energy."}
+      ]
+    }
+  ]
+}

--- a/data/core_events.json
+++ b/data/core_events.json
@@ -1,0 +1,13 @@
+{
+  "fountain": {
+    "rarity": "common",
+    "uses": 2,
+    "bless_chance": 0.3,
+    "curse_chance": 0.1
+  },
+  "locked_cache": {
+    "rarity": "rare",
+    "loot": "gold",
+    "key_name": "cache_key"
+  }
+}

--- a/data/core_items.json
+++ b/data/core_items.json
@@ -1,0 +1,14 @@
+{
+  "items": [
+    {
+      "name": "potion",
+      "rarity": "common",
+      "potion_heal": 20
+    },
+    {
+      "name": "elixir",
+      "rarity": "rare",
+      "potion_heal": 50
+    }
+  ]
+}

--- a/dungeoncrawler/core/combat.py
+++ b/dungeoncrawler/core/combat.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import List
 
+from .data import load_items
 from .entity import Entity
 from .events import AttackResolved, Event, IntentTelegraphed, StatusApplied
 
@@ -119,7 +120,8 @@ def resolve_player_action(player: Entity, enemy: Entity, action: str) -> List[Ev
     elif action == "use_health_potion":
         if "potion" in player.inventory:
             player.inventory.remove("potion")
-            heal = player.stats.get("potion_heal", 20)
+            potion = load_items().get("potion", {})
+            heal = player.stats.get("potion_heal", potion.get("potion_heal", 20))
             max_hp = player.stats.get("max_health", player.stats.get("health", 0))
             new_hp = min(max_hp, player.stats.get("health", 0) + heal)
             player.stats["health"] = new_hp

--- a/dungeoncrawler/core/data.py
+++ b/dungeoncrawler/core/data.py
@@ -1,0 +1,37 @@
+"""Utilities for loading core game data from JSON files."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+
+
+@lru_cache(maxsize=None)
+def load_enemies() -> Dict[str, Dict[str, Any]]:
+    """Return enemy archetype definitions keyed by name."""
+    path = DATA_DIR / "core_enemies.json"
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    return {e["name"]: e for e in data.get("enemies", [])}
+
+
+@lru_cache(maxsize=None)
+def load_items() -> Dict[str, Dict[str, Any]]:
+    """Return item definitions keyed by name."""
+    path = DATA_DIR / "core_items.json"
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    return {i["name"]: i for i in data.get("items", [])}
+
+
+@lru_cache(maxsize=None)
+def load_events() -> Dict[str, Any]:
+    """Return event parameter definitions."""
+    path = DATA_DIR / "core_events.json"
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    return data

--- a/dungeoncrawler/core/events.py
+++ b/dungeoncrawler/core/events.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass
 import random
 from typing import Callable, List, Optional, Tuple
 
+from .data import load_events
+
+EVENT_DATA = load_events()
+
 
 @dataclass
 class Event:
@@ -78,9 +82,10 @@ class Fountain:
         player's ``status`` list.
     """
 
-    uses: int = 2
-    bless_chance: float = 0.3
-    curse_chance: float = 0.1
+    uses: int = EVENT_DATA.get("fountain", {}).get("uses", 2)
+    bless_chance: float = EVENT_DATA.get("fountain", {}).get("bless_chance", 0.3)
+    curse_chance: float = EVENT_DATA.get("fountain", {}).get("curse_chance", 0.1)
+    rarity: str = EVENT_DATA.get("fountain", {}).get("rarity", "common")
 
     def interact(self, player, action: str) -> List[Event]:
         """Return a list of events produced by interacting with the fountain."""
@@ -157,10 +162,11 @@ class LockedCache:
     style :class:`Event` message is returned to hint at its location.
     """
 
-    loot: str = "gold"
-    key_name: str = "cache_key"
+    loot: str = EVENT_DATA.get("locked_cache", {}).get("loot", "gold")
+    key_name: str = EVENT_DATA.get("locked_cache", {}).get("key_name", "cache_key")
     opened: bool = False
     key_spawned: bool = False
+    rarity: str = EVENT_DATA.get("locked_cache", {}).get("rarity", "rare")
 
     def interact(self, player, spawn_key: Callable[[str], None]) -> List[Event]:
         events: List[Event] = []


### PR DESCRIPTION
## Summary
- move core enemy, item, and event definitions to data/core_*.json with rarity tiers
- add loader utilities and wire core modules to read JSON definitions
- support data-driven healing and event parameters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d2c89ba188326a853c8fa52f29acd