### PR TITLE
Improve linting and strengthen typing

### DIFF
--- a/dungeoncrawler/core/entity.py
+++ b/dungeoncrawler/core/entity.py
@@ -84,7 +84,8 @@ ARCHETYPES: Dict[str, ArchetypeData] = _load_archetypes()
 def make_enemy(archetype: str) -> Entity:
     """Create an :class:`Entity` for the given enemy archetype."""
 
-    data = ARCHETYPES[archetype]
-    stats = dict(data["stats"])
+    data: ArchetypeData = ARCHETYPES[archetype]
+    stats: Dict[str, int] = dict(data["stats"])
     intent_gen = data["intent"]()
-    return Entity(archetype, stats, intent=intent_gen, rarity=data["rarity"])
+    rarity: str = data["rarity"]
+    return Entity(archetype, stats, intent=intent_gen, rarity=rarity)

--- a/dungeoncrawler/core/save.py
+++ b/dungeoncrawler/core/save.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, is_dataclass
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional, cast
 
 from ..constants import SAVE_FILE
 
@@ -19,10 +19,10 @@ def save_game(state: Mapping[str, Any] | object) -> None:
     """
 
     SAVE_FILE.parent.mkdir(parents=True, exist_ok=True)
-    if is_dataclass(state) and not isinstance(state, type):
-        payload: Dict[str, Any] = asdict(state)
-    elif isinstance(state, Mapping):
+    if isinstance(state, Mapping):
         payload = dict(state)
+    elif is_dataclass(state) and not isinstance(state, type):
+        payload = cast(Dict[str, Any], asdict(state))
     else:
         raise TypeError("state must be a dataclass instance or mapping")
 

--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -26,7 +26,7 @@ def _load_unlocks():
     unlocks = {"class": False, "guild": False, "race": False}
     if RUN_FILE.exists():
         try:
-            with open(RUN_FILE, encoding="utf-8") as f:
+            with RUN_FILE.open(encoding="utf-8") as f:
                 unlocks.update(json.load(f).get("unlocks", {}))
         except (IOError, json.JSONDecodeError):
             logger.exception("Failed to load unlocks from %s", RUN_FILE)

--- a/dungeoncrawler/tutorial.py
+++ b/dungeoncrawler/tutorial.py
@@ -8,7 +8,7 @@ from .input.keys import Action, get_action
 from .ui.terminal import Renderer
 
 
-def run(game, input_func=input, renderer: Renderer | None = None) -> None:
+def run(game_inst, input_func=input, renderer: Renderer | None = None) -> None:
     """Run the tutorial sequence.
 
     The tutorial walks the player through movement, combat and
@@ -17,8 +17,12 @@ def run(game, input_func=input, renderer: Renderer | None = None) -> None:
     the next section.
     """
 
-    existing = getattr(game, "renderer", None)
-    renderer = renderer or (existing if isinstance(existing, Renderer) else None) or Renderer()
+    existing = getattr(game_inst, "renderer", None)
+    renderer = (
+        renderer
+        or (existing if isinstance(existing, Renderer) else None)
+        or Renderer()
+    )
     renderer.show_message(_("=== Welcome to the Dungeon Crawler tutorial! ==="))
     renderer.show_message(
         _("Let's begin with movement. Use '1' (left), '2' (right), '3' (up) or '4' (down).")
@@ -27,7 +31,9 @@ def run(game, input_func=input, renderer: Renderer | None = None) -> None:
         move = input_func(_("Move: ")).strip()
         action = get_action(move)
         if action in {Action.MOVE_W, Action.MOVE_E, Action.MOVE_N, Action.MOVE_S}:
-            renderer.show_message(_("Good job! You can navigate the dungeon using those keys."))
+            renderer.show_message(
+                _("Good job! You can navigate the dungeon using those keys.")
+            )
             break
         renderer.show_message(_("Please use one of 1, 2, 3 or 4 to move."))
 
@@ -41,16 +47,20 @@ def run(game, input_func=input, renderer: Renderer | None = None) -> None:
             break
         renderer.show_message(_("Type 'attack' to perform an attack."))
 
-    renderer.show_message(_("Finally, open your inventory by typing 'inventory'."))
+    renderer.show_message(
+        _("Finally, open your inventory by typing 'inventory'.")
+    )
     while True:
         action = input_func(_("Command: ")).strip().lower()
         if action == "inventory":
-            renderer.show_message(_("Your empty bag opens. You'll fill it with loot soon enough."))
+            renderer.show_message(
+                _("Your empty bag opens. You'll fill it with loot soon enough.")
+            )
             break
         renderer.show_message(_("Type 'inventory' to check your belongings."))
 
     renderer.show_message(_("That's it for the basics. Good luck in the dungeon!"))
-    game.tutorial_complete = True
+    game_inst.tutorial_complete = True
 
 
 if __name__ == "__main__":  # pragma: no cover - convenience script


### PR DESCRIPTION
## Summary
- ensure unlocks are loaded with explicit UTF-8 encoding
- polish event system with shorter lines, better docs and safer typing
- guard save game helper with mapping checks and dataclass casting

## Testing
- `flake8 dungeoncrawler/main.py tests/test_logging_failures.py dungeoncrawler/events.py dungeoncrawler/tutorial.py dungeoncrawler/core/save.py dungeoncrawler/core/entity.py`
- `pylint dungeoncrawler/events.py dungeoncrawler/tutorial.py`
- `mypy dungeoncrawler/events.py dungeoncrawler/core/save.py dungeoncrawler/core/entity.py --follow-imports=skip`
- `pytest` *(interrupted: KeyboardInterrupt, 44 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689e3eb59554832686e08e5a491ae605