### PR TITLE
Fix slow companion tests

### DIFF
--- a/tests/test_companions.py
+++ b/tests/test_companions.py
@@ -16,7 +16,13 @@ def test_attack_companion_deals_damage(monkeypatch):
     game.player.companions.append(wolf)
 
     monkeypatch.setattr("builtins.input", lambda _: "2")  # defend
-    monkeypatch.setattr(random, "randint", lambda a, b: b)
+
+    def rigged_randint(a, b):
+        if (a, b) == (1, 100):
+            return a
+        return b
+
+    monkeypatch.setattr(random, "randint", rigged_randint)
 
     game.battle(enemy)
 
@@ -32,7 +38,13 @@ def test_healer_companion_restores_health(monkeypatch):
     game.player.companions.append(healer)
 
     monkeypatch.setattr("builtins.input", lambda _: "1")  # attack
-    monkeypatch.setattr(random, "randint", lambda a, b: b)
+
+    def rigged_randint(a, b):
+        if (a, b) == (1, 100):
+            return a
+        return b
+
+    monkeypatch.setattr(random, "randint", rigged_randint)
 
     game.battle(enemy)
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -45,7 +45,7 @@ def test_puzzle_event_rewards_on_correct_answer():
 def test_puzzle_event_handles_no_riddles():
     """Ensure the puzzle event gracefully handles an empty riddle list."""
     game = setup_game()
-    game.riddles.clear()
+    game.riddles = []
     event = PuzzleEvent()
     # ``random.choice`` would raise IndexError if called; patch to track usage.
     with patch("dungeoncrawler.events.random.choice") as mock_choice:


### PR DESCRIPTION
## Summary
- rig deterministic RNG in companion tests to avoid long battle loops
- prevent puzzle event test from mutating global riddle list

## Testing
- `pytest -q`
- `coverage run -m pytest -q` *(fails: command not found: coverage)*

------
https://chatgpt.com/codex/tasks/task_e_689e48c0116c8326b5f99c769903bc74