### PR TITLE
Gate class, guild, and race choices by floor with save-proof tests

### DIFF
--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -23,13 +23,16 @@ logger = logging.getLogger(__name__)
 
 def _load_unlocks():
     unlocks = {"class": False, "guild": False, "race": False}
+    max_floor = 0
     if RUN_FILE.exists():
         try:
             with RUN_FILE.open(encoding="utf-8") as f:
-                unlocks.update(json.load(f).get("unlocks", {}))
+                data = json.load(f)
+            unlocks.update(data.get("unlocks", {}))
+            max_floor = data.get("max_floor", 0)
         except (IOError, json.JSONDecodeError):
             logger.exception("Failed to load unlocks from %s", RUN_FILE)
-    return unlocks
+    return unlocks, max_floor
 
 
 def build_character(input_func=input, output_func=print):
@@ -46,7 +49,7 @@ def build_character(input_func=input, output_func=print):
             output_func(_("Name cannot be blank."))
 
     player = Player(name)
-    unlocks = _load_unlocks()
+    unlocks, max_floor = _load_unlocks()
 
     def prompt_class():
         output_func(_("It's time to choose your class! This choice is permanent."))
@@ -132,11 +135,11 @@ def build_character(input_func=input, output_func=print):
         if race:
             player.choose_race(race[0])
 
-    if unlocks.get("class"):
+    if max_floor >= 1:
         prompt_class()
-    if unlocks.get("guild"):
+    if max_floor >= 2:
         prompt_guild()
-    if unlocks.get("race"):
+    if max_floor >= 3:
         prompt_race()
 
     output_func(_("Welcome {name}! Your journey is just beginning.").format(name=player.name))

--- a/tests/test_character_selection.py
+++ b/tests/test_character_selection.py
@@ -16,6 +16,7 @@ def _setup():
 def test_offer_class_permanent_and_skills(capsys):
     dungeon = _setup()
     inputs = iter(["1"])
+    dungeon.current_floor = 1
     dungeon.offer_class(input_func=lambda _: next(inputs))
     out = capsys.readouterr().out.lower()
     assert "permanent" in out
@@ -25,6 +26,7 @@ def test_offer_class_permanent_and_skills(capsys):
 
 def test_offer_guild_screen(capsys):
     dungeon = _setup()
+    dungeon.current_floor = 2
     dungeon.offer_guild(input_func=lambda _: "1")
     out = capsys.readouterr().out.lower()
     assert "permanent" in out
@@ -34,6 +36,7 @@ def test_offer_guild_screen(capsys):
 
 def test_offer_race_screen(capsys):
     dungeon = _setup()
+    dungeon.current_floor = 3
     dungeon.offer_race(input_func=lambda _: "2")
     out = capsys.readouterr().out.lower()
     assert "permanent" in out
@@ -44,6 +47,7 @@ def test_offer_race_screen(capsys):
 def test_offer_class_lists_new_classes(capsys):
     dungeon = _setup()
     inputs = iter(["13"])
+    dungeon.current_floor = 1
     dungeon.offer_class(input_func=lambda _: next(inputs))
     out = capsys.readouterr().out.lower()
     assert "druid" in out

--- a/tests/test_progress_gates.py
+++ b/tests/test_progress_gates.py
@@ -1,0 +1,48 @@
+import json
+
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+from dungeoncrawler.main import build_character
+
+
+def test_build_character_save_manipulation(tmp_path, monkeypatch):
+    run_path = tmp_path / "run.json"
+    run_path.write_text(
+        json.dumps(
+            {
+                "total_runs": 1,
+                "unlocks": {"class": True, "guild": True, "race": True},
+                "max_floor": 1,
+            }
+        )
+    )
+    monkeypatch.setattr("dungeoncrawler.constants.RUN_FILE", run_path)
+    monkeypatch.setattr("dungeoncrawler.main.RUN_FILE", run_path)
+    inputs = iter(["Bob", "1"])  # name, class
+    player = build_character(input_func=lambda _: next(inputs), output_func=lambda _m: None)
+    assert player.class_type == "Warrior"
+    assert player.guild is None
+    assert player.race is None
+
+
+def test_offer_methods_require_correct_floor():
+    dungeon = DungeonBase(5, 5)
+    dungeon.player = Player("hero")
+    dungeon.unlocks = {"class": True, "guild": True, "race": True}
+
+    dungeon.current_floor = 1
+    dungeon.offer_guild(input_func=lambda _: "1")
+    dungeon.offer_race(input_func=lambda _: "2")
+    assert dungeon.player.guild is None
+    assert dungeon.player.race is None
+
+    dungeon.offer_class(input_func=lambda _: "1")
+    assert dungeon.player.class_type == "Warrior"
+
+    dungeon.current_floor = 2
+    dungeon.offer_guild(input_func=lambda _: "1")
+    assert dungeon.player.guild == "Warriors' Guild"
+
+    dungeon.current_floor = 3
+    dungeon.offer_race(input_func=lambda _: "2")
+    assert dungeon.player.race == "Elf"


### PR DESCRIPTION
## Summary
- Track max floor reached and current floor, gating class, guild, and race selection to floors 1, 2, and 3 respectively
- Persist max floor in run stats and load it to control character creation options
- Add tests ensuring floor gates can't be bypassed by editing save files

## Testing
- `pip install jsonschema`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb3a506488326a32d25e00e99ae74