### PR TITLE
feat: add unique bosses and guaranteed loot

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ statistics, inventory, equipped weapon and companions. High scores are stored in
 - Expanded guild and race options featuring groups such as the Healers'
   Circle or Shadow Brotherhood and races like Tiefling, Dragonborn and
   Goblin.
-- Every floor culminates in a boss battle with a distinctive mechanic and a
-  guaranteed reward such as rare loot or a permanent stat boost.
+- Every floor culminates in a unique boss battle. Bosses telegraph their
+  attacks and defeating one grants the entire reward table for that encounter.
 - Each floor also features a unique special event—like a shrine gauntlet,
   puzzle chamber or escort mission—to break up the routine of boss fights.
 - Floors grow in size and feature unique enemy and boss sets.

--- a/data/bosses.json
+++ b/data/bosses.json
@@ -208,5 +208,173 @@
         "price": 0
       }
     ]
+  },
+  {
+    "name": "Arcane Sentinel",
+    "stats": [
+      300,
+      40,
+      18,
+      170
+    ],
+    "ai": {"aggressive": 3, "defensive": 2, "unpredictable": 1},
+    "traits": ["armored"],
+    "ability": "burn",
+    "loot": [
+      {
+        "name": "Arcblade",
+        "description": "Sword humming with arcane energy.",
+        "min_damage": 27,
+        "max_damage": 35,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Blight Matron",
+    "stats": [
+      305,
+      39,
+      18,
+      172
+    ],
+    "ai": {"aggressive": 2, "defensive": 2, "unpredictable": 2},
+    "traits": ["regenerator"],
+    "ability": "poison",
+    "loot": [
+      {
+        "name": "Toxic Scepter",
+        "description": "Staff dripping with virulent slime.",
+        "min_damage": 25,
+        "max_damage": 33,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Chaos Djinn",
+    "stats": [
+      310,
+      41,
+      19,
+      175
+    ],
+    "ai": {"aggressive": 3, "defensive": 1, "unpredictable": 3},
+    "traits": ["berserker"],
+    "ability": "double_strike",
+    "loot": [
+      {
+        "name": "Chaotic Censer",
+        "description": "Incense burner that spills volatile magic.",
+        "min_damage": 26,
+        "max_damage": 34,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Dread Colossus",
+    "stats": [
+      315,
+      42,
+      20,
+      180
+    ],
+    "ai": {"aggressive": 2, "defensive": 3, "unpredictable": 1},
+    "traits": ["armored"],
+    "ability": "lifesteal",
+    "loot": [
+      {
+        "name": "Colossal Hammer",
+        "description": "Hammer that shakes the earth with each swing.",
+        "min_damage": 28,
+        "max_damage": 36,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Ethereal Harvester",
+    "stats": [
+      320,
+      43,
+      20,
+      185
+    ],
+    "ai": {"aggressive": 3, "defensive": 2, "unpredictable": 2},
+    "traits": ["regenerator"],
+    "ability": "burn",
+    "loot": [
+      {
+        "name": "Soul Reap Scythe",
+        "description": "Scythe that harvests the essence of foes.",
+        "min_damage": 27,
+        "max_damage": 35,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Feral Juggernaut",
+    "stats": [
+      325,
+      44,
+      21,
+      190
+    ],
+    "ai": {"aggressive": 4, "defensive": 1, "unpredictable": 2},
+    "traits": ["berserker"],
+    "ability": "double_strike",
+    "loot": [
+      {
+        "name": "Savage Maul",
+        "description": "Brutal maul that rends armor with ease.",
+        "min_damage": 29,
+        "max_damage": 37,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Gloom Shade",
+    "stats": [
+      330,
+      45,
+      21,
+      195
+    ],
+    "ai": {"aggressive": 2, "defensive": 1, "unpredictable": 4},
+    "traits": ["armored"],
+    "ability": "poison",
+    "loot": [
+      {
+        "name": "Night Veil",
+        "description": "Cloak woven from solid darkness.",
+        "min_damage": 25,
+        "max_damage": 33,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Hex King",
+    "stats": [
+      335,
+      46,
+      22,
+      200
+    ],
+    "ai": {"aggressive": 3, "defensive": 2, "unpredictable": 3},
+    "traits": ["regenerator"],
+    "ability": "freeze",
+    "loot": [
+      {
+        "name": "Cursed Scepter",
+        "description": "Scepter pulsing with hexed power.",
+        "min_damage": 28,
+        "max_damage": 36,
+        "price": 0
+      }
+    ]
   }
 ]

--- a/data/floors.json
+++ b/data/floors.json
@@ -34,8 +34,7 @@
       "Bandit"
     ],
     "bosses": [
-      "Inferno Golem",
-      "Frost Warden"
+      "Inferno Golem"
     ],
     "places": {
       "Trap": 3,
@@ -57,8 +56,7 @@
       "Werewolf"
     ],
     "bosses": [
-      "Shadow Reaver",
-      "Doom Bringer"
+      "Shadow Reaver"
     ],
     "places": {
       "Trap": 3,
@@ -80,9 +78,7 @@
       "Lich"
     ],
     "bosses": [
-      "Void Serpent",
-      "Ember Lord",
-      "Glacier Fiend"
+      "Void Serpent"
     ],
     "places": {
       "Trap": 4,
@@ -104,8 +100,7 @@
       "Beholder"
     ],
     "bosses": [
-      "Grave Monarch",
-      "Storm Reaper"
+      "Grave Monarch"
     ],
     "places": {
       "Trap": 4,
@@ -127,8 +122,7 @@
       "Shade"
     ],
     "bosses": [
-      "Bone Tyrant",
-      "Inferno Golem"
+      "Frost Warden"
     ],
     "places": {
       "Trap": 5,
@@ -150,8 +144,7 @@
       "Gargoyle"
     ],
     "bosses": [
-      "Frost Warden",
-      "Shadow Reaver"
+      "Ember Lord"
     ],
     "places": {
       "Trap": 5,
@@ -173,8 +166,7 @@
       "Werewolf"
     ],
     "bosses": [
-      "Doom Bringer",
-      "Void Serpent"
+      "Glacier Fiend"
     ],
     "places": {
       "Trap": 5,
@@ -196,8 +188,7 @@
       "Warlock"
     ],
     "bosses": [
-      "Ember Lord",
-      "Glacier Fiend"
+      "Storm Reaper"
     ],
     "places": {
       "Trap": 6,
@@ -219,8 +210,7 @@
       "Minotaur"
     ],
     "bosses": [
-      "Grave Monarch",
-      "Storm Reaper"
+      "Doom Bringer"
     ],
     "places": {
       "Trap": 6,
@@ -242,9 +232,7 @@
       "Shade"
     ],
     "bosses": [
-      "Bone Tyrant",
-      "Inferno Golem",
-      "Frost Warden"
+      "Arcane Sentinel"
     ],
     "places": {
       "Trap": 7,
@@ -266,9 +254,7 @@
       "Warlock"
     ],
     "bosses": [
-      "Shadow Reaver",
-      "Doom Bringer",
-      "Void Serpent"
+      "Blight Matron"
     ],
     "places": {
       "Trap": 7,
@@ -290,9 +276,7 @@
       "Lich"
     ],
     "bosses": [
-      "Ember Lord",
-      "Glacier Fiend",
-      "Grave Monarch"
+      "Chaos Djinn"
     ],
     "places": {
       "Trap": 8,
@@ -314,7 +298,7 @@
       "Dark Knight"
     ],
     "bosses": [
-      "Storm Reaper"
+      "Dread Colossus"
     ],
     "places": {
       "Trap": 8,
@@ -336,8 +320,7 @@
       "Minotaur"
     ],
     "bosses": [
-      "Doom Bringer",
-      "Void Serpent"
+      "Ethereal Harvester"
     ],
     "places": {
       "Trap": 9,
@@ -359,8 +342,7 @@
       "Giant Spider"
     ],
     "bosses": [
-      "Ember Lord",
-      "Glacier Fiend"
+      "Feral Juggernaut"
     ],
     "places": {
       "Trap": 9,
@@ -382,8 +364,7 @@
       "Warlock"
     ],
     "bosses": [
-      "Grave Monarch",
-      "Storm Reaper"
+      "Gloom Shade"
     ],
     "places": {
       "Trap": 9,
@@ -405,9 +386,7 @@
       "Dark Knight"
     ],
     "bosses": [
-      "Bone Tyrant",
-      "Doom Bringer",
-      "Void Serpent"
+      "Hex King"
     ],
     "places": {
       "Trap": 10,

--- a/docs/gameplay_guide.rst
+++ b/docs/gameplay_guide.rst
@@ -26,11 +26,10 @@ and the *Infernal resistance* trait, whereas Dragonborn receive +2 health,
 
 Boss Encounters
 ---------------
-Each floor culminates in a boss battle. Every boss showcases a distinctive
-mechanic—such as a channelled nuke that must be interrupted, a summoner that
-spawns adds, or a teleporting assassin—to keep encounters fresh. Defeating a
-boss always grants a guaranteed reward like rare loot, a permanent stat boost,
-or a choice of upgrades.
+Each floor culminates in a boss battle against a foe unique to that level.
+Bosses telegraph their intentions so observant players can react to heavy
+attacks or defensive postures. Defeating a boss now awards the entire loot
+table associated with that encounter, guaranteeing meaningful rewards.
 
 Special Events
 --------------

--- a/dungeoncrawler/ai.py
+++ b/dungeoncrawler/ai.py
@@ -123,3 +123,99 @@ ARCHETYPES = {
     "Beetle": {"aggressive": 1, "defensive": 3, "unpredictable": 1},
     "Acolyte": {"aggressive": 2, "defensive": 1, "unpredictable": 2},
 }
+
+# Telegraphs for bosses to foreshadow their unique mechanics
+IntentAI.TELEGRAPHS.update(
+    {
+        "Bone Tyrant": {
+            "aggressive": "Bone Tyrant hefts its club for a crushing blow.",
+            "defensive": "Bone Tyrant knits stray bones into a shield.",
+            "unpredictable": "Bone Tyrant rattles erratically, bones spiraling.",
+        },
+        "Inferno Golem": {
+            "aggressive": "Inferno Golem's core flares for a magma punch.",
+            "defensive": "Inferno Golem's lava skin hardens into rock.",
+            "unpredictable": "Flames dance wildly around the Inferno Golem.",
+        },
+        "Shadow Reaver": {
+            "aggressive": "Shadow Reaver fades then lunges from the darkness.",
+            "defensive": "Shadow Reaver cloaks itself in shadow.",
+            "unpredictable": "Shadow Reaver flickers unpredictably.",
+        },
+        "Void Serpent": {
+            "aggressive": "Void Serpent coils, void energy crackling.",
+            "defensive": "Void Serpent slips into an ethereal stance.",
+            "unpredictable": "Void Serpent warps space erratically.",
+        },
+        "Grave Monarch": {
+            "aggressive": "Grave Monarch raises its scythe for a soul-cleaving arc.",
+            "defensive": "Grave Monarch summons tombstone shields.",
+            "unpredictable": "Grave Monarch mutters necrotic rites unpredictably.",
+        },
+        "Frost Warden": {
+            "aggressive": "Frost Warden gathers icy winds for a chilling strike.",
+            "defensive": "Frost Warden encases itself in ice.",
+            "unpredictable": "Frost Warden's blizzard swirls unpredictably.",
+        },
+        "Ember Lord": {
+            "aggressive": "Ember Lord ignites embers for a blazing lash.",
+            "defensive": "Ember Lord surrounds itself with a ring of fire.",
+            "unpredictable": "Sparks whirl erratically around the Ember Lord.",
+        },
+        "Glacier Fiend": {
+            "aggressive": "Glacier Fiend raises frozen claws for a heavy swing.",
+            "defensive": "Glacier Fiend reinforces its icy hide.",
+            "unpredictable": "Glacier Fiend crackles, ice shards darting.",
+        },
+        "Storm Reaper": {
+            "aggressive": "Storm Reaper crackles with lightning, ready to cleave.",
+            "defensive": "Storm Reaper channels static into a barrier.",
+            "unpredictable": "Storm Reaper's aura flickers with erratic sparks.",
+        },
+        "Doom Bringer": {
+            "aggressive": "Doom Bringer roars, axe poised for devastation.",
+            "defensive": "Doom Bringer braces behind its massive axe.",
+            "unpredictable": "Doom Bringer's stance shifts unpredictably.",
+        },
+        "Arcane Sentinel": {
+            "aggressive": "Arcane Sentinel charges a beam of raw energy.",
+            "defensive": "Arcane Sentinel conjures a shimmering ward.",
+            "unpredictable": "Arcane Sentinel's runes flare unpredictably.",
+        },
+        "Blight Matron": {
+            "aggressive": "Blight Matron readies a venomous lash.",
+            "defensive": "Blight Matron oozes toxins as a protective veil.",
+            "unpredictable": "Blight Matron's spores drift unpredictably.",
+        },
+        "Chaos Djinn": {
+            "aggressive": "Chaos Djinn whirls up a storm of blades.",
+            "defensive": "Chaos Djinn twists into a protective whirlwind.",
+            "unpredictable": "Chaos Djinn's form distorts unpredictably.",
+        },
+        "Dread Colossus": {
+            "aggressive": "Dread Colossus raises its hammer for a quake.",
+            "defensive": "Dread Colossus plants its feet, stone skin thickening.",
+            "unpredictable": "Dread Colossus lurches in unpredictable stomps.",
+        },
+        "Ethereal Harvester": {
+            "aggressive": "Ethereal Harvester sweeps its scythe in a ghostly arc.",
+            "defensive": "Ethereal Harvester fades partially out of phase.",
+            "unpredictable": "Ethereal Harvester flickers between realms.",
+        },
+        "Feral Juggernaut": {
+            "aggressive": "Feral Juggernaut snarls, muscles bulging for a charge.",
+            "defensive": "Feral Juggernaut hunkers down, hide toughening.",
+            "unpredictable": "Feral Juggernaut paces erratically.",
+        },
+        "Gloom Shade": {
+            "aggressive": "Gloom Shade reaches out with grasping darkness.",
+            "defensive": "Gloom Shade melds with surrounding shadows.",
+            "unpredictable": "Gloom Shade's silhouette warps unpredictably.",
+        },
+        "Hex King": {
+            "aggressive": "Hex King chants a ruinous spell.",
+            "defensive": "Hex King weaves a lattice of cursed sigils.",
+            "unpredictable": "Hex King's curses spiral unpredictably.",
+        },
+    }
+)

--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -223,9 +223,9 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
     if not enemy.is_alive():
         game.announce(f"{enemy.name} has been defeated!")
         if enemy.name in game.boss_loot:
-            loot = random.choice(game.boss_loot[enemy.name])
-            player.collect_item(loot)
-            renderer.show_message(_(f"The {enemy.name} dropped {loot.name}!"))
-            game.announce(_(f"{player.name} obtains {loot.name}!"))
+            for loot in game.boss_loot[enemy.name]:
+                player.collect_item(loot)
+                renderer.show_message(_(f"The {enemy.name} dropped {loot.name}!"))
+                game.announce(_(f"{player.name} obtains {loot.name}!"))
     game.stats_logger.battle_end(player.is_alive(), enemy.name)
     game.check_quest_progress()

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -172,9 +172,9 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
         place(boss)
         boss_drop = game.boss_loot.get(name, [])
         if boss_drop:
-            loot = random.choice(boss_drop)
-            game.queue_message(_(f"✨ The boss dropped a unique weapon: {loot.name}!"))
-            place(loot)
+            for loot in boss_drop:
+                game.queue_message(_(f"✨ The boss dropped a unique weapon: {loot.name}!"))
+                place(loot)
         else:
             game.queue_message(_("⚡ You absorb residual power (+1 attack)."))
             game.player.attack_power += 1

--- a/tests/test_telegraphs.py
+++ b/tests/test_telegraphs.py
@@ -25,3 +25,14 @@ def test_floor_enemies_have_custom_telegraphs():
         default = f"The {name} winds up for a heavy strike…"
         assert msg and msg != default
 
+
+def test_bosses_have_custom_telegraphs():
+    from dungeoncrawler.dungeon import BOSS_STATS
+
+    ai = IntentAI(aggressive=1, defensive=0, unpredictable=0)
+    for name in BOSS_STATS:
+        dummy = DummyEnemy(name)
+        _action, msg = ai.choose_intent(dummy, dummy)
+        default = f"The {name} winds up for a heavy strike…"
+        assert msg and msg != default
+


### PR DESCRIPTION
## Summary
- Give every floor a distinct boss with bespoke telegraphs
- Ensure bosses drop their full reward table instead of a single item
- Document and test boss telegraph behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d4eabe5f88326ba02e6f36684e7de