### PR TITLE
Improve typing and style checks

### DIFF
--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -223,7 +223,7 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
             events = resolve_player_action(p_entity, e_entity, "flee")
             for event in events:
                 renderer.handle_event(event)
-            if events[-1].data.get("success"):
+            if getattr(events[-1], "value", 0):
                 game.announce(f"{player.name} flees from {enemy.name}!")
                 game.stats_logger.record_turn()
                 break

--- a/dungeoncrawler/data.py
+++ b/dungeoncrawler/data.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Tuple
 
 from .entities import Companion
 from .events import (
+    BaseEvent,
     CacheEvent,
     EscortMissionEvent,
     FountainEvent,
@@ -98,21 +99,21 @@ def load_companions() -> List[Companion]:
 
 
 @lru_cache(maxsize=None)
-def load_event_defs() -> Tuple[List[type], List[float], Dict[str, int], List[type]]:
+def load_event_defs() -> Tuple[List[type[BaseEvent]], List[float], Dict[str, int], List[type[BaseEvent]]]:
     """Load event definitions including signature encounters."""
     path = DATA_DIR / "events_extended.json"
     with open(path, encoding="utf-8") as f:
         data = json.load(f)
 
-    events = []
-    weights = []
+    events: List[type[BaseEvent]] = []
+    weights: List[float] = []
     for name, weight in data.get("random", {}).items():
         cls = EVENT_CLASS_MAP.get(name)
         if cls:
             events.append(cls)
             weights.append(weight)
 
-    signature: List[type] = []
+    signature: List[type[BaseEvent]] = []
     for name in data.get("signature", []):
         cls = EVENT_CLASS_MAP.get(name)
         if cls:

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -7,7 +7,7 @@ import random
 from functools import lru_cache
 from gettext import gettext as _
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .items import Item
 from .quests import EscortNPC, EscortQuest
@@ -176,7 +176,7 @@ class LoreNoteEvent(BaseEvent):
     """Reveal a snippet of lore."""
 
     def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
-        notes = [
+        notes: list[dict[str, Any]] = [
             {"text": _("The walls whisper of an ancient battle.")},
             {"text": _("Scrawled handwriting reads: 'Beware the shadows.'")},
             {"text": _("A faded map hints at deeper treasures.")},

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -50,8 +50,8 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
     ]
     game.discovered = [[False for __ in range(game.width)] for __ in range(game.height)]
     game.visible = [[False for __ in range(game.width)] for __ in range(game.height)]
-    visited = set()
-    path = []
+    visited: set[tuple[int, int]] = set()
+    path: list[tuple[int, int]] = []
     x, y = game.width // 2, game.height // 2
     start = (x, y)
     visited.add(start)
@@ -76,23 +76,25 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
     game.visited_rooms.add(start)
 
     visited.remove(start)
-    visited = list(visited)
-    random.shuffle(visited)
+    available: list[tuple[int, int]] = list(visited)
+    random.shuffle(available)
 
     def place(obj):
-        if visited:
-            px, py = visited.pop()
+        if available:
+            px, py = available.pop()
             game.rooms[py][px] = obj
             return (px, py)
 
     def place_near_start(obj, max_dist):
         candidates = [
-            pos for pos in visited if abs(pos[0] - start[0]) + abs(pos[1] - start[1]) <= max_dist
+            pos
+            for pos in available
+            if abs(pos[0] - start[0]) + abs(pos[1] - start[1]) <= max_dist
         ]
         random.shuffle(candidates)
         if candidates:
             px, py = candidates.pop()
-            visited.remove((px, py))
+            available.remove((px, py))
             game.rooms[py][px] = obj
             return (px, py)
         return place(obj)

--- a/dungeoncrawler/tutorial.py
+++ b/dungeoncrawler/tutorial.py
@@ -17,7 +17,8 @@ def run(game, input_func=input, renderer: Renderer | None = None) -> None:
     the next section.
     """
 
-    renderer = renderer or getattr(game, "renderer", Renderer())
+    existing = getattr(game, "renderer", None)
+    renderer = renderer or (existing if isinstance(existing, Renderer) else None) or Renderer()
     renderer.show_message(_("=== Welcome to the Dungeon Crawler tutorial! ==="))
     renderer.show_message(
         _("Let's begin with movement. Use '1' (left), '2' (right), '3' (up) or '4' (down).")


### PR DESCRIPTION
## Summary
- Annotate event notes with explicit typing and guard against invalid access in combat flow
- Correct event data loader typing and map generation set usage
- Ensure tutorial uses a valid renderer instance when displaying messages

## Testing
- `flake8`
- `mypy --follow-imports=skip dungeoncrawler/events.py dungeoncrawler/combat.py dungeoncrawler/data.py dungeoncrawler/map.py dungeoncrawler/tutorial.py`
- `pytest` *(failed: KeyboardInterrupt after 44 passed tests)*

------
https://chatgpt.com/codex/tasks/task_e_689e31c79f888326acbc0d1cd71d1397