### PR TITLE
Add Rat King intro floor and boss hook

### DIFF
--- a/data/bosses.json
+++ b/data/bosses.json
@@ -1,4 +1,25 @@
-[
+[ 
+  {
+    "name": "Rat King",
+    "stats": [
+      150,
+      20,
+      8,
+      50
+    ],
+    "ai": {"aggressive": 2, "defensive": 1},
+    "traits": [],
+    "ability": "poison",
+    "loot": [
+      {
+        "name": "Royal Rat Spear",
+        "description": "A spear fashioned from gnawed bones.",
+        "min_damage": 10,
+        "max_damage": 14,
+        "price": 0
+      }
+    ]
+  },
   {
     "name": "Bone Tyrant",
     "stats": [

--- a/data/floors.json
+++ b/data/floors.json
@@ -10,7 +10,7 @@
       "Bandit"
     ],
     "bosses": [
-      "Bone Tyrant"
+      "Rat King"
     ],
     "places": {
       "Trap": 2,

--- a/data/floors/01_intro.json
+++ b/data/floors/01_intro.json
@@ -5,8 +5,10 @@
   "map": [],
   "rule_mods": {},
   "objective": {
-    "type": "none"
+    "type": "boss",
+    "target": "Rat King"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": ["dungeoncrawler.hooks.rat_king"]
 }

--- a/dungeoncrawler/ai.py
+++ b/dungeoncrawler/ai.py
@@ -133,6 +133,11 @@ ARCHETYPES = {
 # Telegraphs for bosses to foreshadow their unique mechanics
 IntentAI.TELEGRAPHS.update(
     {
+        "Rat King": {
+            "aggressive": "Rat King lashes out amid a swarm of rats.",
+            "defensive": "Rat King commands its brood to form a living wall.",
+            "unpredictable": "Rat King scurries unpredictably between minions.",
+        },
         "Bone Tyrant": {
             "aggressive": "Bone Tyrant hefts its club for a crushing blow.",
             "defensive": "Bone Tyrant knits stray bones into a shield.",

--- a/dungeoncrawler/core/state.py
+++ b/dungeoncrawler/core/state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Any
 
 from .map import GameMap
 
@@ -34,6 +34,7 @@ class GameState:
     player: Optional["Player"]
     game_map: GameMap
     log: List[str] = field(default_factory=list)
+    game: Any | None = None
 
     def queue_message(self, message: str) -> None:
         """Append ``message`` to the log buffer."""

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -411,6 +411,7 @@ class DungeonBase:
             player=self.player,
             game_map=gm,
             log=list(self.messages),
+            game=self,
         )
 
     def save_game(self, floor):

--- a/dungeoncrawler/hooks/rat_king.py
+++ b/dungeoncrawler/hooks/rat_king.py
@@ -1,0 +1,74 @@
+import random
+
+from dungeoncrawler.dungeon import FloorHooks
+from dungeoncrawler.entities import Enemy
+
+
+class Hooks(FloorHooks):
+    """Special behaviour for the Rat King boss."""
+
+    def __init__(self) -> None:
+        self.exit_location = None
+
+    def on_floor_start(self, state, floor):
+        """Seal the exit until the Rat King falls."""
+        game = state.game
+        if game.exit_coords:
+            self.exit_location = game.exit_coords
+            ex, ey = game.exit_coords
+            game.rooms[ey][ex] = None
+            game.exit_coords = None
+
+    def on_turn(self, state, floor):
+        """Spawn spectral rats each turn unless the boss is stunned."""
+        game = state.game
+        boss = None
+        for y, row in enumerate(game.rooms):
+            for x, obj in enumerate(row):
+                if isinstance(obj, Enemy) and obj.name == "Rat King":
+                    boss = obj
+                    break
+            if boss:
+                break
+        if not boss or "stun" in boss.status_effects:
+            return
+
+        # Find empty adjacent tiles around the boss
+        positions = []
+        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+            nx, ny = boss.x + dx, boss.y + dy
+            if 0 <= nx < game.width and 0 <= ny < game.height and game.rooms[ny][nx] is None:
+                positions.append((nx, ny))
+        if not positions:
+            return
+
+        nx, ny = random.choice(positions)
+        stats = game.enemy_stats.get("Spectral Rat")
+        if not stats:
+            return
+        hp_min, hp_max, atk_min, atk_max, defense = stats
+        enemy = Enemy(
+            "Spectral Rat",
+            random.randint(hp_min, hp_max),
+            random.randint(atk_min, atk_max),
+            defense,
+            0,
+            ability=game.enemy_abilities.get("Spectral Rat"),
+            ai=None,
+            traits=game.enemy_traits.get("Spectral Rat"),
+        )
+        enemy.x, enemy.y = nx, ny
+        game.rooms[ny][nx] = enemy
+
+    def on_objective_check(self, state, floor):
+        """Open the exit once the Rat King has been defeated."""
+        game = state.game
+        for y, row in enumerate(game.rooms):
+            for x, obj in enumerate(row):
+                if isinstance(obj, Enemy) and obj.name == "Rat King":
+                    return False
+        if self.exit_location and game.exit_coords is None:
+            ex, ey = self.exit_location
+            game.rooms[ey][ex] = "Exit"
+            game.exit_coords = (ex, ey)
+        return False

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -150,12 +150,15 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
     place(Item("Key", "Opens the dungeon exit"))
     if floor == 1:
         place_near_start("Sanctuary", 10)
-
-    # Always ensure a helpful non-combat feature near the starting room
-    total = config.trap_chance + config.loot_mult
-    fountain_prob = config.trap_chance / total if total else 0.5
-    event_cls = FountainEvent if random.random() < fountain_prob else CacheEvent
-    place_near_start(event_cls(), 10)
+        # Guarantee both healing and loot opportunities near the start
+        place_near_start(FountainEvent(), 10)
+        place_near_start(CacheEvent(), 10)
+    else:
+        # Always ensure a helpful non-combat feature near the starting room
+        total = config.trap_chance + config.loot_mult
+        fountain_prob = config.trap_chance / total if total else 0.5
+        event_cls = FountainEvent if random.random() < fountain_prob else CacheEvent
+        place_near_start(event_cls(), 10)
 
     enemy_pool = cfg.get("enemy_pool", cfg.get("enemies", []))
     early_game_bonus = 5 if floor <= 3 else 0

--- a/tests/test_boss_loot.py
+++ b/tests/test_boss_loot.py
@@ -32,7 +32,7 @@ def test_stat_boost_when_no_loot(monkeypatch):
     load_floor_definitions()
     game = DungeonBase(1, 1)
     game.player = Player("Hero")
-    monkeypatch.setitem(game.boss_loot, "Bone Tyrant", [])
+    monkeypatch.setitem(game.boss_loot, "Rat King", [])
     base = game.player.attack_power
     dungeon_map.generate_dungeon(game, floor=1)
     assert game.player.attack_power == base + 1

--- a/tests/test_intro_floor.py
+++ b/tests/test_intro_floor.py
@@ -1,0 +1,61 @@
+import os
+import random
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler import map as dungeon_map
+from dungeoncrawler.data import load_floor_definitions, get_floor
+from dungeoncrawler.dungeon import DungeonBase, load_hook_modules
+from dungeoncrawler.entities import Player, Enemy
+from dungeoncrawler.events import FountainEvent, CacheEvent
+
+
+def test_intro_floor_has_fountain_and_cache_near_spawn():
+    random.seed(0)
+    load_floor_definitions()
+    game = DungeonBase(1, 1)
+    game.player = Player("Tester")
+    dungeon_map.generate_dungeon(game, floor=1)
+
+    px, py = game.player.x, game.player.y
+    fountain = cache = None
+    for y, row in enumerate(game.rooms):
+        for x, obj in enumerate(row):
+            if isinstance(obj, FountainEvent):
+                fountain = (x, y)
+            elif isinstance(obj, CacheEvent):
+                cache = (x, y)
+    assert fountain and cache
+    assert abs(px - fountain[0]) + abs(py - fountain[1]) <= 10
+    assert abs(px - cache[0]) + abs(py - cache[1]) <= 10
+
+
+def test_rat_king_defeat_opens_exit():
+    random.seed(0)
+    load_floor_definitions()
+    game = DungeonBase(1, 1)
+    game.player = Player("Tester")
+    dungeon_map.generate_dungeon(game, floor=1)
+
+    floor_def = get_floor(1)
+    hooks = load_hook_modules(floor_def.hooks)
+    state = game._make_state(1)
+    hook = hooks[0]
+    hook.on_floor_start(state, floor_def)
+
+    # Exit should be sealed at start
+    assert game.exit_coords is None
+
+    # Remove the Rat King to simulate defeat
+    for y, row in enumerate(game.rooms):
+        for x, obj in enumerate(row):
+            if isinstance(obj, Enemy) and obj.name == "Rat King":
+                game.rooms[y][x] = None
+                break
+
+    state = game._make_state(1)
+    hook.on_objective_check(state, floor_def)
+    ex, ey = hook.exit_location
+    assert game.exit_coords == (ex, ey)
+    assert game.rooms[ey][ex] == "Exit"


### PR DESCRIPTION
## Summary
- create intro floor file pointing to Rat King boss and hook
- implement hook that seals exit, spawns spectral rats, and unlocks exit on boss defeat
- guarantee fountain and cache near spawn on floor 1 and add Rat King boss data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ead076a7c83269b4f33a13336b1fc