### PR TITLE
Add weighted enemy intent system with telegraphed actions

### DIFF
--- a/dungeoncrawler/ai.py
+++ b/dungeoncrawler/ai.py
@@ -64,14 +64,16 @@ class IntentAI:
 
         Returns
         -------
-        tuple[str, str]
-            A pair ``(action, message)`` describing what the enemy will do on
-            its next turn and the text used to foreshadow that intent.
+        tuple[str, str, str]
+            ``(action, intent, message)`` describing what the enemy will do on
+            its next turn, the intent category (``"Aggressive"``,
+            ``"Defensive"`` or ``"Unpredictable"``) and the text used to
+            foreshadow that intent.
         """
 
         intents = list(self.weights.keys())
         weights = list(self.weights.values())
-        intent = random.choices(intents, weights=weights, k=1)[0]
+        intent_key = random.choices(intents, weights=weights, k=1)[0]
 
         # Map intents to actions and default telegraphs
         action = "attack"
@@ -79,20 +81,21 @@ class IntentAI:
             "aggressive": f"The {enemy.name} winds up for a heavy strike…",
             "defensive": f"The {enemy.name} raises its guard.",
             "unpredictable": f"The {enemy.name} wavers unpredictably…",
-        }[intent]
+        }[intent_key]
 
-        if intent == "aggressive" and getattr(enemy, "heavy_cd", 0) == 0:
+        if intent_key == "aggressive" and getattr(enemy, "heavy_cd", 0) == 0:
             action = "heavy_attack"
-        elif intent == "defensive" and enemy.health <= enemy.max_health // 3:
+        elif intent_key == "defensive" and enemy.health <= enemy.max_health // 3:
             action = "defend"
-        elif intent == "unpredictable":
+        elif intent_key == "unpredictable":
             action = random.choice(["wild_attack", "defend"])
 
         # Custom telegraphs for specific enemy archetypes
         telegraphs = self.TELEGRAPHS.get(enemy.name, {})
-        message = telegraphs.get(intent, message)
+        message = telegraphs.get(intent_key, message)
 
-        return action, message
+        intent = intent_key.capitalize()
+        return action, intent, message
 
     # Backwards compatibility for older saves/tests
     plan_next = choose_intent

--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -49,9 +49,10 @@ def enemy_turn(enemy: "Enemy", player: "Player", renderer: Renderer | None = Non
             for event in events:
                 renderer.handle_event(event)
         if enemy.ai and hasattr(enemy.ai, "choose_intent"):
-            enemy.next_action, enemy.intent_message = enemy.ai.choose_intent(enemy, player)
+            enemy.next_action, enemy.intent, enemy.intent_message = enemy.ai.choose_intent(enemy, player)
         else:
             enemy.next_action = None
+            enemy.intent = None
             enemy.intent_message = ""
         if enemy.heavy_cd > 0:
             enemy.heavy_cd -= 1
@@ -79,7 +80,7 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
         )
     )
     if enemy.ai and hasattr(enemy.ai, "choose_intent"):
-        enemy.next_action, enemy.intent_message = enemy.ai.choose_intent(enemy, player)
+        enemy.next_action, enemy.intent, enemy.intent_message = enemy.ai.choose_intent(enemy, player)
     game.announce(f"{player.name} engages {enemy.name}!")
     while player.is_alive() and enemy.is_alive():
         skip_player = player.apply_status_effects()
@@ -100,6 +101,8 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
         renderer.show_message(
             _(f"Enemy Health: {enemy.health} {format_status_tags(enemy.status_effects)}")
         )
+        if enemy.intent:
+            renderer.show_message(_(f"Intent: {enemy.intent}"))
         if enemy.intent_message:
             renderer.show_message(_(enemy.intent_message))
         renderer.show_message(_(f"Stamina: {player.stamina}/{player.max_stamina}"))

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -686,6 +686,7 @@ class Enemy(Entity):
         self.traits = traits or []
         # Intent planning and cooldowns
         self.next_action = None
+        self.intent = None
         self.intent_message = ""
         self.heavy_cd = 0
 
@@ -721,6 +722,7 @@ class Enemy(Entity):
     def take_turn(self, player):
         action = self.next_action
         self.next_action = None
+        self.intent = None
         if action is None:
             if self.ai:
                 action = self.ai.choose_action(self, player)

--- a/tests/test_intent_system.py
+++ b/tests/test_intent_system.py
@@ -1,0 +1,23 @@
+import random
+from dungeoncrawler.ai import IntentAI
+from dungeoncrawler.entities import Enemy
+
+
+class DummyPlayer:
+    def __init__(self):
+        self.status_effects = {}
+
+
+def test_intent_field_and_delayed_resolution():
+    random.seed(0)
+    player = DummyPlayer()
+    ai = IntentAI(aggressive=0, defensive=1, unpredictable=0)
+    enemy = Enemy("Goblin", 9, 5, 0, 0, ai=ai)
+    enemy.health = 3  # ensure defensive intent triggers defend
+    action, intent, msg = enemy.ai.choose_intent(enemy, player)
+    enemy.next_action, enemy.intent, enemy.intent_message = action, intent, msg
+    assert enemy.intent == "Defensive"
+    assert action == "defend"
+    enemy.take_turn(player)
+    assert "shield" in enemy.status_effects
+    assert enemy.intent is None

--- a/tests/test_telegraphs.py
+++ b/tests/test_telegraphs.py
@@ -22,7 +22,7 @@ def test_floor_enemies_have_custom_telegraphs():
     ai = IntentAI(aggressive=1, defensive=0, unpredictable=0)
     for name in enemies:
         dummy = DummyEnemy(name)
-        _action, msg = ai.choose_intent(dummy, dummy)
+        _action, _intent, msg = ai.choose_intent(dummy, dummy)
         default = f"The {name} winds up for a heavy strike…"
         assert msg and msg != default
 
@@ -33,6 +33,6 @@ def test_bosses_have_custom_telegraphs():
     ai = IntentAI(aggressive=1, defensive=0, unpredictable=0)
     for name in BOSS_STATS:
         dummy = DummyEnemy(name)
-        _action, msg = ai.choose_intent(dummy, dummy)
+        _action, _intent, msg = ai.choose_intent(dummy, dummy)
         default = f"The {name} winds up for a heavy strike…"
         assert msg and msg != default


### PR DESCRIPTION
## Summary
- Track enemy behaviour intent (Aggressive, Defensive, Unpredictable) alongside planned action
- Show upcoming intent in combat and resolve planned actions after a one-turn delay
- Cover intent selection and execution with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5dbc69e48326b28f19556a18b365