### PR TITLE
feat: support heavy and wild enemy attacks

### DIFF
--- a/docs/gameplay_guide.rst
+++ b/docs/gameplay_guide.rst
@@ -54,3 +54,8 @@ for example::
 
 Pay attention to these tells to decide when to Defend or attempt a Feint.
 
+Aggressive telegraphs often precede a heavy attack that deals roughly
+50% more damage.  Unpredictable intents may unleash wild attacks which
+suffer a 20% accuracy penalty but have a small chance to inflict double
+damage.
+

--- a/dungeoncrawler/ai.py
+++ b/dungeoncrawler/ai.py
@@ -25,7 +25,10 @@ class IntentAI:
     Each enemy configured with this AI chooses between Aggressive,
     Defensive and Unpredictable intents every turn according to the
     provided weights.  The chosen intent is *telegraphed* to the player in
-    advance so they can react during their turn.
+    advance so they can react during their turn. Aggressive intents may
+    unleash a ``heavy_attack`` for increased damage, while Unpredictable
+    intents can result in a ``wild_attack`` that trades accuracy for a
+    powerful blow.
 
     Parameters
     ----------

--- a/tests/test_core_intents.py
+++ b/tests/test_core_intents.py
@@ -1,4 +1,4 @@
-from dungeoncrawler.core.combat import resolve_attack, resolve_enemy_turn
+from dungeoncrawler.core.combat import calculate_hit, resolve_attack, resolve_enemy_turn
 from dungeoncrawler.core.entity import Entity, make_enemy
 from dungeoncrawler.core.events import AttackResolved, IntentTelegraphed, StatusApplied
 
@@ -38,3 +38,33 @@ def test_defend_consumption(monkeypatch):
     assert isinstance(events2[0], IntentTelegraphed)
     assert isinstance(events2[1], AttackResolved)
     assert "defend_attack" not in enemy.status
+
+
+def test_heavy_attack_increases_damage(monkeypatch):
+    rolls = iter([1, 100])
+    monkeypatch.setattr(
+        "dungeoncrawler.core.combat.random.randint", lambda a, b: next(rolls)
+    )
+    player = Entity("Hero", {"health": 50})
+    enemy = Entity("Orc", {"health": 10, "attack": 10})
+    enemy.intent = (item for item in [("heavy_attack", "")])
+    events = resolve_enemy_turn(enemy, player)
+    assert isinstance(events[1], AttackResolved)
+    assert events[1].damage == 15
+    assert player.stats["health"] == 35
+
+
+def test_wild_attack_accuracy_penalty(monkeypatch):
+    rolls = iter([60])
+    monkeypatch.setattr(
+        "dungeoncrawler.core.combat.random.randint", lambda a, b: next(rolls)
+    )
+    player = Entity("Hero", {"health": 50})
+    enemy = Entity("Orc", {"health": 10, "attack": 10})
+    base_hit = calculate_hit(enemy, player)
+    assert base_hit == 75
+    enemy.intent = (item for item in [("wild_attack", "")])
+    events = resolve_enemy_turn(enemy, player)
+    assert isinstance(events[1], AttackResolved)
+    assert events[1].damage == 0
+    assert player.stats["health"] == 50


### PR DESCRIPTION
## Summary
- handle `heavy_attack` and `wild_attack` in combat resolver
- document heavy and wild enemy intents
- test heavy attack bonus and wild attack penalty

## Testing
- `pytest tests/test_core_intents.py tests/test_core_combat.py tests/test_core_events.py tests/test_combat_resolver_determinism.py`

------
https://chatgpt.com/codex/tasks/task_e_689d788f5a348326ae056e753e648337