### PR TITLE
Add guild trials and champion mechanics

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -376,6 +376,8 @@ class DungeonBase:
         self.novice_luck_announced = False
         self.stairs_prompt_shown = False
         self.active_quest = None
+        # Track guild trial completion when present
+        self.completed_trials: set[str] = set()
         # Balance metrics logger and combat message buffer
         self.stats_logger = StatsLogger()
         self.combat_log = CombatLog()

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -187,6 +187,19 @@ class CacheEvent(BaseEvent):
         game.stats_logger.record_reward()
 
 
+class TrialEvent(BaseEvent):
+    """Guild trial that records completion as an event."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
+        trials = getattr(game, "completed_trials", set())
+        trials.add(self.name)
+        game.completed_trials = trials
+        output_func(_(f"You complete the {self.name} trial."))
+
+
 class LoreNote(TypedDict, total=False):
     """Lore note entry loaded from configuration."""
 

--- a/dungeoncrawler/hooks/guild_trials.py
+++ b/dungeoncrawler/hooks/guild_trials.py
@@ -1,0 +1,9 @@
+from dungeoncrawler.dungeon import FloorHooks
+
+
+class Hooks(FloorHooks):
+    """Hook tracking guild trial completion."""
+
+    def on_objective_check(self, state, floor):
+        """Objective met when any two trials are completed."""
+        return len(getattr(state.game, "completed_trials", set())) >= 2

--- a/tests/test_guild_trials.py
+++ b/tests/test_guild_trials.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player, create_guild_champion
+from dungeoncrawler.events import TrialEvent
+from dungeoncrawler.hooks.guild_trials import Hooks
+
+
+def test_join_guild_adds_skill():
+    player = Player("Hero")
+    player.join_guild("Warriors' Guild")
+    assert player.guild == "Warriors' Guild"
+    assert any(s["name"] == "Warrior Technique" for s in player.skills.values())
+
+
+def test_trials_objective_met_after_two_events():
+    game = DungeonBase(5, 5)
+    game.player = Player("Hero")
+    hook = Hooks()
+    state = game._make_state(1)
+    assert not hook.on_objective_check(state, None)
+    TrialEvent("Strength").trigger(game)
+    state = game._make_state(1)
+    assert not hook.on_objective_check(state, None)
+    TrialEvent("Wisdom").trigger(game)
+    state = game._make_state(1)
+    assert hook.on_objective_check(state, None)
+
+
+def test_guild_champion_mirrors_player():
+    player = Player("Hero")
+    player.choose_class("Mage")
+    champ = create_guild_champion(player)
+    assert champ.name == "Guild Champion"
+    assert champ.health == player.max_health
+    assert champ.attack_power == player.attack_power


### PR DESCRIPTION
## Summary
- add TrialEvent and hook to track guild trials and mark objective complete after any two trials
- extend guilds with active skills, attach skill on joining, and provide generic guild skill handler
- introduce Guild Champion enemy mirroring player stats

## Testing
- `pytest tests/test_guild_trials.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eaf57a1688326ba3a103c9f7baa4c