### PR TITLE
Add generic telegraphs for floor enemies

### DIFF
--- a/dungeoncrawler/ai.py
+++ b/dungeoncrawler/ai.py
@@ -1,4 +1,6 @@
+import json
 import random
+from pathlib import Path
 
 
 class AggressiveAI:
@@ -94,6 +96,25 @@ class IntentAI:
 
     # Backwards compatibility for older saves/tests
     plan_next = choose_intent
+
+
+# Extend telegraphs for enemies defined in floors.json
+try:
+    _floors_path = Path(__file__).resolve().parents[1] / "data" / "floors.json"
+    with _floors_path.open() as _f:
+        _floors = json.load(_f)
+    for _cfg in _floors.values():
+        for _name in _cfg.get("enemies", []):
+            IntentAI.TELEGRAPHS.setdefault(
+                _name,
+                {
+                    "aggressive": f"{_name} prepares a vicious strike.",
+                    "defensive": f"{_name} braces for incoming attacks.",
+                    "unpredictable": f"{_name} shifts unpredictably.",
+                },
+            )
+except FileNotFoundError:
+    pass
 
 
 # Default archetype weights for enemies that use IntentAI

--- a/tests/test_telegraphs.py
+++ b/tests/test_telegraphs.py
@@ -1,0 +1,27 @@
+import json
+from dungeoncrawler.ai import IntentAI
+
+
+class DummyEnemy:
+    def __init__(self, name):
+        self.name = name
+        self.health = 10
+        self.max_health = 10
+        self.status_effects = {}
+        self.heavy_cd = 0
+
+
+def test_floor_enemies_have_custom_telegraphs():
+    with open('data/floors.json') as f:
+        floors = json.load(f)
+    enemies = set()
+    for cfg in floors.values():
+        enemies.update(cfg['enemies'])
+
+    ai = IntentAI(aggressive=1, defensive=0, unpredictable=0)
+    for name in enemies:
+        dummy = DummyEnemy(name)
+        _action, msg = ai.choose_intent(dummy, dummy)
+        default = f"The {name} winds up for a heavy strike…"
+        assert msg and msg != default
+


### PR DESCRIPTION
## Summary
- Auto-populate IntentAI telegraphs for every enemy listed in floors.json
- Verify via unit test that each floor enemy emits a custom telegraph

## Testing
- `pytest tests/test_telegraphs.py -q`
- `pytest tests/test_core_intents.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4636206c83269107feb825465ac5