### PR TITLE
fix: add missing blank line in test_events

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -57,6 +57,7 @@ def test_puzzle_event_handles_no_riddles():
     # The event should exit early without attempting to select a riddle.
     mock_choice.assert_not_called()
 
+
 def test_trap_event_deals_damage():
     game = setup_game()
     event = TrapEvent()


### PR DESCRIPTION
## Summary
- fix flake8 E302 by ensuring two blank lines before `test_trap_event_deals_damage`

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e9527951c8326b6d9e6cbcc0b1ba7