### PR TITLE
Handle malformed riddle data gracefully

### DIFF
--- a/dungeoncrawler/constants.py
+++ b/dungeoncrawler/constants.py
@@ -47,14 +47,24 @@ def load_riddles():
     data_dir = Path(__file__).resolve().parent.parent / "data"
     path = data_dir / "riddles.json"
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             riddles = json.load(f)
-    except (IOError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError):
         return []
-    # Normalise answers for case-insensitive comparison
-    for r in riddles:
-        r["answer"] = r["answer"].lower()
-    return riddles
+
+    if not isinstance(riddles, list):
+        return []
+
+    normalised: list[dict[str, str]] = []
+    for entry in riddles:
+        if not isinstance(entry, dict):
+            continue
+        question = entry.get("question")
+        answer = entry.get("answer")
+        if not isinstance(question, str) or not isinstance(answer, str):
+            continue
+        normalised.append({"question": question, "answer": answer.lower()})
+    return normalised
 
 
 # Simple riddles used for trap rooms. Answer correctly to avoid damage.

--- a/tests/test_riddles.py
+++ b/tests/test_riddles.py
@@ -5,6 +5,23 @@ from dungeoncrawler import dungeon as dungeon_module
 from dungeoncrawler.entities import Player
 
 
+def test_load_riddles_invalid_data(monkeypatch):
+    """``load_riddles`` should gracefully handle malformed JSON structures."""
+    import io
+    from dungeoncrawler import constants
+
+    # Provide JSON that is not the expected list of riddles
+    import builtins
+    monkeypatch.setattr(
+        builtins,
+        "open",
+        lambda *args, **kwargs: io.StringIO("{\"not\": \"a list\"}"),
+    )
+
+    constants.load_riddles.cache_clear()
+    assert constants.load_riddles() == []
+
+
 def test_riddles_loaded_and_used(monkeypatch, capsys):
     # Ensure riddles were loaded from the data file and contain many entries
     assert isinstance(constants.RIDDLES, list)


### PR DESCRIPTION
## Summary
- Robustify `load_riddles` to validate JSON structure and entries
- Normalize valid riddles and ignore malformed data
- Add regression test for handling malformed riddle files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d6af7e2a88326b6c2e8091892bf4d