### PR TITLE
docs: fix repo URLs and config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 Dungeon Crawler is a small text-based adventure that borrows the core ideas of the *Dungeon Crawler Carl* where you guide your hero through procedurally generated floors filled with monsters, treasure, and meaningful character choices.
 
-Full documentation is available in [docs/README.md](docs/README.md).
+Full documentation is available in [docs/index.rst](docs/index.rst).
 
 ## Quickstart
 
 Clone the repository and start the game with Python 3:
 
 ```bash
-git clone https://github.com/ttc24/Dungeon-Crawler.git
+git clone https://github.com/ttc24/Dungeon-Crawler
 cd Dungeon-Crawler
 python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
@@ -45,8 +45,8 @@ Make sure the file is executable if you wish to launch it with `./dungeon_crawle
 
 ## Configuration
 
-Game settings are loaded from `config.json` if present. Copy the provided
-`config.example.json` and adjust values as needed:
+Game settings are loaded from `config.json` in the project root. Copy the provided
+`config.example.json` there and adjust values as needed:
 
 ```bash
 cp config.example.json config.json

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,13 @@ Install the game by cloning the repository and running it with Python 3.
 
 .. code-block:: bash
 
-   git clone https://github.com/yourname/Dungeon-Crawler.git
+   git clone https://github.com/ttc24/Dungeon-Crawler
    cd Dungeon-Crawler
    python -m dungeoncrawler
+
+You can customize settings by copying the sample configuration to the project root:
+
+.. code-block:: bash
+
+   cp config.example.json config.json
 


### PR DESCRIPTION
## Summary
- point quickstart and installation guides to the correct repository URL
- link README to `docs/index.rst`
- clarify that `config.example.json` lives in the project root

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e9928aaa88326863c9af868b4896d