### PR TITLE
Add battle simulation CLI for balance testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,16 @@ game = DungeonBase(10, 10)
 game.player = player
 game.play_game()
 ```
+
+## Balance Simulation
+
+A small command-line helper can simulate combat to aid balance testing. Run it
+against any enemy archetype and tweak the player's stats to model different
+classes:
+
+```bash
+python -m dungeoncrawler.sim Bandit --runs 100 --player-health 40 --player-attack 10
+```
+
+The script reports the win rate and average number of turns taken. The same
+interface is available via `scripts/simulate_battles.py`.

--- a/dungeoncrawler/sim.py
+++ b/dungeoncrawler/sim.py
@@ -2,18 +2,39 @@
 
 from __future__ import annotations
 
+import argparse
 import random
-from typing import Dict
+from typing import Dict, Mapping
 
 from .core.combat import resolve_enemy_turn, resolve_player_action
 from .core.entity import Entity
 from .dungeon import ENEMY_STATS
 
 
-def simulate_battles(enemy_name: str, runs: int, seed: int | None = None) -> Dict[str, float]:
+def simulate_battles(
+    enemy_name: str,
+    runs: int,
+    seed: int | None = None,
+    player_stats: Mapping[str, int] | None = None,
+) -> Dict[str, float]:
     """Simulate ``runs`` battles against ``enemy_name``.
 
-    Returns a dictionary with ``winrate`` and ``avg_turns``.
+    Parameters
+    ----------
+    enemy_name:
+        Name of the enemy archetype to fight.
+    runs:
+        Number of battles to simulate.
+    seed:
+        Optional seed for deterministic results.
+    player_stats:
+        Optional mapping defining the player's ``health``, ``attack`` and
+        ``speed`` values. Defaults to a basic hero profile.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``winrate`` and ``avg_turns``.
     """
 
     rng = random.Random(seed)
@@ -22,8 +43,11 @@ def simulate_battles(enemy_name: str, runs: int, seed: int | None = None) -> Dic
     hp_min, hp_max, atk_min, atk_max, defense = ENEMY_STATS[enemy_name]
     wins = 0
     total_turns = 0
+    base_player = {"health": 30, "attack": 8, "speed": 10}
+    if player_stats:
+        base_player.update(player_stats)
     for _ in range(runs):
-        player = Entity("Hero", {"health": 30, "attack": 8, "speed": 10})
+        player = Entity("Hero", base_player.copy())
         enemy = Entity(
             enemy_name,
             {
@@ -47,3 +71,30 @@ def simulate_battles(enemy_name: str, runs: int, seed: int | None = None) -> Dic
     winrate = wins / runs if runs else 0
     avg_turns = total_turns / wins if wins else 0
     return {"winrate": winrate, "avg_turns": avg_turns}
+
+
+def main() -> None:
+    """Command line entry point for quick balance simulations."""
+
+    parser = argparse.ArgumentParser(description="Simulate battles against a given enemy.")
+    parser.add_argument("enemy", help="Enemy name to fight")
+    parser.add_argument("--runs", type=int, default=100, help="Number of battles to simulate")
+    parser.add_argument("--seed", type=int, default=None, help="Optional seed for deterministic results")
+    parser.add_argument("--player-health", type=int, default=30, help="Player health value")
+    parser.add_argument("--player-attack", type=int, default=8, help="Player attack value")
+    parser.add_argument("--player-speed", type=int, default=10, help="Player speed value")
+    args = parser.parse_args()
+
+    player_stats = {
+        "health": args.player_health,
+        "attack": args.player_attack,
+        "speed": args.player_speed,
+    }
+
+    stats = simulate_battles(args.enemy, args.runs, seed=args.seed, player_stats=player_stats)
+    print(f"Winrate: {stats['winrate']:.2%}")
+    print(f"Average Turns: {stats['avg_turns']:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/simulate_battles.py
+++ b/scripts/simulate_battles.py
@@ -1,0 +1,7 @@
+"""CLI wrapper for :func:`dungeoncrawler.sim.simulate_battles`."""
+
+from dungeoncrawler.sim import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sim_cli.py
+++ b/tests/test_sim_cli.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+
+
+def test_simulate_battles_cli():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "dungeoncrawler.sim",
+            "Bandit",
+            "--runs",
+            "5",
+            "--seed",
+            "0",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "Winrate:" in result.stdout
+    assert "Average Turns:" in result.stdout


### PR DESCRIPTION
## Summary
- extend `simulate_battles` with configurable player stats and CLI entry point
- expose wrapper script for running simulations from the command line
- document balance simulation utility and add CLI test

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d66d1201c8326991c07847bfe0590