### PR TITLE
Fix fountain event handling for 'q' input

### DIFF
--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -131,7 +131,7 @@ class FountainEvent(BaseEvent):
         while self.remaining_uses > 0:
             output_func(_("Drink (D) / Bottle (B) / Leave (any other key)"))
             choice = input_func(_("Choice: ")).strip().lower()
-            if choice in ("d", "q"):
+            if choice == "d":
                 heal = random.randint(6, 10)
                 game.player.health = min(game.player.max_health, game.player.health + heal)
                 output_func(_(f"You feel refreshed and recover {heal} health."))

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -103,6 +103,19 @@ def test_fountain_event_bottle_adds_item():
     assert event.remaining_uses == 1
 
 
+def test_fountain_event_q_leaves_untouched():
+    game = setup_game()
+    game.player.health = 50
+    event = FountainEvent()
+    event.trigger(
+        game,
+        input_func=lambda _: "q",
+        output_func=lambda _msg: None,
+    )
+    assert game.player.health == 50
+    assert event.remaining_uses == 2
+
+
 def test_random_event_selection_from_floor_config():
     game = setup_game()
     with (


### PR DESCRIPTION
## Summary
- Ensure fountain events do not treat 'q' as a drink action
- Add regression test for 'q' input leaving the fountain untouched

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d475f9fa08326b93a221d320aaaf1