### PR TITLE
Include defense stats in combat resolution

### DIFF
--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -36,6 +36,7 @@ def enemy_turn(enemy: "Enemy", player: "Player", renderer: Renderer | None = Non
                 {
                     "health": enemy.health,
                     "attack": getattr(enemy, "attack_power", 0),
+                    "defense": getattr(enemy, "defense", 0),
                     "speed": getattr(enemy, "speed", 0),
                 },
             )
@@ -43,7 +44,11 @@ def enemy_turn(enemy: "Enemy", player: "Player", renderer: Renderer | None = Non
             enemy_entity.intent = (item for item in [(enemy.next_action, enemy.intent_message)])
             player_entity = CoreEntity(
                 player.name,
-                {"health": player.health, "defense": 0, "speed": getattr(player, "speed", 0)},
+                {
+                    "health": player.health,
+                    "defense": getattr(player.armor, "defense", 0),
+                    "speed": getattr(player, "speed", 0),
+                },
             )
             events = resolve_enemy_turn(enemy_entity, player_entity)
             enemy.health = enemy_entity.stats["health"]
@@ -120,6 +125,7 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
                     "health": player.health,
                     "attack": getattr(player, "attack_power", 0),
                     "max_health": player.max_health,
+                    "defense": getattr(player.armor, "defense", 0),
                     "speed": getattr(player, "speed", 0),
                 },
             )
@@ -129,6 +135,7 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
                     "health": enemy.health,
                     "attack": getattr(enemy, "attack_power", 0),
                     "max_health": enemy.max_health,
+                    "defense": getattr(enemy, "defense", 0),
                     "speed": getattr(enemy, "speed", 0),
                 },
             )
@@ -151,6 +158,7 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
                     "health": player.health,
                     "attack": getattr(player, "attack_power", 0),
                     "max_health": player.max_health,
+                    "defense": getattr(player.armor, "defense", 0),
                     "speed": getattr(player, "speed", 0),
                 },
             )
@@ -160,6 +168,7 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
                     "health": enemy.health,
                     "attack": getattr(enemy, "attack_power", 0),
                     "max_health": enemy.max_health,
+                    "defense": getattr(enemy, "defense", 0),
                     "speed": getattr(enemy, "speed", 0),
                 },
             )
@@ -197,6 +206,7 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
                     "health": player.health,
                     "attack": getattr(player, "attack_power", 0),
                     "max_health": player.max_health,
+                    "defense": getattr(player.armor, "defense", 0),
                     "speed": getattr(player, "speed", 0),
                 },
             )
@@ -206,6 +216,7 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
                     "health": enemy.health,
                     "attack": getattr(enemy, "attack_power", 0),
                     "max_health": enemy.max_health,
+                    "defense": getattr(enemy, "defense", 0),
                     "speed": getattr(enemy, "speed", 0),
                 },
             )

--- a/tests/test_defense_stats.py
+++ b/tests/test_defense_stats.py
@@ -1,0 +1,58 @@
+"""Tests ensuring defense values are considered in combat."""
+
+from dungeoncrawler.combat import enemy_turn
+from dungeoncrawler.core.combat import resolve_player_action
+from dungeoncrawler.core.entity import Entity as CoreEntity
+from dungeoncrawler.entities import Armor, Enemy, Player
+
+
+class DummyRenderer:
+    def handle_event(self, event) -> None:  # pragma: no cover - no logic
+        pass
+
+
+def test_enemy_turn_respects_player_armor(monkeypatch):
+    """Enemy attacks should be reduced by the player's armor defense."""
+
+    monkeypatch.setattr("dungeoncrawler.core.combat.random.randint", lambda a, b: 1)
+    player = Player("Hero")
+    player.armor = Armor("Plate", "", defense=3)
+    enemy = Enemy("Goblin", 10, 5, 0, 0)
+    start = player.health
+
+    enemy_turn(enemy, player, DummyRenderer())
+
+    assert player.health == start - 2  # 5 attack - 3 defense
+
+
+def test_player_attack_respects_enemy_defense(monkeypatch):
+    """Player damage should be reduced by enemy defense."""
+
+    monkeypatch.setattr("dungeoncrawler.core.combat.random.randint", lambda a, b: 1)
+    player = Player("Hero")
+    enemy = Enemy("Goblin", 10, 0, 3, 0)
+
+    p_entity = CoreEntity(
+        player.name,
+        {
+            "health": player.health,
+            "attack": getattr(player, "attack_power", 0),
+            "max_health": player.max_health,
+            "defense": getattr(player.armor, "defense", 0),
+            "speed": getattr(player, "speed", 0),
+        },
+    )
+    e_entity = CoreEntity(
+        enemy.name,
+        {
+            "health": enemy.health,
+            "attack": getattr(enemy, "attack_power", 0),
+            "max_health": enemy.max_health,
+            "defense": getattr(enemy, "defense", 0),
+            "speed": getattr(enemy, "speed", 0),
+        },
+    )
+
+    resolve_player_action(p_entity, e_entity, "attack")
+
+    assert e_entity.stats["health"] == enemy.health - (player.attack_power - enemy.defense)


### PR DESCRIPTION
## Summary
- pass defense values into combat entities for both player and enemies
- add tests confirming player armor and enemy defense reduce damage

## Testing
- `pytest tests/test_defense_stats.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d7595016883269949af5a4c2881f8