### PR TITLE
Handle empty balance logs gracefully

### DIFF
--- a/scripts/analyze_balance.py
+++ b/scripts/analyze_balance.py
@@ -26,6 +26,14 @@ def main() -> None:
             if row["time_to_first_reward"]:
                 rewards.append(int(row["time_to_first_reward"]))
             fog.append(float(row["fog_reveal_rate"]))
+
+    # ``statistics.mean`` raises ``StatisticsError`` when called with an empty
+    # sequence.  This can happen if ``balance.csv`` exists but contains no
+    # measurements (for example an empty file with just headers).  Guard against
+    # that scenario to keep the helper script robust.
+    if not turns:
+        print("No balance data found.")
+        return
     print("Death Causes:")
     for cause, count in Counter(runs.values()).items():
         print(f"  {cause}: {count}")


### PR DESCRIPTION
## Summary
- avoid StatisticsError in analyze_balance when CSV has no data
- add guard that prints message instead of crashing on empty balance logs

## Testing
- `pytest`
- `flake8 scripts/analyze_balance.py`


------
https://chatgpt.com/codex/tasks/task_e_689d6a35162883269cbf8800614b3484