### PR TITLE
Add combat logging and simulation harness

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -865,6 +865,8 @@ class DungeonBase:
             self.view_leaderboard()
         elif config.enable_debug and choice.startswith(":god"):
             self.god_mode(choice)
+        elif config.enable_debug and choice.startswith(":sim"):
+            self.simulate(command=choice)
         elif choice == ":codex":
             self.show_codex()
         else:
@@ -918,6 +920,33 @@ class DungeonBase:
             self.renderer.show_message(
                 self.queue_message(_("Invalid god command"), output_func=None)
             )
+
+    def simulate(self, command: str) -> None:
+        """Run automated combat simulations.
+
+        Usage: ``:sim <enemy> <runs>``
+        """
+        parts = command.split()
+        if len(parts) < 3:
+            self.renderer.show_message(
+                self.queue_message(_("Usage: :sim <enemy> <runs>"), output_func=None)
+            )
+            return
+        enemy_name = parts[1]
+        try:
+            runs = int(parts[2])
+        except ValueError:
+            self.renderer.show_message(
+                self.queue_message(_("Invalid run count"), output_func=None)
+            )
+            return
+        from .sim import simulate_battles
+
+        stats = simulate_battles(enemy_name, runs, seed=42)
+        msg = _(
+            f"Winrate: {stats['winrate']:.2%} | Avg TTK: {stats['avg_turns']:.2f}"
+        )
+        self.renderer.show_message(self.queue_message(msg, output_func=None))
 
     def show_codex(self, output_func=print):
         if not self.player.codex:

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -438,17 +438,18 @@ class Player(Entity):
         skill = self.skills.get(str(choice))
         if not skill:
             print(_("Invalid skill choice."))
-            return
+            return None
         if skill["cooldown"] > 0:
             print(_(f"{skill['name']} is on cooldown for {skill['cooldown']} more turn(s)."))
-            return
+            return None
         if self.stamina < skill["cost"]:
             needed = skill["cost"] - self.stamina
             print(_(f"You're winded (need {needed} more STA)."))
-            return
+            return None
         self.stamina -= skill["cost"]
         skill["func"](enemy)
         skill["cooldown"] = skill["base_cooldown"]
+        return skill["name"]
 
     def level_up(self):
         self.level += 1

--- a/dungeoncrawler/sim.py
+++ b/dungeoncrawler/sim.py
@@ -1,0 +1,49 @@
+"""Automated combat simulation utilities."""
+
+from __future__ import annotations
+
+import random
+from typing import Dict
+
+from .dungeon import ENEMY_STATS
+from .core.entity import Entity
+from .core.combat import resolve_player_action, resolve_enemy_turn
+
+
+def simulate_battles(enemy_name: str, runs: int, seed: int | None = None) -> Dict[str, float]:
+    """Simulate ``runs`` battles against ``enemy_name``.
+
+    Returns a dictionary with ``winrate`` and ``avg_turns``.
+    """
+
+    rng = random.Random(seed)
+    if enemy_name not in ENEMY_STATS:
+        raise KeyError(f"Unknown enemy: {enemy_name}")
+    hp_min, hp_max, atk_min, atk_max, defense = ENEMY_STATS[enemy_name]
+    wins = 0
+    total_turns = 0
+    for _ in range(runs):
+        player = Entity("Hero", {"health": 30, "attack": 8, "speed": 10})
+        enemy = Entity(
+            enemy_name,
+            {
+                "health": rng.randint(hp_min, hp_max),
+                "attack": rng.randint(atk_min, atk_max),
+                "defense": defense,
+                "speed": 10,
+            },
+        )
+        turns = 0
+        while player.stats["health"] > 0 and enemy.stats["health"] > 0:
+            resolve_player_action(player, enemy, "attack")
+            if enemy.stats["health"] <= 0:
+                turns += 1
+                break
+            resolve_enemy_turn(enemy, player)
+            turns += 1
+        if player.stats["health"] > 0:
+            wins += 1
+            total_turns += turns
+    winrate = wins / runs if runs else 0
+    avg_turns = total_turns / wins if wins else 0
+    return {"winrate": winrate, "avg_turns": avg_turns}

--- a/dungeoncrawler/stats_logger.py
+++ b/dungeoncrawler/stats_logger.py
@@ -10,11 +10,18 @@ class StatsLogger:
     def __init__(self) -> None:
         self.run_id = int(time.time())
         self.rows: List[Dict[str, object]] = []
+        self.combat_rows: List[Dict[str, object]] = []
         self.current_floor: Optional[int] = None
         self.turns = 0
         self.encounters = 0
         self.first_reward_turn: Optional[int] = None
         self.total_tiles = 0
+        # per-battle trackers
+        self._battle_enemy: Optional[str] = None
+        self._battle_turns = 0
+        self._damage_dealt = 0
+        self._damage_taken = 0
+        self._skills_used: List[str] = []
 
     def start_floor(self, game, floor: int) -> None:
         """Begin tracking stats for ``floor``."""
@@ -27,12 +34,45 @@ class StatsLogger:
     def record_move(self) -> None:
         self.turns += 1
 
-    def battle_start(self) -> None:
+    # ------------------------------------------------------------------
+    # Combat logging helpers
+    # ------------------------------------------------------------------
+    def battle_start(self, enemy: str) -> None:
+        """Begin tracking a combat encounter."""
         self.encounters += 1
+        self._battle_enemy = enemy
+        self._battle_turns = 0
+        self._damage_dealt = 0
+        self._damage_taken = 0
+        self._skills_used = []
 
-    def battle_end(self, *_args, **_kwargs) -> None:  # pragma: no cover - placeholder
-        """Hook for future detailed combat metrics."""
-        return
+    def record_turn(self) -> None:
+        self._battle_turns += 1
+
+    def record_damage(self, *, dealt: int = 0, taken: int = 0) -> None:
+        self._damage_dealt += max(0, dealt)
+        self._damage_taken += max(0, taken)
+
+    def record_skill(self, name: str) -> None:
+        self._skills_used.append(name)
+
+    def battle_end(self, victory: bool, enemy: str) -> None:
+        """Persist collected combat stats for the current battle."""
+        if self._battle_enemy is None:
+            self._battle_enemy = enemy
+        self.combat_rows.append(
+            {
+                "run_id": self.run_id,
+                "floor": self.current_floor if self.current_floor is not None else "",
+                "enemy": self._battle_enemy,
+                "turns": self._battle_turns,
+                "damage_dealt": self._damage_dealt,
+                "damage_taken": self._damage_taken,
+                "skills_used": ";".join(self._skills_used),
+                "win": int(bool(victory)),
+            }
+        )
+        self._battle_enemy = None
 
     def record_reward(self) -> None:
         if self.first_reward_turn is None:
@@ -57,31 +97,52 @@ class StatsLogger:
         self.current_floor = None
 
     def finalize(self, game, death_cause: str) -> None:
-        """Write collected metrics to ``logs/balance.csv``."""
+        """Write collected metrics to ``logs`` directory."""
         if self.current_floor is not None:
             self.end_floor(game)
-        if not self.rows:
-            return
         path = Path("logs")
         path.mkdir(parents=True, exist_ok=True)
-        csv_path = path / "balance.csv"
-        fieldnames = [
-            "run_id",
-            "death_cause",
-            "floor",
-            "turns",
-            "encounters",
-            "time_to_first_reward",
-            "fog_reveal_rate",
-        ]
-        file_exists = csv_path.exists()
-        with csv_path.open("a", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=fieldnames)
-            if not file_exists:
-                writer.writeheader()
-            for row in self.rows:
-                row = row.copy()
-                row["run_id"] = self.run_id
-                row["death_cause"] = death_cause
-                writer.writerow(row)
-        self.rows.clear()
+
+        if self.rows:
+            csv_path = path / "balance.csv"
+            fieldnames = [
+                "run_id",
+                "death_cause",
+                "floor",
+                "turns",
+                "encounters",
+                "time_to_first_reward",
+                "fog_reveal_rate",
+            ]
+            file_exists = csv_path.exists()
+            with csv_path.open("a", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                if not file_exists:
+                    writer.writeheader()
+                for row in self.rows:
+                    row = row.copy()
+                    row["run_id"] = self.run_id
+                    row["death_cause"] = death_cause
+                    writer.writerow(row)
+            self.rows.clear()
+
+        if self.combat_rows:
+            csv_path = path / "combat.csv"
+            fieldnames = [
+                "run_id",
+                "floor",
+                "enemy",
+                "turns",
+                "damage_dealt",
+                "damage_taken",
+                "skills_used",
+                "win",
+            ]
+            file_exists = csv_path.exists()
+            with csv_path.open("a", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                if not file_exists:
+                    writer.writeheader()
+                for row in self.combat_rows:
+                    writer.writerow(row)
+            self.combat_rows.clear()

--- a/tests/test_combat_logging.py
+++ b/tests/test_combat_logging.py
@@ -1,0 +1,16 @@
+import random
+
+from dungeoncrawler.combat import battle
+from dungeoncrawler.entities import Enemy
+
+
+def test_combat_logging(game):
+    random.seed(0)
+    game.stats_logger.start_floor(game, 1)
+    game.player.attack_power = 10
+    enemy = Enemy("Dummy", 5, 0, 0, 0)
+    battle(game, enemy, input_func=lambda _="": "1")
+    row = game.stats_logger.combat_rows[0]
+    assert row["enemy"] == "Dummy"
+    assert row["turns"] >= 1
+    assert row["damage_dealt"] >= 0

--- a/tests/test_sim_harness.py
+++ b/tests/test_sim_harness.py
@@ -1,0 +1,7 @@
+from dungeoncrawler.sim import simulate_battles
+
+
+def test_simulate_battles():
+    stats = simulate_battles("Bandit", runs=5, seed=0)
+    assert 0 <= stats["winrate"] <= 1
+    assert stats["avg_turns"] >= 0


### PR DESCRIPTION
## Summary
- log per-battle metrics (floor, enemy, turns, damage, skills) to logs/combat.csv
- expose a :sim command and simulation module to measure winrate and turns-to-kill
- track skill usage by returning skill names and augment combat loop to record stats

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d375d0a2083268dac17877ae761bf