### PR TITLE
Fix flake8 errors by cleaning imports

### DIFF
--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import random
 from gettext import gettext as _
 from typing import TYPE_CHECKING
 

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -26,6 +26,7 @@ from .entities import SKILL_DEFS, Companion, Enemy, Player
 from .items import Armor, Item, Trinket, Weapon
 from .plugins import apply_enemy_plugins, apply_item_plugins
 from .quests import EscortNPC, EscortQuest, FetchQuest, HuntQuest
+from .events import CacheEvent
 from .rendering import Renderer, render_map_string
 from .stats_logger import StatsLogger
 


### PR DESCRIPTION
## Summary
- remove unused `random` import from combat module
- import `CacheEvent` in dungeon generator to reference event class

## Testing
- `flake8 . --count`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5c369d48832697f2ade8f665c2fb