### PR TITLE
Fix flake8 warnings in main and tests

### DIFF
--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -21,6 +21,7 @@ from .i18n import set_language
 
 logger = logging.getLogger(__name__)
 
+
 def _load_unlocks():
     unlocks = {"class": False, "guild": False, "race": False}
     if RUN_FILE.exists():

--- a/tests/test_logging_failures.py
+++ b/tests/test_logging_failures.py
@@ -73,5 +73,3 @@ def test_init_logs_when_run_stats_unreadable(tmp_path, monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         DungeonBase(1, 1)
     assert any("Failed to load run statistics" in rec.getMessage() for rec in caplog.records)
-
-


### PR DESCRIPTION
## Summary
- add missing blank line before `_load_unlocks` to satisfy flake8
- drop stray blank line at end of `test_logging_failures` test

## Testing
- `flake8`
- `pytest tests/test_logging_failures.py`
- `pytest` *(fails: KeyboardInterrupt after ~7 minutes)*

------
https://chatgpt.com/codex/tasks/task_e_689e256b206483269184b70d972b364e