### PR TITLE
Add floor schema validation and hook order tests

### DIFF
--- a/data/floors/01_intro.json
+++ b/data/floors/01_intro.json
@@ -4,7 +4,9 @@
   "name": "Intro",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/02_floor.json
+++ b/data/floors/02_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/03_floor.json
+++ b/data/floors/03_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/04_floor.json
+++ b/data/floors/04_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/05_floor.json
+++ b/data/floors/05_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/06_floor.json
+++ b/data/floors/06_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/07_floor.json
+++ b/data/floors/07_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/08_floor.json
+++ b/data/floors/08_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/09_floor.json
+++ b/data/floors/09_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/10_floor.json
+++ b/data/floors/10_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/11_floor.json
+++ b/data/floors/11_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/12_floor.json
+++ b/data/floors/12_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/13_floor.json
+++ b/data/floors/13_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/14_floor.json
+++ b/data/floors/14_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/15_floor.json
+++ b/data/floors/15_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/16_floor.json
+++ b/data/floors/16_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/17_floor.json
+++ b/data/floors/17_floor.json
@@ -4,7 +4,9 @@
   "name": "Floor",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/data/floors/18_final.json
+++ b/data/floors/18_final.json
@@ -4,7 +4,9 @@
   "name": "Final",
   "map": [],
   "rule_mods": {},
-  "objective": {},
+  "objective": {
+    "type": "none"
+  },
   "spawns": [],
   "ui": {}
 }

--- a/tests/test_floor_schema.py
+++ b/tests/test_floor_schema.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA = json.loads((ROOT / "schemas" / "floor.json").read_text())
+FLOOR_FILES = sorted((ROOT / "data" / "floors").glob("*.json"))
+
+@pytest.mark.parametrize("floor_path", FLOOR_FILES, ids=lambda p: p.name)
+def test_floor_files_conform_to_schema(floor_path):
+    data = json.loads(floor_path.read_text())
+    data.pop("$schema", None)
+    Draft7Validator(SCHEMA).validate(data)

--- a/tests/test_floor_swapping.py
+++ b/tests/test_floor_swapping.py
@@ -1,0 +1,25 @@
+import json
+import shutil
+from pathlib import Path
+
+from dungeoncrawler import data
+
+
+def test_swapping_floor_json_changes_behavior(tmp_path, monkeypatch):
+    original = data.load_floor_definitions()["01"].name
+
+    temp_data = tmp_path
+    src_floors = Path(data.DATA_DIR) / "floors"
+    shutil.copytree(src_floors, temp_data / "floors")
+
+    modified = temp_data / "floors" / "01_intro.json"
+    contents = json.loads(modified.read_text())
+    contents["name"] = "Altered Floor"
+    modified.write_text(json.dumps(contents))
+
+    monkeypatch.setattr(data, "DATA_DIR", temp_data)
+    data.load_floor_definitions.cache_clear()
+    altered = data.load_floor_definitions()["01"].name
+
+    assert altered == "Altered Floor"
+    assert altered != original

--- a/tests/test_hook_order.py
+++ b/tests/test_hook_order.py
@@ -1,0 +1,43 @@
+from dungeoncrawler.dungeon import DungeonBase, FloorHooks
+from dungeoncrawler.entities import Player
+from dungeoncrawler import data
+
+
+class LoggingHooks(FloorHooks):
+    def __init__(self, log):
+        self.log = log
+
+    def on_floor_start(self, state, floor):
+        self.log.append("start")
+
+    def on_turn(self, state, floor):
+        self.log.append("turn")
+
+    def on_objective_check(self, state, floor):
+        self.log.append("objective")
+        return True
+
+    def on_floor_end(self, state, floor):
+        self.log.append("end")
+
+
+def test_hooks_execute_in_correct_order():
+    data.load_floor_definitions()
+    game = DungeonBase(5, 5)
+    game.player = Player("hero")
+    game.floor_def = data.get_floor(1)
+    log = []
+    game.floor_hooks = [LoggingHooks(log)]
+
+    state = game._make_state(1)
+    for hook in game.floor_hooks:
+        hook.on_floor_start(state, game.floor_def)
+
+    floor, continue_floor = game.process_turn(1)
+    assert continue_floor is False
+
+    end_state = game._make_state(floor - 1)
+    for hook in game.floor_hooks:
+        hook.on_floor_end(end_state, game.floor_def)
+
+    assert log == ["start", "turn", "objective", "end"]


### PR DESCRIPTION
## Summary
- ensure each floor JSON includes a placeholder objective type for schema compliance
- add schema validation test over all floor definitions
- test that hooks run in start-turn-objective-end order and that swapping floor JSON affects runtime data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ea56c6c048326a53a417d3c4b459b