### PR TITLE
Add cached floor definition loader

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,8 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from dungeoncrawler.dungeon import DungeonBase, load_floor_configs
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.data import load_floor_definitions
 from dungeoncrawler.entities import Player
 
 
@@ -18,7 +19,7 @@ def player() -> Player:
 
 @pytest.fixture
 def game(player: Player) -> DungeonBase:
-    load_floor_configs()
+    load_floor_definitions()
     game = DungeonBase(3, 3)
     game.current_floor = 1
     game.player = player

--- a/tests/test_boss_loot.py
+++ b/tests/test_boss_loot.py
@@ -9,8 +9,8 @@ from dungeoncrawler.dungeon import (
     BOSS_LOOT,
     BOSS_TRAITS,
     DungeonBase,
-    load_floor_configs,
 )
+from dungeoncrawler.data import load_floor_definitions
 from dungeoncrawler.entities import Enemy, Player
 
 
@@ -29,7 +29,7 @@ def test_boss_drops_loot(monkeypatch):
 
 
 def test_stat_boost_when_no_loot(monkeypatch):
-    load_floor_configs()
+    load_floor_definitions()
     game = DungeonBase(1, 1)
     game.player = Player("Hero")
     monkeypatch.setitem(game.boss_loot, "Bone Tyrant", [])

--- a/tests/test_dungeon_generation.py
+++ b/tests/test_dungeon_generation.py
@@ -5,14 +5,15 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from dungeoncrawler import map as dungeon_map
-from dungeoncrawler.dungeon import DungeonBase, load_floor_configs
+from dungeoncrawler.dungeon import DungeonBase
 from dungeoncrawler.entities import Enemy, Player
 from dungeoncrawler.events import CacheEvent, FountainEvent
+from dungeoncrawler.data import load_floor_definitions
 
 
 def test_generate_dungeon_size_and_population():
     random.seed(0)
-    load_floor_configs()
+    load_floor_definitions()
     dungeon = DungeonBase(1, 1)
     dungeon.player = Player("Tester")
     dungeon_map.generate_dungeon(dungeon, floor=1)
@@ -47,7 +48,7 @@ def test_generate_dungeon_size_and_population():
 
 def test_generate_dungeon_scaling_and_spawn_features_floor2():
     random.seed(0)
-    load_floor_configs()
+    load_floor_definitions()
     dungeon = DungeonBase(1, 1)
     dungeon.player = Player("Tester")
     dungeon_map.generate_dungeon(dungeon, floor=2)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from dungeoncrawler.dungeon import DungeonBase, load_floor_configs
+from dungeoncrawler.dungeon import DungeonBase
 from dungeoncrawler.entities import Player
 from dungeoncrawler.events import (
     FountainEvent,
@@ -12,10 +12,11 @@ from dungeoncrawler.events import (
     PuzzleEvent,
     TrapEvent,
 )
+from dungeoncrawler.data import load_floor_definitions
 
 
 def setup_game():
-    load_floor_configs()
+    load_floor_definitions()
     game = DungeonBase(5, 5)
     game.player = Player("hero")
     return game

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -5,13 +5,14 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from dungeoncrawler import map as dungeon_map
-from dungeoncrawler.dungeon import DungeonBase, load_floor_configs
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.data import load_floor_definitions
 from dungeoncrawler.entities import Player
 
 
 def test_render_map_snapshot():
     random.seed(0)
-    load_floor_configs()
+    load_floor_definitions()
     game = DungeonBase(1, 1)
     game.player = Player("Tester")
     dungeon_map.generate_dungeon(game, floor=1)
@@ -35,7 +36,7 @@ def test_render_map_snapshot():
 
 def test_render_map_symbols_after_show_map():
     random.seed(0)
-    load_floor_configs()
+    load_floor_definitions()
     game = DungeonBase(1, 1)
     game.player = Player("Tester")
     dungeon_map.generate_dungeon(game, floor=1)
@@ -53,7 +54,7 @@ def test_render_map_symbols_after_show_map():
 
 def test_map_legend_toggle():
     random.seed(0)
-    load_floor_configs()
+    load_floor_definitions()
     game = DungeonBase(1, 1)
     game.player = Player("Tester")
     dungeon_map.generate_dungeon(game, floor=1)

--- a/tests/test_mini_quest_hook_event.py
+++ b/tests/test_mini_quest_hook_event.py
@@ -3,14 +3,15 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from dungeoncrawler.dungeon import DungeonBase, load_floor_configs
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.data import load_floor_definitions
 from dungeoncrawler.entities import Player
 from dungeoncrawler.events import MiniQuestHookEvent
 from dungeoncrawler.quests import EscortNPC, EscortQuest
 
 
 def setup_game():
-    load_floor_configs()
+    load_floor_definitions()
     game = DungeonBase(5, 5)
     game.player = Player("hero")
     return game


### PR DESCRIPTION
## Summary
- add `FloorDefinition` dataclass and loader
- expose cached floors through `get_floor`
- update tests to use new loader

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ea2999c9c8326a4f8dbcc7820a5c7