### PR TITLE
Handle missing event config file

### DIFF
--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -23,8 +23,11 @@ DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 @lru_cache(maxsize=None)
 def load_event_config():
     path = DATA_DIR / "events.json"
-    with open(path) as f:
-        return json.load(f)
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
 
 
 EVENT_CONFIG = load_event_config()

--- a/tests/test_event_config_missing.py
+++ b/tests/test_event_config_missing.py
@@ -1,0 +1,8 @@
+from dungeoncrawler import events
+
+
+def test_load_event_config_missing_file(monkeypatch, tmp_path):
+    # Point DATA_DIR to an empty directory to simulate a missing events.json
+    monkeypatch.setattr(events, "DATA_DIR", tmp_path)
+    events.load_event_config.cache_clear()
+    assert events.load_event_config() == {}


### PR DESCRIPTION
## Summary
- Gracefully handle missing `events.json` by returning an empty configuration
- Add regression test ensuring `load_event_config` tolerates missing file

## Testing
- `pytest`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_689d6af7e2a88326b6c2e8091892bf4d