### PR TITLE
Add Dragonborn and Goblin races with stat bonuses

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -638,6 +638,8 @@ class DungeonBase:
             "4": ("Orc", _("Savage")),
             "5": ("Gnome", _("Clever")),
             "6": ("Tiefling", _("Fiendish")),
+            "7": ("Dragonborn", _("Draconic")),
+            "8": ("Goblin", _("Sneaky")),
         }
         skill_tip = ", ".join(f"{s['name']} ({s['cost']} stamina)" for s in SKILL_DEFS)
         for key, (name, desc) in races.items():

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -512,6 +512,12 @@ class Player(Entity):
             self.health += 2
         elif race == "Tiefling":
             self.attack_power += 2
+        elif race == "Dragonborn":
+            self.max_health += 2
+            self.health += 2
+            self.attack_power += 2
+        elif race == "Goblin":
+            self.attack_power += 1
         print(_(f"Race selected: {race}."))
 
     def equip_weapon(self, weapon):

--- a/tests/test_build_character.py
+++ b/tests/test_build_character.py
@@ -60,3 +60,18 @@ def test_race_and_guild_bonuses():
     player.join_guild("Healers' Circle")
     assert player.max_health == 108
     assert player.health == 108
+
+
+@pytest.mark.parametrize(
+    "race,hp,atk",
+    [
+        ("Tiefling", 100, 12),
+        ("Dragonborn", 102, 12),
+        ("Goblin", 100, 11),
+    ],
+)
+def test_new_race_bonuses(race, hp, atk):
+    player = Player("Sam")
+    player.choose_race(race)
+    assert player.max_health == hp
+    assert player.attack_power == atk


### PR DESCRIPTION
## Summary
- Expand race selection with Dragonborn and Goblin options
- Apply stat bonuses for Dragonborn and Goblin races
- Test race bonuses for Tiefling, Dragonborn, and Goblin

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d4065a14083269c61e0a30cd380b5