### PR TITLE
Add quest tracking UI and Escort NPC dataclass

### DIFF
--- a/dungeoncrawler/quests.py
+++ b/dungeoncrawler/quests.py
@@ -52,14 +52,20 @@ class HuntQuest(Quest):
         return f"{self.description} ({'done' if self.is_complete(game) else 'alive'})"
 
 
+@dataclass
 class EscortNPC:
-    """Passive NPC used for escort quests."""
+    """Passive NPC used for escort quests.
 
-    def __init__(self, name: str):
-        self.name = name
-        self.x = 0
-        self.y = 0
-        self.following = False
+    The NPC only tracks its position within the dungeon and whether it has
+    started following the player.  Using a dataclass keeps the implementation
+    lightweight while still providing a clear structure for the test-suite to
+    interact with.
+    """
+
+    name: str
+    x: int = 0
+    y: int = 0
+    following: bool = False
 
 
 class EscortQuest(Quest):

--- a/dungeoncrawler/ui/terminal.py
+++ b/dungeoncrawler/ui/terminal.py
@@ -128,10 +128,22 @@ class Renderer:
         table.add_row("Gold", str(player.gold))
         table.add_row("Level", str(player.level))
         table.add_row("Floor", str(game_state.current_floor))
+
+        # Include quest progress if one is active.  ``Quest`` objects provide a
+        # :meth:`status` method which returns a human readable summary.
+        quest = getattr(game_state, "active_quest", None)
+        if quest is not None:
+            quest_status = quest.status(game_state)
+            table.add_row("Quest", quest_status)
+        else:
+            quest_status = _("None")
+            table.add_row("Quest", quest_status)
+
         self.console.print(table)
         status = _(
             f"Health: {player.health}/{player.max_health} | STA: {player.stamina}/{player.max_stamina} | "
-            f"XP: {player.xp} | Gold: {player.gold} | Level: {player.level} | Floor: {game_state.current_floor}"
+            f"XP: {player.xp} | Gold: {player.gold} | Level: {player.level} | Floor: {game_state.current_floor} | "
+            f"Quest: {quest_status}"
         )
         if self.output_func is not print:
             self.output_func(status)


### PR DESCRIPTION
## Summary
- Convert EscortNPC to a dataclass and document its purpose
- Extend terminal renderer to display active quest progress in status view

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d64949e1483268d1fa7626a4a92ae