### PR TITLE
Add map legend toggle to map view

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -873,7 +873,7 @@ class DungeonBase:
             self.renderer.show_message(_("Thanks for playing!"))
             return False
         elif choice == "8":
-            self.render_map()
+            self.view_map()
         elif choice == "9":
             self.view_leaderboard()
         elif config.enable_debug and choice.startswith(":god"):
@@ -1031,6 +1031,17 @@ class DungeonBase:
 
     def render_map(self):
         self.renderer.draw_map(render_map_string(self))
+
+    def view_map(self, input_func=None):
+        if input_func is None:
+            input_func = input if sys.stdin.isatty() else (lambda _: "")
+        while True:
+            self.render_map()
+            response = input_func(_("Press '?' for legend, any other key to exit: ")).strip()
+            if response == "?":
+                self.renderer.toggle_legend()
+                continue
+            break
 
     def handle_room(self, x, y):
         map_module.handle_room(self, x, y)

--- a/dungeoncrawler/ui/terminal.py
+++ b/dungeoncrawler/ui/terminal.py
@@ -92,6 +92,7 @@ class Renderer:
         self.console = Console()
         self.lines: list[str] = []
         self.palette = COLORBLIND_PALETTE if config.colorblind_mode else DEFAULT_PALETTE
+        self.legend_visible = False
         if event_bus is not None and hasattr(event_bus, "subscribe"):
             event_bus.subscribe(self.handle_event)
 
@@ -147,6 +148,23 @@ class Renderer:
             if self.output_func is not print:
                 self.output_func(line)
             self.lines.append(line)
+
+        if self.legend_visible:
+            legend = [
+                _("Legend:"),
+                _(" @ - You"),
+                _(" E - Exit"),
+                _(" . - Floor"),
+                _(" · - Discovered"),
+                _(" # - Unexplored"),
+            ]
+            for entry in legend:
+                self.show_message(entry)
+
+    def toggle_legend(self) -> None:
+        """Toggle display of the map legend."""
+
+        self.legend_visible = not self.legend_visible
 
 
 # Public API

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -49,3 +49,27 @@ def test_render_map_symbols_after_show_map():
     assert "." in rendered
     assert "#" in rendered
     assert rendered.count("@") == 1
+
+
+def test_map_legend_toggle():
+    random.seed(0)
+    load_floor_configs()
+    game = DungeonBase(1, 1)
+    game.player = Player("Tester")
+    dungeon_map.generate_dungeon(game, floor=1)
+
+    inputs = iter(["?", "?", "x"])
+    game.view_map(input_func=lambda _: next(inputs))
+
+    legend_entries = [
+        "Legend:",
+        " @ - You",
+        " E - Exit",
+        " . - Floor",
+        " · - Discovered",
+        " # - Unexplored",
+    ]
+    for entry in legend_entries:
+        assert entry in game.renderer.lines
+    assert game.renderer.lines.count("Legend:") == 1
+    assert not game.renderer.legend_visible


### PR DESCRIPTION
## Summary
- allow toggling map legend with `?` in terminal renderer
- add map-view loop capturing `?` to show/hide legend
- cover legend toggling with dedicated unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d44dd9ff88326a8edf64780bf40f6