### PR TITLE
Add new playable classes with stats and tests

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -569,6 +569,13 @@ class DungeonBase:
             "4": ("Cleric", _("Holy healer")),
             "5": ("Barbarian", _("Brutal strength")),
             "6": ("Ranger", _("Skilled hunter")),
+            "7": ("Druid", _("Nature's guardian")),
+            "8": ("Sorcerer", _("Chaotic caster")),
+            "9": ("Monk", _("Disciplined striker")),
+            "10": ("Warlock", _("Pact magic")),
+            "11": ("Necromancer", _("Master of the dead")),
+            "12": ("Shaman", _("Spiritual guide")),
+            "13": ("Alchemist", _("Potion expert")),
         }
         names = {v[0].lower(): k for k, v in classes.items()}
         skill_tip = ", ".join(f"{s['name']} ({s['cost']} stamina)" for s in SKILL_DEFS)
@@ -591,7 +598,7 @@ class DungeonBase:
                 if key in names:
                     choice = names[key]
             if choice is None:
-                print(_("Please enter a number (1–6) or a valid class name."))
+                print(_("Please enter a number (1–13) or a valid class name."))
                 continue
             self.player.choose_class(classes[choice][0])
             break

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -107,6 +107,13 @@ class Player(Entity):
             "Cleric": (110, 9),
             "Barbarian": (130, 12),
             "Ranger": (105, 11),
+            "Druid": (100, 11),
+            "Sorcerer": (75, 15),
+            "Monk": (95, 13),
+            "Warlock": (85, 14),
+            "Necromancer": (90, 13),
+            "Shaman": (110, 10),
+            "Alchemist": (90, 12),
         }
 
         if class_type not in stats:

--- a/tests/test_build_character.py
+++ b/tests/test_build_character.py
@@ -3,6 +3,8 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+import pytest
+
 from dungeoncrawler.entities import Player
 from dungeoncrawler.main import build_character
 
@@ -29,6 +31,26 @@ def test_choose_barbarian_stats():
     assert player.class_type == "Barbarian"
     assert player.max_health == 130
     assert player.attack_power == 12
+
+
+@pytest.mark.parametrize(
+    "cls,hp,atk",
+    [
+        ("Druid", 100, 11),
+        ("Sorcerer", 75, 15),
+        ("Monk", 95, 13),
+        ("Warlock", 85, 14),
+        ("Necromancer", 90, 13),
+        ("Shaman", 110, 10),
+        ("Alchemist", 90, 12),
+    ],
+)
+def test_new_class_stats(cls, hp, atk):
+    player = Player("Test")
+    player.choose_class(cls)
+    assert player.class_type == cls
+    assert player.max_health == hp
+    assert player.attack_power == atk
 
 
 def test_race_and_guild_bonuses():

--- a/tests/test_character_selection.py
+++ b/tests/test_character_selection.py
@@ -39,3 +39,12 @@ def test_offer_race_screen(capsys):
     assert "permanent" in out
     assert "power strike" in out
     assert dungeon.player.race == "Elf"
+
+def test_offer_class_lists_new_classes(capsys):
+    dungeon = _setup()
+    inputs = iter(["13"])
+    dungeon.offer_class(input_func=lambda _: next(inputs))
+    out = capsys.readouterr().out.lower()
+    assert "druid" in out
+    assert "alchemist" in out
+    assert dungeon.player.class_type == "Alchemist"


### PR DESCRIPTION
## Summary
- extend player class stats with Druid, Sorcerer, Monk, Warlock, Necromancer, Shaman, and Alchemist
- expand class selection menu to include the new options and update validation
- test new class stat initialization and selection

## Testing
- `pytest tests/test_build_character.py tests/test_character_selection.py`

------
https://chatgpt.com/codex/tasks/task_e_689d3e72c0e8832694c8d6ca4d98bffc