### PR TITLE
Add race unlock event and new floor hooks

### DIFF
--- a/dungeoncrawler/data.py
+++ b/dungeoncrawler/data.py
@@ -20,6 +20,7 @@ from .events import (
     MiniQuestHookEvent,
     PuzzleChamberEvent,
     PuzzleEvent,
+    RaceUnlockEvent,
     ShrineEvent,
     ShrineGauntletEvent,
     TrapEvent,
@@ -43,6 +44,7 @@ EVENT_CLASS_MAP = {
         ShrineGauntletEvent,
         PuzzleChamberEvent,
         EscortMissionEvent,
+        RaceUnlockEvent,
     ]
 }
 

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -252,6 +252,7 @@ class Player(Entity):
         self.cause_of_death = ""
         self.novice_luck_active = False
         self.speed = 10
+        self.vision = 5
         # Temporary combat modifiers for the defend action
         self.guard_damage = False
         self.guard_attack = False

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -332,3 +332,23 @@ class EscortMissionEvent(BaseEvent):
         quest = EscortQuest(npc, reward=100, flavor=_("Guide the acolyte to the exit."))
         game.active_quest = quest
         output_func(_("A fearful acolyte asks for your protection."))
+
+
+class RaceUnlockEvent(BaseEvent):
+    """Unlock a special race with vision and speed adjustments."""
+
+    def __init__(self, race="Night Elf", vision=8, speed_mod=-2) -> None:
+        self.race = race
+        self.vision = vision
+        self.speed_mod = speed_mod
+
+    def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
+        """Apply race unlock and modify player attributes."""
+
+        game.unlocks["race"] = True
+        player = game.player
+        if player:
+            player.race = self.race
+            player.vision = self.vision
+            player.speed += self.speed_mod
+        output_func(_(f"Your heritage awakens as a {self.race}!"))

--- a/dungeoncrawler/hooks/gas_vent.py
+++ b/dungeoncrawler/hooks/gas_vent.py
@@ -1,0 +1,16 @@
+from dungeoncrawler.dungeon import FloorHooks
+
+
+class Hooks(FloorHooks):
+    """Hazard dealing damage when standing on a gas vent."""
+
+    def on_turn(self, state, floor):
+        game = state.game
+        player = state.player
+        if not player:
+            return
+        x, y = player.x, player.y
+        if 0 <= y < game.height and 0 <= x < game.width:
+            if game.rooms[y][x] == "Gas Vent":
+                player.take_damage(5, source="Gas Vent")
+                state.queue_message("A gas vent spews noxious fumes!")

--- a/dungeoncrawler/hooks/warden_statue.py
+++ b/dungeoncrawler/hooks/warden_statue.py
@@ -1,0 +1,30 @@
+from itertools import cycle
+
+from dungeoncrawler.dungeon import FloorHooks
+from dungeoncrawler.entities import Enemy
+
+
+class Hooks(FloorHooks):
+    """Floor behaviour for the Warden Statue boss."""
+
+    def __init__(self) -> None:
+        self._cycle = cycle(["physical", "fire", "ice"])
+        self.current_immunity = next(self._cycle)
+
+    def _find_boss(self, game):
+        for row in game.rooms:
+            for obj in row:
+                if isinstance(obj, Enemy) and obj.name == "Warden Statue":
+                    return obj
+        return None
+
+    def on_turn(self, state, floor):
+        boss = self._find_boss(state.game)
+        if boss:
+            boss.current_immunity = self.current_immunity
+            self.current_immunity = next(self._cycle)
+
+    def on_objective_check(self, state, floor):
+        player = state.player
+        count = sum(1 for item in getattr(player, "inventory", []) if getattr(item, "name", "") == "Sigil")
+        return count >= 3

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -11,6 +11,7 @@ from dungeoncrawler.events import (
     MerchantEvent,
     PuzzleEvent,
     TrapEvent,
+    RaceUnlockEvent,
 )
 from dungeoncrawler.data import load_floor_definitions
 
@@ -141,3 +142,14 @@ def test_random_event_selection_from_floor_config():
     ):
         game.trigger_random_event(1)
         assert mock_shop.called
+
+
+def test_race_unlock_event_modifies_stats_and_unlocks():
+    game = setup_game()
+    event = RaceUnlockEvent(race="Seer", vision=7, speed_mod=-1)
+    speed_before = game.player.speed
+    event.trigger(game, output_func=lambda _msg: None)
+    assert game.unlocks["race"] is True
+    assert game.player.race == "Seer"
+    assert game.player.vision == 7
+    assert game.player.speed == speed_before - 1

--- a/tests/test_gas_vent_hook.py
+++ b/tests/test_gas_vent_hook.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+from dungeoncrawler.hooks import gas_vent
+
+
+def test_gas_vent_deals_damage_and_logs_message():
+    game = DungeonBase(1, 1)
+    game.player = Player("Tester")
+    game.rooms = [["Gas Vent"]]
+    game.player.x = game.player.y = 0
+    hook = gas_vent.Hooks()
+    state = game._make_state(1)
+    hp_before = game.player.health
+    hook.on_turn(state, None)
+    assert game.player.health == hp_before - 5
+    assert any("gas vent" in msg.lower() for msg in state.log)

--- a/tests/test_warden_statue_hook.py
+++ b/tests/test_warden_statue_hook.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Enemy, Player
+from dungeoncrawler.items import Item
+from dungeoncrawler.hooks import warden_statue
+
+
+def test_warden_statue_rotates_immunity_and_checks_sigils():
+    game = DungeonBase(1, 1)
+    game.player = Player("Tester")
+    boss = Enemy("Warden Statue", 10, 1, 0, 0)
+    boss.x = boss.y = 0
+    game.rooms = [[boss]]
+
+    hook = warden_statue.Hooks()
+    state = game._make_state(1)
+
+    hook.on_turn(state, None)
+    assert boss.current_immunity == "physical"
+    hook.on_turn(state, None)
+    assert boss.current_immunity == "fire"
+    hook.on_turn(state, None)
+    assert boss.current_immunity == "ice"
+
+    player = game.player
+    player.inventory = [Item("Sigil", ""), Item("Sigil", ""), Item("Sigil", "")]
+    state = game._make_state(1)
+    assert hook.on_objective_check(state, None) is True


### PR DESCRIPTION
## Summary
- add RaceUnlockEvent that grants vision and speed modifiers
- introduce gas vent hazard processed via on_turn hook
- add Warden Statue hook with rotating immunity and sigil objective

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eb154201c8326b23094c42aaffda5