### PR TITLE
Validate settings menu input

### DIFF
--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -162,6 +162,16 @@ def settings_menu(
         except ValueError:
             output_func(f"Invalid value for {key!r}; keeping {current}.")
             continue
+        valid = True
+        if key in {"screen_width", "screen_height"}:
+            valid = isinstance(value, int) and value > 0
+        elif key == "trap_chance":
+            valid = isinstance(value, (int, float)) and 0 <= float(value) <= 1
+        elif key in {"enemy_hp_mult", "enemy_dmg_mult", "loot_mult"}:
+            valid = isinstance(value, (int, float)) and float(value) > 0
+        if not valid:
+            output_func(f"Invalid value for {key!r}; keeping {current}.")
+            continue
         setattr(cfg, key, value)
 
     save_config(cfg, path)

--- a/tests/test_settings_menu.py
+++ b/tests/test_settings_menu.py
@@ -26,3 +26,32 @@ def test_settings_menu_updates_and_saves(tmp_path):
     loaded = load_config(cfg_file)
     assert loaded.screen_width == 12
     assert loaded.colorblind_mode is True
+
+
+def test_settings_menu_rejects_invalid_values(tmp_path):
+    cfg = Config()
+    cfg_file = tmp_path / "config.json"
+
+    inputs = iter(["-5", "0", "1.5", "-1", "0", "-2", "maybe"])
+    outputs = []
+
+    def fake_input(_prompt: str) -> str:
+        return next(inputs)
+
+    def fake_output(msg: str) -> None:
+        outputs.append(msg)
+
+    new_cfg = settings_menu(cfg, path=cfg_file, input_func=fake_input, output_func=fake_output)
+
+    defaults = Config()
+    assert new_cfg.screen_width == defaults.screen_width
+    assert new_cfg.screen_height == defaults.screen_height
+    assert new_cfg.trap_chance == defaults.trap_chance
+    assert new_cfg.enemy_hp_mult == defaults.enemy_hp_mult
+    assert new_cfg.enemy_dmg_mult == defaults.enemy_dmg_mult
+    assert new_cfg.loot_mult == defaults.loot_mult
+    assert new_cfg.colorblind_mode is False
+
+    # confirm warnings emitted for invalid values
+    assert any("screen_width" in msg for msg in outputs)
+    assert any("trap_chance" in msg for msg in outputs)


### PR DESCRIPTION
## Summary
- validate user-supplied settings values and reject invalid entries
- add regression tests for settings menu value validation

## Testing
- `pytest tests/test_settings_menu.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e44d312bc832691647e88ec28dd13