### PR TITLE
Add lint and test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Lint and Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Run linters
+        run: |
+          isort --check-only .
+          black --check .
+          flake8 .
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Dungeon Crawler
 
 [![CI](https://github.com/ttc24/Dungeon-Crawler/actions/workflows/ci.yml/badge.svg)](https://github.com/ttc24/Dungeon-Crawler/actions/workflows/ci.yml)
+[![Lint and Test](https://github.com/ttc24/Dungeon-Crawler/actions/workflows/tests.yml/badge.svg)](https://github.com/ttc24/Dungeon-Crawler/actions/workflows/tests.yml)
 ![Coverage](coverage.svg)
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://ttc24.github.io/Dungeon-Crawler/)
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that runs isort, black, flake8, and pytest
- display workflow status badge in README

## Testing
- `isort --check-only .`
- `black --check .`
- `flake8 .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e9a0df0808326b008772648507f8d