### PR TITLE
Handle non-object JSON in config loader

### DIFF
--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -64,8 +64,10 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
     cfg = Config()
     if path.exists():
         try:
-            data: dict[str, Any] = json.loads(path.read_text())
+            data: Any = json.loads(path.read_text())
         except json.JSONDecodeError:
+            return cfg
+        if not isinstance(data, dict):
             return cfg
         for key, value in data.items():
             if hasattr(cfg, key):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -81,6 +81,16 @@ def test_unknown_keys_preserved(tmp_path):
     assert cfg.extras["future_option"] == 42
 
 
+def test_non_dict_config_returns_defaults(tmp_path):
+    cfg_file = tmp_path / "config.json"
+    # A valid JSON file that does not contain a dictionary should not raise
+    # an exception and should fall back to default configuration values.
+    cfg_file.write_text("[]")
+    cfg = load_config(cfg_file)
+    assert cfg.max_floors == 18
+    assert cfg.extras == {}
+
+
 def test_key_repeat_delay_validation(tmp_path):
     cfg_file = tmp_path / "config.json"
     cfg_file.write_text(json.dumps({"key_repeat_delay": -1}))


### PR DESCRIPTION
## Summary
- avoid AttributeError when config file isn't a JSON object
- ensure default configuration is returned for non-dict JSON
- test non-dict config case

## Testing
- `pytest tests/test_config.py::test_non_dict_config_returns_defaults -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3d55c91c8326a6c9aabbcef463e8