### PR TITLE
Handle missing locale in i18n

### DIFF
--- a/dungeoncrawler/i18n.py
+++ b/dungeoncrawler/i18n.py
@@ -20,7 +20,10 @@ def set_language(lang: str | None = None) -> None:
             lang = None
         else:
             lang = locale.getlocale()[0]
+
     if lang:
         lang = lang.split("_")[0]
+
     localedir = Path(__file__).resolve().parent.parent / "locale"
-    gettext.translation("messages", localedir=localedir, languages=[lang], fallback=True).install()
+    languages = [lang] if lang else None
+    gettext.translation("messages", localedir=localedir, languages=languages, fallback=True).install()

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,31 @@
+import gettext
+import locale
+
+from dungeoncrawler import i18n
+
+
+def test_set_language_handles_missing_locale(monkeypatch):
+    """``set_language`` should fall back gracefully when locale can't be determined."""
+
+    # Simulate failing locale configuration
+    def fake_setlocale(*_args, **_kwargs):
+        raise locale.Error
+
+    monkeypatch.setattr(locale, "setlocale", fake_setlocale)
+
+    captured = {}
+
+    def fake_translation(domain, localedir=None, languages=None, fallback=False):  # noqa: D401
+        captured["languages"] = languages
+
+        class Dummy:
+            def install(self):
+                return None
+
+        return Dummy()
+
+    monkeypatch.setattr(gettext, "translation", fake_translation)
+
+    # Should not raise and should call translation with languages=None
+    i18n.set_language()
+    assert captured["languages"] is None


### PR DESCRIPTION
## Summary
- Avoid passing `[None]` to `gettext.translation` when locale can't be determined
- Add regression test covering the missing-locale path in `set_language`

## Testing
- `flake8 dungeoncrawler/i18n.py tests/test_i18n.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3c4f0ff48326a1f254ab8a5d3bb3