### PR TITLE
Add scoring breakdown and retirement option

### DIFF
--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -722,8 +722,35 @@ class Player(Entity):
         else:
             print(_("You don't have a valid trinket to equip."))
 
+    def get_score_breakdown(self):
+        """Return a detailed score breakdown.
+
+        The base score is computed from the player's level, inventory size and
+        gold.  Style bonuses reward particular achievements such as completing a
+        run without taking damage or leaving the dungeon wealthy.  The result is
+        returned as a dictionary detailing each component and the grand total.
+        """
+
+        breakdown = {
+            "level": self.level * 100,
+            "inventory": len(self.inventory) * 10,
+            "gold": self.gold,
+            "style": {},
+        }
+
+        if self.health == self.max_health:
+            breakdown["style"]["no_damage"] = 50
+        if self.gold >= 100:
+            breakdown["style"]["rich"] = 50
+
+        total = breakdown["level"] + breakdown["inventory"] + breakdown["gold"]
+        total += sum(breakdown["style"].values())
+        breakdown["total"] = total
+        return breakdown
+
     def get_score(self):
-        return self.level * 100 + len(self.inventory) * 10 + self.gold
+        """Compatibility wrapper returning only the total score."""
+        return self.get_score_breakdown()["total"]
 
 
 class Enemy(Entity):

--- a/tests/test_early_exit_save.py
+++ b/tests/test_early_exit_save.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+import dungeoncrawler.dungeon as dungeon_module
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+from dungeoncrawler.items import Item
+
+
+def test_retire_removes_save_file(tmp_path, monkeypatch):
+    save_path = tmp_path / "save.json"
+    score_path = tmp_path / "scores.json"
+    monkeypatch.setattr(dungeon_module, "SAVE_FILE", save_path)
+    monkeypatch.setattr(dungeon_module, "SCORE_FILE", score_path)
+
+    dungeon = DungeonBase(1, 1)
+    player = Player("Tester")
+    player.inventory.append(Item("Key", ""))
+    dungeon.player = player
+    dungeon.exit_coords = (0, 0)
+    player.x = 0
+    player.y = 0
+
+    save_path.write_text("{}")
+
+    monkeypatch.setattr("builtins.input", lambda _: "r")
+    floor, status = dungeon.check_floor_completion(9)
+
+    assert status is None
+    assert not save_path.exists()

--- a/tests/test_leaderboard_append.py
+++ b/tests/test_leaderboard_append.py
@@ -1,0 +1,27 @@
+import json
+
+import dungeoncrawler.dungeon as dungeon_module
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+
+
+def test_record_score_appends_with_timestamp(tmp_path, monkeypatch):
+    score_path = tmp_path / "scores.json"
+    monkeypatch.setattr(dungeon_module, "SCORE_FILE", score_path)
+
+    dungeon = DungeonBase(1, 1)
+    dungeon.player = Player("One")
+    dungeon.run_start = 1
+    dungeon.seed = 123
+    monkeypatch.setattr(dungeon_module.time, "time", lambda: 11)
+    dungeon.record_score(3)
+
+    dungeon.player = Player("Two")
+    dungeon.run_start = 1
+    monkeypatch.setattr(dungeon_module.time, "time", lambda: 21)
+    dungeon.record_score(4)
+
+    data = json.loads(score_path.read_text())
+    assert len(data) == 2
+    assert "timestamp" in data[0]
+    assert data[1]["player_name"] == "Two"

--- a/tests/test_score_calculation.py
+++ b/tests/test_score_calculation.py
@@ -1,0 +1,20 @@
+import json
+import os
+
+from dungeoncrawler.entities import Player
+
+
+def test_score_style_bonuses():
+    player = Player("Tester")
+    player.level = 2
+    player.gold = 120
+    player.inventory.extend([object(), object()])
+    player.health = player.max_health
+
+    breakdown = player.get_score_breakdown()
+    assert breakdown["level"] == 200
+    assert breakdown["inventory"] == 20
+    assert breakdown["gold"] == 120
+    assert breakdown["style"]["no_damage"] == 50
+    assert breakdown["style"]["rich"] == 50
+    assert breakdown["total"] == 440


### PR DESCRIPTION
## Summary
- Prompt players on floor 9 to descend or retire
- Add score breakdown with style bonuses and timestamped leaderboard records
- Test scoring, retirement cleanup and leaderboard append behavior

## Testing
- `pytest tests/test_score_calculation.py tests/test_early_exit_save.py tests/test_leaderboard_append.py tests/test_leaderboard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb74055d08326be35280ac2e17ebb