### PR TITLE
Add leaderboard sorting and centralize save path

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,15 @@ Progress is automatically saved whenever you clear a floor. On the next launch y
 
 Save data is written to `~/.dungeon_crawler/saves/savegame.json`. The file is a
 JSON document containing the current floor and full player state including
-statistics, inventory, equipped weapon and companions. High scores are stored in
-`scores.json` alongside the save file.
+statistics, inventory, equipped weapon and companions. Save games and leaderboard
+entries are written to `~/.dungeon_crawler` in your home directory.
 
 ## Objectives
 
 - Survive each floor and defeat the boss to descend.
 - Collect powerful weapons and trustworthy companions.
-- Rack up the highest score on the in-game leaderboard.
+- Rack up the highest score on the in-game leaderboard. Runs can be ranked by
+  score, deepest floor reached or fastest completion time.
 
 ## Features
 

--- a/dungeoncrawler/core/save.py
+++ b/dungeoncrawler/core/save.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, is_dataclass
-from pathlib import Path
 from typing import Any, Dict, Optional
 
+from ..constants import SAVE_FILE
+
 SCHEMA_VERSION = 1
-SAVE_FILE = Path.home() / ".dungeon_crawler" / "saves" / "savegame.json"
 
 
 def save_game(state: Any) -> None:

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -48,3 +48,39 @@ def test_view_leaderboard_display(tmp_path, monkeypatch, capsys):
     assert "Alice" in captured.out
     assert "Floor 4" in captured.out
     assert "Seed 42" in captured.out
+
+
+def test_leaderboard_sorting(tmp_path, monkeypatch, capsys):
+    score_path = tmp_path / "scores.json"
+    records = [
+        {
+            "player_name": "Alice",
+            "score": 100,
+            "floor_reached": 4,
+            "run_duration": 30,
+            "seed": 42,
+        },
+        {
+            "player_name": "Bob",
+            "score": 80,
+            "floor_reached": 6,
+            "run_duration": 20,
+            "seed": 43,
+        },
+    ]
+    score_path.write_text(json.dumps(records))
+    monkeypatch.setattr(dungeon_module, "SCORE_FILE", str(score_path))
+
+    dungeon = DungeonBase(1, 1)
+
+    dungeon.view_leaderboard(sort_by="depth")
+    out = capsys.readouterr().out.splitlines()
+    assert out[1].startswith("Bob")
+
+    dungeon.view_leaderboard(sort_by="time")
+    out = capsys.readouterr().out.splitlines()
+    assert out[1].startswith("Bob")
+
+    dungeon.view_leaderboard(sort_by="score")
+    out = capsys.readouterr().out.splitlines()
+    assert out[1].startswith("Alice")


### PR DESCRIPTION
## Summary
- Centralize save game location by reusing global SAVE_FILE
- Allow leaderboard to rank runs by score, depth, or time
- Document home directory storage and add tests for leaderboard ordering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d67dbb4f48326a9864d6dc9e7e3c5