### PR TITLE
Add runtime configuration menu and default config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ profile_default/
 # Temporary Save Files
 savegame.json
 scores.json
-config.json
 
 # OS generated files
 .DS_Store

--- a/config.json
+++ b/config.json
@@ -1,0 +1,16 @@
+{
+  "save_file": "savegame.json",
+  "score_file": "scores.json",
+  "max_floors": 18,
+  "screen_width": 10,
+  "screen_height": 10,
+  "verbose_combat": false,
+  "slow_messages": false,
+  "key_repeat_delay": 0.5,
+  "colorblind_mode": false,
+  "trap_chance": 0.1,
+  "enemy_hp_mult": 1.0,
+  "enemy_dmg_mult": 1.0,
+  "loot_mult": 1.0,
+  "enable_debug": false
+}

--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -11,7 +11,7 @@ import json
 from gettext import gettext as _
 
 from . import tutorial
-from .config import Config, load_config
+from .config import Config, load_config, settings_menu
 from .constants import RUN_FILE
 from .dungeon import DungeonBase
 from .entities import SKILL_DEFS, Player
@@ -166,6 +166,9 @@ def main(argv=None, input_func=input, output_func=print, cfg: Config | None = No
     set_language(args.lang)
 
     cfg = cfg or load_config()
+    change = input_func(_("Adjust settings? (y/n): ")).strip().lower()
+    if change == "y":
+        cfg = settings_menu(cfg, input_func=input_func, output_func=output_func)
     game = DungeonBase(cfg.screen_width, cfg.screen_height)
     cont = input_func(_("Load existing save? (y/n): ")).strip().lower()
     if cont == "y":

--- a/tests/test_settings_menu.py
+++ b/tests/test_settings_menu.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+from dungeoncrawler.config import Config, load_config, settings_menu
+
+
+def test_settings_menu_updates_and_saves(tmp_path):
+    cfg = Config()
+    cfg_file = tmp_path / "config.json"
+
+    inputs = iter(["12", "8", "0.2", "1.5", "1.2", "1.3", "y"])
+    outputs = []
+
+    def fake_input(_prompt: str) -> str:
+        return next(inputs)
+
+    def fake_output(msg: str) -> None:
+        outputs.append(msg)
+
+    new_cfg = settings_menu(
+        cfg, path=cfg_file, input_func=fake_input, output_func=fake_output
+    )
+    assert new_cfg.screen_width == 12
+    assert new_cfg.screen_height == 8
+    assert new_cfg.trap_chance == 0.2
+    assert new_cfg.enemy_hp_mult == 1.5
+    assert new_cfg.enemy_dmg_mult == 1.2
+    assert new_cfg.loot_mult == 1.3
+    assert new_cfg.colorblind_mode is True
+
+    loaded = load_config(cfg_file)
+    assert loaded.screen_width == 12
+    assert loaded.colorblind_mode is True

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -32,10 +32,10 @@ def test_tutorial_runs_once_per_save(tmp_path, monkeypatch):
 
     monkeypatch.setattr(DungeonBase, "play_game", fake_play_game)
 
-    inputs = iter(["n", "Alice"])
+    inputs = iter(["n", "n", "Alice"])
     main([], input_func=lambda _: next(inputs), output_func=lambda _msg: None)
     assert len(calls) == 1
 
-    inputs = iter(["y"])
+    inputs = iter(["n", "y"])
     main([], input_func=lambda _: next(inputs), output_func=lambda _msg: None)
     assert len(calls) == 1


### PR DESCRIPTION
## Summary
- include a default `config.json` with screen, trap, enemy and loot settings
- add configuration menu with saving capability at game start
- cover configuration menu with tests and adjust tutorial flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5f6058b88326abd6057be6c6e049