### PR TITLE
Log suppressed errors and add tests

### DIFF
--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -8,6 +8,7 @@ races on floor 3.
 
 import argparse
 import json
+import logging
 from gettext import gettext as _
 
 from . import tutorial
@@ -18,6 +19,8 @@ from .entities import SKILL_DEFS, Player
 from .i18n import set_language
 
 
+logger = logging.getLogger(__name__)
+
 def _load_unlocks():
     unlocks = {"class": False, "guild": False, "race": False}
     if RUN_FILE.exists():
@@ -25,7 +28,7 @@ def _load_unlocks():
             with open(RUN_FILE) as f:
                 unlocks.update(json.load(f).get("unlocks", {}))
         except (IOError, json.JSONDecodeError):
-            pass
+            logger.exception("Failed to load unlocks from %s", RUN_FILE)
     return unlocks
 
 
@@ -176,7 +179,7 @@ def main(argv=None, input_func=input, output_func=print, cfg: Config | None = No
         try:
             output_func(_("Resuming on Floor {floor}.").format(floor=floor))
         except Exception:
-            pass
+            logger.exception("Failed to display resume message")
         if getattr(game, "player", None) is None:
             output_func(_("No valid save found. Starting a new game…"))
             game.player = build_character(input_func=input_func, output_func=output_func)

--- a/tests/test_logging_failures.py
+++ b/tests/test_logging_failures.py
@@ -1,0 +1,77 @@
+import logging
+from json import JSONDecodeError
+
+import dungeoncrawler.dungeon as dungeon_module
+import dungeoncrawler.main as main_module
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+
+
+def test_save_game_logs_and_informs_user(tmp_path, monkeypatch, caplog):
+    save_path = tmp_path / "save.json"
+    monkeypatch.setattr(dungeon_module, "SAVE_FILE", save_path)
+    dungeon = DungeonBase(1, 1)
+    dungeon.player = Player("Hero")
+
+    messages = []
+    monkeypatch.setattr(dungeon.renderer, "show_message", lambda msg: messages.append(msg))
+
+    def _raise(*args, **kwargs):  # pragma: no cover - helper
+        raise IOError("boom")
+
+    monkeypatch.setattr("builtins.open", _raise)
+    with caplog.at_level(logging.ERROR):
+        dungeon.save_game(1)
+    assert any("Failed to save game" in rec.getMessage() for rec in caplog.records)
+    assert any("Failed to save game" in m for m in messages)
+
+
+def test_save_run_stats_logs_and_informs_user(tmp_path, monkeypatch, caplog):
+    run_path = tmp_path / "run.json"
+    monkeypatch.setattr(dungeon_module, "RUN_FILE", run_path)
+    dungeon = DungeonBase(1, 1)
+    messages = []
+    monkeypatch.setattr(dungeon.renderer, "show_message", lambda msg: messages.append(msg))
+
+    def _raise(*args, **kwargs):  # pragma: no cover - helper
+        raise IOError("boom")
+
+    monkeypatch.setattr("builtins.open", _raise)
+    with caplog.at_level(logging.ERROR):
+        dungeon.save_run_stats()
+    assert any("Failed to save run statistics" in rec.getMessage() for rec in caplog.records)
+    assert any("Failed to update run statistics" in m for m in messages)
+
+
+def test_load_unlocks_logs_on_failure(tmp_path, monkeypatch, caplog):
+    run_path = tmp_path / "run.json"
+    run_path.touch()
+    monkeypatch.setattr(main_module, "RUN_FILE", run_path)
+
+    def _raise(*args, **kwargs):  # pragma: no cover - helper
+        raise IOError("boom")
+
+    monkeypatch.setattr("builtins.open", _raise)
+    with caplog.at_level(logging.ERROR):
+        main_module._load_unlocks()
+    assert any("Failed to load unlocks" in rec.getMessage() for rec in caplog.records)
+
+
+def test_init_logs_when_run_stats_unreadable(tmp_path, monkeypatch, caplog):
+    run_path = tmp_path / "run.json"
+    run_path.write_text("{}")
+    monkeypatch.setattr(dungeon_module, "RUN_FILE", run_path)
+
+    original_open = open
+
+    def fake_open(path, *args, **kwargs):  # pragma: no cover - helper
+        if path == run_path:
+            raise JSONDecodeError("boom", "", 0)
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    with caplog.at_level(logging.ERROR):
+        DungeonBase(1, 1)
+    assert any("Failed to load run statistics" in rec.getMessage() for rec in caplog.records)
+
+


### PR DESCRIPTION
## Summary
- log run stat loading failures and save/delete errors in dungeon, notifying players when saves fail
- log unlock file and resume message issues in main so startup problems are recorded
- add tests that simulate file I/O errors and assert logging and user messages

## Testing
- `pytest tests/test_logging_failures.py -q`
- `pytest -q` *(fails: command hung after test completion; previous run showed all tests passing)*

------
https://chatgpt.com/codex/tasks/task_e_689e11f79c7c8326a438b5812082c786