### PR TITLE
Document optional Textual UI and test instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ pip install -r requirements.txt
 python3 -m dungeoncrawler
 ```
 
+### Optional Textual Interface
+
+The experimental graphical interface uses the third‑party
+[`textual`](https://textual.textualize.io/) framework.  It is not required for
+the standard terminal renderer, but you can install it separately to try the
+`DungeonApp` showcase:
+
+```bash
+pip install textual
+```
+
 Make sure the file is executable if you wish to launch it with `./dungeon_crawler.py`.
 
 ## Configuration

--- a/dungeoncrawler/ui/__init__.py
+++ b/dungeoncrawler/ui/__init__.py
@@ -30,7 +30,9 @@ except ModuleNotFoundError:  # pragma: no cover - textual not installed
         """
 
         def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - simple guard
-            raise ModuleNotFoundError("`textual` is required to use DungeonApp")
+            raise ModuleNotFoundError(
+                "`textual` is required to use DungeonApp. Install it with `pip install textual`."
+            )
 
 
 __all__ = ["Renderer", "DungeonApp"]

--- a/dungeoncrawler/ui/textual_app.py
+++ b/dungeoncrawler/ui/textual_app.py
@@ -1,8 +1,19 @@
+"""Graphical user interface built with the optional :mod:`textual` library.
+
+This module is imported only when the third‑party dependency is available.  It
+provides :class:`DungeonApp`, a small showcase application composed of several
+resizable panels.  Importing this file without :mod:`textual` installed will
+raise :class:`ModuleNotFoundError` with a helpful message.
+"""
+
 from __future__ import annotations
 
-from textual.app import App, ComposeResult
-from textual.containers import Grid
-from textual.widgets import Static
+try:  # pragma: no cover - import guard exercised in __init__
+    from textual.app import App, ComposeResult
+    from textual.containers import Grid
+    from textual.widgets import Static
+except ModuleNotFoundError as exc:  # pragma: no cover - textual not installed
+    raise ModuleNotFoundError("`textual` is required to use DungeonApp") from exc
 
 
 class MapPanel(Static):
@@ -38,3 +49,6 @@ class DungeonApp(App):
             yield StatsPanel("Stats", id="stats")
             yield LogPanel("Log", id="log")
             yield ActionsPanel("Actions", id="actions")
+
+
+__all__ = ["DungeonApp"]

--- a/tests/test_textual_ui.py
+++ b/tests/test_textual_ui.py
@@ -1,0 +1,12 @@
+import pytest
+
+pytest.importorskip("textual")
+
+from dungeoncrawler.ui import DungeonApp
+from textual.app import App
+
+
+def test_dungeon_app_instantiation() -> None:
+    """DungeonApp can be constructed when textual is available."""
+    app = DungeonApp()
+    assert isinstance(app, App)


### PR DESCRIPTION
## Summary
- provide a Textual-based `DungeonApp` with an import guard so the module is only available when `textual` is installed
- improve `dungeoncrawler.ui` placeholder error message and document optional `textual` installation steps
- add a test ensuring the Textual UI can be instantiated

## Testing
- `pytest tests/test_textual_ui.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e543680d88326891f4afff7962053