### PR TITLE
Introduce random rolls for combat and update tests

### DIFF
--- a/dungeoncrawler/core/combat.py
+++ b/dungeoncrawler/core/combat.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from typing import List
 
+import random
+
 from .data import load_items
 from .entity import Entity
 from .events import AttackResolved, Event, IntentTelegraphed, StatusApplied
@@ -80,12 +82,12 @@ def resolve_attack(attacker: Entity, defender: Entity) -> AttackResolved:
     """Resolve a basic attack from ``attacker`` to ``defender``."""
 
     hit = calculate_hit(attacker, defender)
-    if hit < 50:
+    if random.randint(1, 100) > hit:
         msg = f"{attacker.name} misses {defender.name}."
         return AttackResolved(msg, attacker.name, defender.name, 0, 0)
 
     crit_chance = calculate_crit(attacker, defender)
-    critical = crit_chance >= 100
+    critical = random.randint(1, 100) <= crit_chance
     damage = calculate_damage(attacker, defender, critical)
     defeated = int(not defender.is_alive())
     if critical:
@@ -141,7 +143,8 @@ def resolve_player_action(player: Entity, enemy: Entity, action: str) -> List[Ev
     elif action == "flee":
         speed_diff = player.stats.get("speed", 0) - enemy.stats.get("speed", 0)
         chance = max(10, min(90, 40 + speed_diff * 5))
-        success = int(chance > 50)
+        roll = random.randint(1, 100)
+        success = int(roll <= chance)
         if success:
             msg = f"{player.name} flees from {enemy.name}."
         else:

--- a/tests/test_core_combat.py
+++ b/tests/test_core_combat.py
@@ -7,7 +7,11 @@ from dungeoncrawler.core.combat import (
 from dungeoncrawler.core.entity import Entity
 
 
-def test_defend_reduces_damage_and_boosts_hit():
+def test_defend_reduces_damage_and_boosts_hit(monkeypatch):
+    rolls = iter([1, 100])
+    monkeypatch.setattr(
+        "dungeoncrawler.core.combat.random.randint", lambda a, b: next(rolls)
+    )
     player = Entity("Hero", {"health": 10, "attack": 5, "speed": 5})
     enemy = Entity("Gob", {"health": 10, "attack": 10, "speed": 5})
     resolve_player_action(player, enemy, "defend")
@@ -21,7 +25,11 @@ def test_defend_reduces_damage_and_boosts_hit():
     assert "defend_attack" not in player.status
 
 
-def test_flee_action_speed_difference():
+def test_flee_action_speed_difference(monkeypatch):
+    rolls = iter([1, 100, 1, 100])
+    monkeypatch.setattr(
+        "dungeoncrawler.core.combat.random.randint", lambda a, b: next(rolls)
+    )
     fast = Entity("Hero", {"health": 10, "speed": 15})
     slow_enemy = Entity("Gob", {"health": 10, "speed": 5})
     events = resolve_player_action(fast, slow_enemy, "flee")
@@ -37,7 +45,8 @@ def test_flee_action_speed_difference():
     assert "advantage" not in fast_enemy.status
 
 
-def test_critical_hits_double_damage():
+def test_critical_hits_double_damage(monkeypatch):
+    monkeypatch.setattr("dungeoncrawler.core.combat.random.randint", lambda a, b: 1)
     attacker = Entity("A", {"health": 10, "attack": 5, "crit": 150})
     defender = Entity("D", {"health": 20, "defense": 1})
     event = resolve_attack(attacker, defender)

--- a/tests/test_core_events.py
+++ b/tests/test_core_events.py
@@ -8,7 +8,8 @@ from dungeoncrawler.core.events import AttackResolved, IntentTelegraphed, Status
 from dungeoncrawler.core.map import GameMap
 
 
-def test_attack_returns_event():
+def test_attack_returns_event(monkeypatch):
+    monkeypatch.setattr("dungeoncrawler.core.combat.random.randint", lambda a, b: 1)
     attacker = Entity("A", {"health": 10, "attack": 5})
     defender = Entity("D", {"health": 8, "defense": 1})
     event = resolve_attack(attacker, defender)
@@ -35,7 +36,11 @@ def test_use_potion_event():
     assert events[0].value == 5
 
 
-def test_enemy_turn_returns_attack_event():
+def test_enemy_turn_returns_attack_event(monkeypatch):
+    rolls = iter([1, 100])
+    monkeypatch.setattr(
+        "dungeoncrawler.core.combat.random.randint", lambda a, b: next(rolls)
+    )
     player = Entity("Hero", {"health": 10})
     enemy = Entity("Gob", {"health": 5, "attack": 3})
     events = resolve_enemy_turn(enemy, player)

--- a/tests/test_core_intents.py
+++ b/tests/test_core_intents.py
@@ -3,7 +3,11 @@ from dungeoncrawler.core.entity import Entity, make_enemy
 from dungeoncrawler.core.events import AttackResolved, IntentTelegraphed, StatusApplied
 
 
-def test_telegraph_precedes_action():
+def test_telegraph_precedes_action(monkeypatch):
+    rolls = iter([1, 100])
+    monkeypatch.setattr(
+        "dungeoncrawler.core.combat.random.randint", lambda a, b: next(rolls)
+    )
     player = Entity("Hero", {"health": 10})
     enemy = make_enemy("Goblin Skirm")
     events = resolve_enemy_turn(enemy, player)
@@ -11,7 +15,11 @@ def test_telegraph_precedes_action():
     assert isinstance(events[1], AttackResolved)
 
 
-def test_defend_consumption():
+def test_defend_consumption(monkeypatch):
+    rolls = iter([1, 100, 1, 100])
+    monkeypatch.setattr(
+        "dungeoncrawler.core.combat.random.randint", lambda a, b: next(rolls)
+    )
     player = Entity("Hero", {"health": 20, "attack": 8})
     enemy = make_enemy("Guard Beetle")
     events = resolve_enemy_turn(enemy, player)


### PR DESCRIPTION
## Summary
- Add randomized rolls for hit, critical, and flee resolutions
- Import `random` and update combat mechanics to use random chance
- Adjust core tests to monkeypatch randomness for deterministic checks

## Testing
- `pytest tests/test_core_combat.py -q`
- `pytest tests/test_core_events.py -q`
- `pytest tests/test_core_intents.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d6e3524548326a657a77f4662ae0d