### PR TITLE
Add configurable enemy and loot multipliers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Available configuration options:
 | `screen_width` | int | `10` | Width of each dungeon floor in rooms. |
 | `screen_height` | int | `10` | Height of each dungeon floor in rooms. |
 | `trap_chance` | float | `0.1` | Probability that a room contains a trap; higher values favor healing fountains on early floors. |
-| `loot_multiplier` | float | `1.0` | Multiplies the amount of loot found; higher values favor treasure caches on early floors. |
+| `enemy_hp_mult` | float | `1.0` | Global multiplier applied to enemy hit points. |
+| `enemy_dmg_mult` | float | `1.0` | Global multiplier applied to enemy attack damage. |
+| `loot_mult` | float | `1.0` | Multiplies the amount of loot found; higher values favor treasure caches on early floors. |
 | `verbose_combat` | bool | `false` | Log additional combat details. |
 | `slow_messages` | bool | `false` | Introduce a short delay between message prints. |
 | `key_repeat_delay` | float | `0.5` | Time in seconds before held keys repeat. |

--- a/config.example.json
+++ b/config.example.json
@@ -9,6 +9,8 @@
   "key_repeat_delay": 0.5,
   "colorblind_mode": false,
   "trap_chance": 0.1,
-  "loot_multiplier": 1.0,
+  "enemy_hp_mult": 1.0,
+  "enemy_dmg_mult": 1.0,
+  "loot_mult": 1.0,
   "enable_debug": false
 }

--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -14,7 +14,9 @@ class Config:
 
     Besides basic layout settings such as ``screen_width`` and
     ``screen_height`` the configuration also exposes gameplay toggles like
-    ``trap_chance``, ``loot_multiplier`` and ``verbose_combat``.  Default
+    ``trap_chance`` and several multipliers that affect overall balance.  The
+    ``enemy_hp_mult`` and ``enemy_dmg_mult`` values allow quick adjustment of
+    monster statistics while ``loot_mult`` scales treasure gains.  Default
     values mirror the previous hard-coded constants so the game remains
     playable even if no configuration file is provided.
     """
@@ -29,7 +31,9 @@ class Config:
     key_repeat_delay: float = 0.5
     colorblind_mode: bool = False
     trap_chance: float = 0.1
-    loot_multiplier: float = 1.0
+    enemy_hp_mult: float = 1.0
+    enemy_dmg_mult: float = 1.0
+    loot_mult: float = 1.0
     enable_debug: bool = False
     extras: dict[str, Any] = field(default_factory=dict)
 
@@ -82,12 +86,13 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
                     if not 0 <= float(value) <= 1:
                         raise ValueError(f"{key} must be between 0 and 1, got {value}")
                     value = float(value)
-                elif key == "loot_multiplier":
+                elif key in {"loot_mult", "enemy_hp_mult", "enemy_dmg_mult", "loot_multiplier"}:
                     if not isinstance(value, (int, float)):
                         raise ValueError(f"{key} must be a number, got {type(value).__name__}")
                     if float(value) <= 0:
                         raise ValueError(f"{key} must be greater than 0, got {value}")
                     value = float(value)
+                    key = "loot_mult" if key == "loot_multiplier" else key
                 elif key == "key_repeat_delay":
                     if not isinstance(value, (int, float)):
                         raise ValueError(f"{key} must be a number, got {type(value).__name__}")

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -103,7 +103,7 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
         place_near_start("Sanctuary", 10)
 
     # Always ensure a helpful non-combat feature near the starting room
-    total = config.trap_chance + config.loot_multiplier
+    total = config.trap_chance + config.loot_mult
     fountain_prob = config.trap_chance / total if total else 0.5
     event_cls = FountainEvent if random.random() < fountain_prob else CacheEvent
     place_near_start(event_cls(), 10)
@@ -123,10 +123,16 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
 
         defense = max(1, defense + floor // 3)
 
-        health = random.randint(hp_min + floor * hp_scale, hp_max + floor * hp_scale)
-        attack = random.randint(
-            atk_min + floor * atk_scale,
-            atk_max + floor * atk_scale,
+        health = int(
+            random.randint(hp_min + floor * hp_scale, hp_max + floor * hp_scale)
+            * config.enemy_hp_mult
+        )
+        attack = int(
+            random.randint(
+                atk_min + floor * atk_scale,
+                atk_max + floor * atk_scale,
+            )
+            * config.enemy_dmg_mult
         )
         gold = random.randint(15 + early_game_bonus + floor, 30 + floor * 2)
 
@@ -146,8 +152,8 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
     boss_ai = IntentAI(**boss_weights) if boss_weights else None
     boss = Enemy(
         name,
-        hp + floor * 10,
-        atk + floor,
+        int((hp + floor * 10) * config.enemy_hp_mult),
+        int((atk + floor) * config.enemy_dmg_mult),
         dfs + floor // 2,
         gold + floor * 5,
         ability=ability,
@@ -170,7 +176,7 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
     trap_base = place_counts.get("Trap", 0)
     place_counts["Trap"] = max(0, round(trap_base * (1 + config.trap_chance)))
     treasure_base = place_counts.get("Treasure", 0)
-    place_counts["Treasure"] = max(0, round(treasure_base * config.loot_multiplier))
+    place_counts["Treasure"] = max(0, round(treasure_base * config.loot_mult))
     for pname, count in place_counts.items():
         for __ in range(count):
             place(pname)

--- a/dungeoncrawler/shop.py
+++ b/dungeoncrawler/shop.py
@@ -27,7 +27,7 @@ def shop(
             base_price = item.price
         else:
             base_price = 10
-        price = int(base_price * config.loot_multiplier)
+        price = int(base_price * config.loot_mult)
         output_func(_(f"{i}. {item.name} - {price} Gold"))
     sell_option = len(game.shop_items) + 1
     exit_option = sell_option + 1
@@ -43,7 +43,7 @@ def shop(
                 base_price = item.price
             else:
                 base_price = 10
-            price = int(base_price * config.loot_multiplier)
+            price = int(base_price * config.loot_mult)
             if game.player.gold >= price:
                 game.player.collect_item(item)
                 game.player.gold -= price

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,7 +64,9 @@ def test_new_keys_default(tmp_path):
     cfg_file.write_text("{}")
     cfg = load_config(cfg_file)
     assert cfg.trap_chance == 0.1
-    assert cfg.loot_multiplier == 1.0
+    assert cfg.loot_mult == 1.0
+    assert cfg.enemy_hp_mult == 1.0
+    assert cfg.enemy_dmg_mult == 1.0
     assert cfg.verbose_combat is False
     assert cfg.slow_messages is False
     assert cfg.key_repeat_delay == 0.5
@@ -95,5 +97,18 @@ def test_bool_toggle_validation(tmp_path):
     with pytest.raises(ValueError):
         load_config(cfg_file)
     cfg_file.write_text(json.dumps({"colorblind_mode": "no"}))
+    with pytest.raises(ValueError):
+        load_config(cfg_file)
+
+
+def test_multiplier_validation(tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"enemy_hp_mult": 0}))
+    with pytest.raises(ValueError):
+        load_config(cfg_file)
+    cfg_file.write_text(json.dumps({"enemy_dmg_mult": -1}))
+    with pytest.raises(ValueError):
+        load_config(cfg_file)
+    cfg_file.write_text(json.dumps({"loot_mult": 0}))
     with pytest.raises(ValueError):
         load_config(cfg_file)

--- a/tests/test_novice_luck.py
+++ b/tests/test_novice_luck.py
@@ -1,0 +1,32 @@
+import random
+
+from dungeoncrawler.entities import Player, Enemy
+
+
+def test_novice_luck_hit_bonus(monkeypatch):
+    player = Player("Hero")
+    enemy = Enemy("Rat", 5, 1, 0, 0)
+    player.novice_luck_active = True
+
+    monkeypatch.setattr(random, "randint", lambda a, b: 90)
+    monkeypatch.setattr(player, "calculate_damage", lambda: 1)
+    player.attack(enemy)
+    assert enemy.health == 4
+
+    enemy.health = enemy.max_health
+    player.novice_luck_active = False
+    player.attack(enemy)
+    assert enemy.health == enemy.max_health
+
+
+def test_novice_luck_damage_reduction():
+    player = Player("Hero")
+    start = player.health
+    player.novice_luck_active = True
+    player.take_damage(5)
+    assert player.health == start - 4
+
+    player.health = start
+    player.novice_luck_active = False
+    player.take_damage(5)
+    assert player.health == start - 5


### PR DESCRIPTION
## Summary
- expose `enemy_hp_mult`, `enemy_dmg_mult`, and `loot_mult` in configuration
- scale enemy stats, treasure placement, and shop prices using new multipliers
- add tests covering Novice's Luck hit and damage bonuses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d38f65fcc8326897de71df36f41c6