### PR TITLE
fix: replace deprecated locale call

### DIFF
--- a/dungeoncrawler/i18n.py
+++ b/dungeoncrawler/i18n.py
@@ -14,7 +14,12 @@ def set_language(lang: str | None = None) -> None:
         requested language is not available.
     """
     if lang is None:
-        lang = locale.getdefaultlocale()[0]
+        try:
+            locale.setlocale(locale.LC_ALL, "")
+        except locale.Error:
+            lang = None
+        else:
+            lang = locale.getlocale()[0]
     if lang:
         lang = lang.split("_")[0]
     localedir = Path(__file__).resolve().parent.parent / "locale"


### PR DESCRIPTION
## Summary
- replace deprecated locale.getdefaultlocale usage in i18n

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3b97a4c0832682ef8cfbc3c1ed36