### PR TITLE
Add mini quest hook event

### DIFF
--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -239,10 +239,22 @@ class MiniQuestHookEvent(BaseEvent):
     """Placeholder for mini-quest hooks."""
 
     def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
-        if getattr(game, "active_quest", None):
-            output_func(game.active_quest.flavor)
-        else:
-            output_func(_("A mysterious figure hints at a quest to come."))
+        quest = getattr(game, "active_quest", None)
+        if quest:
+            if quest.is_complete(game):
+                output_func(_("Quest complete!"))
+                game.player.gold += quest.reward
+                if getattr(game, "stats_logger", None):
+                    game.stats_logger.record_reward()
+                game.active_quest = None
+            else:
+                output_func(_(f"Quest ongoing: {quest.status(game)}"))
+            return
+
+        npc = EscortNPC(_("Lost Villager"))
+        quest = EscortQuest(npc, reward=50, flavor=_("Escort the villager to the exit."))
+        game.active_quest = quest
+        output_func(_("A lost villager begs for escort."))
 
 
 class HazardEvent(BaseEvent):

--- a/tests/test_mini_quest_hook_event.py
+++ b/tests/test_mini_quest_hook_event.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.dungeon import DungeonBase, load_floor_configs
+from dungeoncrawler.entities import Player
+from dungeoncrawler.events import MiniQuestHookEvent
+from dungeoncrawler.quests import EscortNPC, EscortQuest
+
+
+def setup_game():
+    load_floor_configs()
+    game = DungeonBase(5, 5)
+    game.player = Player("hero")
+    return game
+
+
+def test_mini_quest_hook_starts_quest():
+    game = setup_game()
+    event = MiniQuestHookEvent()
+    outputs = []
+    event.trigger(game, output_func=outputs.append)
+    assert isinstance(game.active_quest, EscortQuest)
+    assert any("escort" in msg.lower() for msg in outputs)
+
+
+def test_mini_quest_hook_existing_quest():
+    game = setup_game()
+    npc = EscortNPC("Test NPC")
+    quest = EscortQuest(npc, reward=10, flavor="Existing quest")
+    game.active_quest = quest
+    event = MiniQuestHookEvent()
+    outputs = []
+    event.trigger(game, output_func=outputs.append)
+    assert game.active_quest is quest
+    assert any("quest ongoing" in msg.lower() for msg in outputs)


### PR DESCRIPTION
## Summary
- Implement mini quest hook logic to start or finish escort quests
- Add tests for starting and handling active mini quests

## Testing
- `pytest tests/test_mini_quest_hook_event.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d803ccda8832680270a4f4af9215b