### PR TITLE
Remove unused imports from settings menu test

### DIFF
--- a/tests/test_settings_menu.py
+++ b/tests/test_settings_menu.py
@@ -1,6 +1,3 @@
-import json
-from pathlib import Path
-
 from dungeoncrawler.config import Config, load_config, settings_menu
 
 


### PR DESCRIPTION
## Summary
- tidy up settings menu test by removing unused json and pathlib imports

## Testing
- `flake8 .`
- `pytest tests/test_settings_menu.py::test_settings_menu_updates_and_saves -q`


------
https://chatgpt.com/codex/tasks/task_e_689d64cce72c8326b5360f8255f1620b