### PR TITLE
Add character selection screens

### DIFF
--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -101,22 +101,12 @@ class Player(Entity):
 
         self.class_type = class_type
         stats = {
+            "Warrior": (100, 10),
             "Mage": (80, 14),
             "Rogue": (90, 12),
             "Cleric": (110, 9),
-            "Paladin": (120, 11),
-            "Bard": (90, 10),
-            "Warrior": (100, 10),
-            # New classes inspired by the tabletop source material
             "Barbarian": (130, 12),
-            "Druid": (105, 11),
             "Ranger": (105, 11),
-            "Sorcerer": (85, 15),
-            "Monk": (95, 11),
-            "Warlock": (85, 14),
-            "Necromancer": (90, 13),
-            "Shaman": (100, 12),
-            "Alchemist": (95, 12),
         }
 
         if class_type not in stats:
@@ -481,6 +471,10 @@ class Player(Entity):
             self.health += 10
         elif guild == "Mages' Guild":
             self.attack_power += 3
+        elif guild == "Rogues' Guild":
+            for skill in self.skills.values():
+                skill["base_cooldown"] = max(1, skill["base_cooldown"] - 1)
+                skill["cooldown"] = max(0, skill["cooldown"] - 1)
         elif guild == "Healers' Circle":
             self.max_health += 8
             self.health += 8
@@ -488,12 +482,6 @@ class Player(Entity):
             self.attack_power += 4
         elif guild == "Arcane Order":
             self.attack_power += 2
-        elif guild == "Rangers' Lodge":
-            self.max_health += 5
-            self.health += 5
-            self.attack_power += 1
-        elif guild == "Berserkers' Clan":
-            self.attack_power += 3
         print(_(f"You have joined the {guild}!"))
 
     def choose_race(self, race):
@@ -514,33 +502,8 @@ class Player(Entity):
         elif race == "Gnome":
             self.max_health += 2
             self.health += 2
-        elif race == "Halfling":
-            pass
-        elif race == "Catfolk":
-            self.attack_power += 1
-        elif race == "Lizardfolk":
-            self.max_health += 4
-            self.health += 4
         elif race == "Tiefling":
             self.attack_power += 2
-        elif race == "Aasimar":
-            self.max_health += 4
-            self.health += 4
-        elif race == "Goblin":
-            pass
-        elif race == "Dragonborn":
-            self.attack_power += 2
-            self.max_health += 2
-            self.health += 2
-        elif race == "Half-Elf":
-            self.attack_power += 1
-            self.max_health += 2
-            self.health += 2
-        elif race == "Kobold":
-            self.attack_power += 1
-        elif race == "Triton":
-            self.max_health += 3
-            self.health += 3
         print(_(f"Race selected: {race}."))
 
     def equip_weapon(self, weapon):

--- a/tests/test_character_selection.py
+++ b/tests/test_character_selection.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+
+
+def _setup():
+    dungeon = DungeonBase(5, 5)
+    dungeon.player = Player("hero")
+    return dungeon
+
+
+def test_offer_class_permanent_and_skills(capsys):
+    dungeon = _setup()
+    inputs = iter(["1"])
+    dungeon.offer_class(input_func=lambda _: next(inputs))
+    out = capsys.readouterr().out.lower()
+    assert "permanent" in out
+    assert "power strike" in out
+    assert dungeon.player.class_type != "Novice"
+
+
+def test_offer_guild_screen(capsys):
+    dungeon = _setup()
+    dungeon.offer_guild(input_func=lambda _: "1")
+    out = capsys.readouterr().out.lower()
+    assert "permanent" in out
+    assert "power strike" in out
+    assert dungeon.player.guild == "Warriors' Guild"
+
+
+def test_offer_race_screen(capsys):
+    dungeon = _setup()
+    dungeon.offer_race(input_func=lambda _: "2")
+    out = capsys.readouterr().out.lower()
+    assert "permanent" in out
+    assert "power strike" in out
+    assert dungeon.player.race == "Elf"

--- a/tests/test_floor_events.py
+++ b/tests/test_floor_events.py
@@ -74,7 +74,7 @@ def test_floor_progression_unlocks_features():
     with (
         patch("dungeoncrawler.dungeon.random.choice", return_value=DummyEvent),
         patch("dungeoncrawler.dungeon.random.randint", return_value=1),
-        patch.object(DungeonBase, "offer_class", new=fake_offer_class, create=True),
+        patch.object(DungeonBase, "offer_class", new=fake_offer_class),
         patch.object(DungeonBase, "offer_guild", new=fake_offer_guild),
         patch.object(DungeonBase, "offer_race", new=fake_offer_race),
     ):


### PR DESCRIPTION
## Summary
- Introduce permanent class, guild and race selection screens on floors 1-3
- Limit options to 6 classes, 6 guilds and 6 races and display stamina skill tooltips
- Update player stats and guild benefits to match new options
- Add tests for selection prompts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d3280cacc8326bb2cfc9da7520c54