### PR TITLE
Add test verifying defend consumption after next hit

### DIFF
--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -131,3 +131,27 @@ def test_player_flee_failure_gives_enemy_advantage():
     enemy.attack(player)
     assert player.health < before
     assert "advantage" not in enemy.status_effects
+
+
+def test_defend_consumed_after_next_hit(monkeypatch):
+    player = Player("Hero")
+    enemy = Enemy("Goblin", 20, 10, 0, 0)
+
+    rolls = iter([1, 10, 1, 10])
+    monkeypatch.setattr(
+        "dungeoncrawler.entities.random.randint", lambda a, b: next(rolls)
+    )
+
+    player.defend()
+    before = player.health
+    enemy.attack(player)
+
+    assert player.health == before - 6
+    assert player.guard_damage is False
+    assert player.guard_attack is True
+
+    enemy_before = enemy.health
+    player.attack(enemy)
+    assert enemy.health == enemy_before - 10
+    assert player.guard_attack is False
+    assert "guard" not in player.status_effects


### PR DESCRIPTION
## Summary
- add unit test confirming a defended player only reduces the next incoming blow and retains a guard bonus for the following attack

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ea6a65b2083269f23c6ba5eb4f306