### PR TITLE
feat: expand boss mechanics

### DIFF
--- a/data/bosses.json
+++ b/data/bosses.json
@@ -7,8 +7,8 @@
       12,
       120
     ],
-    "ai": {},
-    "traits": [],
+    "ai": {"aggressive": 3, "defensive": 1, "unpredictable": 1},
+    "traits": ["armored"],
     "ability": "lifesteal",
     "loot": [
       {
@@ -28,8 +28,8 @@
       16,
       160
     ],
-    "ai": {},
-    "traits": [],
+    "ai": {"aggressive": 4, "defensive": 1, "unpredictable": 1},
+    "traits": ["berserker"],
     "ability": "double_strike",
     "loot": [
       {
@@ -49,8 +49,8 @@
       16,
       158
     ],
-    "ai": {},
-    "traits": [],
+    "ai": {"aggressive": 3, "defensive": 1, "unpredictable": 2},
+    "traits": ["regenerator"],
     "ability": "burn",
     "loot": [
       {
@@ -70,8 +70,8 @@
       13,
       130
     ],
-    "ai": {},
-    "traits": [],
+    "ai": {"aggressive": 1, "defensive": 3, "unpredictable": 1},
+    "traits": ["armored"],
     "ability": "freeze",
     "loot": [
       {
@@ -91,8 +91,8 @@
       14,
       133
     ],
-    "ai": {},
-    "traits": [],
+    "ai": {"aggressive": 2, "defensive": 2, "unpredictable": 1},
+    "traits": ["regenerator"],
     "ability": "freeze",
     "loot": [
       {
@@ -112,8 +112,8 @@
       15,
       138
     ],
-    "ai": {},
-    "traits": [],
+    "ai": {"aggressive": 2, "defensive": 3, "unpredictable": 1},
+    "traits": ["armored"],
     "ability": "lifesteal",
     "loot": [
       {
@@ -133,8 +133,8 @@
       14,
       140
     ],
-    "ai": {},
-    "traits": [],
+    "ai": {"aggressive": 3, "defensive": 2, "unpredictable": 1},
+    "traits": ["armored"],
     "ability": "burn",
     "loot": [
       {
@@ -154,8 +154,8 @@
       15,
       150
     ],
-    "ai": {},
-    "traits": [],
+    "ai": {"aggressive": 3, "defensive": 1, "unpredictable": 2},
+    "traits": ["berserker"],
     "ability": "poison",
     "loot": [
       {
@@ -175,8 +175,8 @@
       15,
       145
     ],
-    "ai": {},
-    "traits": [],
+    "ai": {"aggressive": 3, "defensive": 1, "unpredictable": 2},
+    "traits": ["berserker"],
     "ability": "double_strike",
     "loot": [
       {
@@ -196,8 +196,8 @@
       17,
       155
     ],
-    "ai": {},
-    "traits": [],
+    "ai": {"aggressive": 2, "defensive": 1, "unpredictable": 3},
+    "traits": ["regenerator"],
     "ability": "poison",
     "loot": [
       {

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -707,6 +707,7 @@ class DungeonBase:
                 atk_max + floor * 2,
                 defense + floor // 2,
                 random.randint(30, 60),
+                traits=self.enemy_traits.get(name),
             )
             enemy.xp = max(5, (enemy.health + enemy.attack_power + enemy.defense) // 15)
             loc = empty[0]

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -139,7 +139,8 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
         ability = game.enemy_abilities.get(name)
         weights = game.enemy_ai.get(name)
         ai = IntentAI(**weights) if weights else None
-        enemy = Enemy(name, health, attack, defense, gold, ability, ai)
+        traits = game.enemy_traits.get(name)
+        enemy = Enemy(name, health, attack, defense, gold, ability, ai, traits=traits)
         enemy.xp = max(5, (health + attack + defense) // 15)
 
         place(enemy)
@@ -158,13 +159,17 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
         gold + floor * 5,
         ability=ability,
         ai=boss_ai,
+        traits=game.boss_traits.get(name),
     )
     place(boss)
     boss_drop = game.boss_loot.get(name, [])
-    if boss_drop and random.random() < 0.5:
+    if boss_drop:
         loot = random.choice(boss_drop)
         game.queue_message(_(f"✨ The boss dropped a unique weapon: {loot.name}!"))
         place(loot)
+    else:
+        game.queue_message(_("⚡ You absorb residual power (+1 attack)."))
+        game.player.attack_power += 1
 
     place(Item("Key", "A magical key dropped by the boss"))
     companion_options = load_companions()


### PR DESCRIPTION
## Summary
- assign AI weights and traits for each boss
- guarantee boss rewards and grant stat boost when no loot
- implement boss trait behaviour (armored, regenerator, berserker)
- cover new mechanics with tests

## Testing
- `pytest tests/test_boss_loot.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d41520cb08326a1fca4378664f35f