### PR TITLE
Add floor hook interface and hook execution for dungeon floors

### DIFF
--- a/dungeoncrawler/data.py
+++ b/dungeoncrawler/data.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
@@ -137,6 +137,7 @@ class FloorDefinition:
     objective: Dict[str, Any]
     spawns: List[Dict[str, Any]]
     ui: Dict[str, Any]
+    hooks: List[str] = field(default_factory=list)
 
 
 @lru_cache(maxsize=None)
@@ -160,6 +161,7 @@ def load_floor_definitions() -> Dict[str, FloorDefinition]:
             objective=cfg.get("objective", {}),
             spawns=cfg.get("spawns", []),
             ui=cfg.get("ui", {}),
+            hooks=cfg.get("hooks", []),
         )
         floors[floor.id] = floor
     return floors

--- a/schemas/floor.json
+++ b/schemas/floor.json
@@ -104,6 +104,11 @@
         "map_overlay": {"type": "boolean"}
       },
       "additionalProperties": false
+    },
+    "hooks": {
+      "description": "List of module paths providing floor hooks.",
+      "type": "array",
+      "items": {"type": "string"}
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary
- add FloorHooks interface with lifecycle methods
- load optional hook modules from floor JSON definitions
- invoke hooks during floor start, turn loop, objective check and floor end
- extend floor schema to allow specifying hook modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ea41d939883268f1e13d30f73cc56