### PR TITLE
feat: add floor events and tests

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -31,6 +31,9 @@ from .events import (
     MiniQuestHookEvent,
     ShrineEvent,
     TrapEvent,
+    ShrineGauntletEvent,
+    PuzzleChamberEvent,
+    EscortMissionEvent,
 )
 from .items import Armor, Item, Trinket, Weapon
 from .plugins import apply_enemy_plugins, apply_item_plugins
@@ -1114,8 +1117,17 @@ class DungeonBase:
             1: self._floor_one_event,
             2: self._floor_two_event,
             3: self._floor_three_event,
+            4: self._floor_four_event,
             5: self._floor_five_event,
+            6: self._floor_six_event,
+            7: self._floor_seven_event,
             8: self._floor_eight_event,
+            9: self._floor_nine_event,
+            10: self._floor_ten_event,
+            11: self._floor_eleven_event,
+            12: self._floor_twelve_event,
+            13: self._floor_thirteen_event,
+            14: self._floor_fourteen_event,
             15: self._floor_fifteen_event,
         }
         if floor in events:
@@ -1139,12 +1151,48 @@ class DungeonBase:
         for __ in range(2):
             random.choice(options)().trigger(self)
 
+    def _floor_four_event(self):
+        print(_("A sealed chamber of puzzles blocks your advance."))
+        PuzzleChamberEvent().trigger(self)
+
     def _floor_five_event(self):
         print(_("A mysterious merchant sets up shop, selling exotic wares."))
+
+    def _floor_six_event(self):
+        print(_("You enter a corridor lined with shrines."))
+        ShrineGauntletEvent().trigger(self)
+
+    def _floor_seven_event(self):
+        print(_("A timid figure begs to be escorted to safety."))
+        EscortMissionEvent().trigger(self)
 
     def _floor_eight_event(self):
         print(_("You stumble upon a radiant shrine, filling you with determination."))
         self.grant_inspiration()
+
+    def _floor_nine_event(self):
+        print(_("Arcane puzzles hum in the air around you."))
+        PuzzleChamberEvent().trigger(self)
+
+    def _floor_ten_event(self):
+        print(_("Shrines test your resolve at every turn."))
+        ShrineGauntletEvent().trigger(self)
+
+    def _floor_eleven_event(self):
+        print(_("A desperate prisoner seeks an escort."))
+        EscortMissionEvent().trigger(self)
+
+    def _floor_twelve_event(self):
+        print(_("You wander into a hall of bewildering puzzles."))
+        PuzzleChamberEvent().trigger(self)
+
+    def _floor_thirteen_event(self):
+        print(_("The shrine gauntlet returns, more daunting than before."))
+        ShrineGauntletEvent().trigger(self)
+
+    def _floor_fourteen_event(self):
+        print(_("A wounded scout pleads for an escort."))
+        EscortMissionEvent().trigger(self)
 
     def _floor_fifteen_event(self):
         print(_("A robed sage blocks your path, offering a riddle challenge."))

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from .items import Item
 from .status_effects import add_status_effect
+from .quests import EscortNPC, EscortQuest
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .dungeon import DungeonBase
@@ -248,3 +249,34 @@ class HazardEvent(BaseEvent):
         damage = random.randint(3, 8)
         game.player.take_damage(damage, source="Environmental Hazard")
         output_func(_(f"Falling debris hits you for {damage} damage."))
+
+
+class ShrineGauntletEvent(BaseEvent):
+    """Confront a sequence of shrines one after another."""
+
+    def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
+        output_func(_("You step into a gauntlet of ancient shrines."))
+        for __ in range(3):
+            ShrineEvent().trigger(game, input_func=input_func, output_func=output_func)
+
+
+class PuzzleChamberEvent(BaseEvent):
+    """Face multiple riddles in a single chamber."""
+
+    def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
+        output_func(_("Runes glow as puzzles surround you."))
+        for __ in range(2):
+            PuzzleEvent().trigger(game, input_func=input_func, output_func=output_func)
+
+
+class EscortMissionEvent(BaseEvent):
+    """Start a quest to escort a fragile NPC to safety."""
+
+    def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
+        if getattr(game, "active_quest", None):
+            output_func(game.active_quest.flavor)
+            return
+        npc = EscortNPC(_("Wayward Acolyte"))
+        quest = EscortQuest(npc, reward=100, flavor=_("Guide the acolyte to the exit."))
+        game.active_quest = quest
+        output_func(_("A fearful acolyte asks for your protection."))

--- a/tests/test_floor_events.py
+++ b/tests/test_floor_events.py
@@ -29,6 +29,7 @@ def test_shops_spawn_every_few_floors():
         patch("dungeoncrawler.dungeon.random.randint", return_value=2),
         patch.object(DungeonBase, "offer_guild", return_value=None),
         patch.object(DungeonBase, "offer_race", return_value=None),
+        patch.object(DungeonBase, "_floor_four_event", return_value=None),
     ):
         dungeon.trigger_floor_event(2)
         assert mock_shop.call_count == 1
@@ -86,3 +87,34 @@ def test_floor_progression_unlocks_features():
     assert dungeon.player.guild == "Warriors' Guild"
     assert dungeon.player.race == "Elf"
     assert called == {"class": True, "guild": True, "race": True}
+
+
+def test_trigger_floor_event_calls_expected_handler():
+    dungeon = setup_dungeon()
+    floor_method_map = {
+        1: "_floor_one_event",
+        2: "_floor_two_event",
+        3: "_floor_three_event",
+        4: "_floor_four_event",
+        5: "_floor_five_event",
+        6: "_floor_six_event",
+        7: "_floor_seven_event",
+        8: "_floor_eight_event",
+        9: "_floor_nine_event",
+        10: "_floor_ten_event",
+        11: "_floor_eleven_event",
+        12: "_floor_twelve_event",
+        13: "_floor_thirteen_event",
+        14: "_floor_fourteen_event",
+        15: "_floor_fifteen_event",
+    }
+    for floor, method in floor_method_map.items():
+        called = False
+
+        def stub(self):
+            nonlocal called
+            called = True
+
+        with patch.object(DungeonBase, method, new=stub):
+            dungeon.trigger_floor_event(floor)
+            assert called, f"{method} not triggered for floor {floor}"


### PR DESCRIPTION
## Summary
- add shrine gauntlet, puzzle chamber, and escort mission events
- expand dungeon floor events to cover floors 1-15
- ensure floor event handler mapping is tested across all floors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d439133b08326939ed71d0fe6e3c3