### PR TITLE
feat: add shop restock and pricing tiers

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -1,20 +1,20 @@
 {
   "shop": [
-    {"type": "Item", "name": "Health Potion", "description": "Restores 20 health"},
-    {"type": "Weapon", "name": "Sword", "description": "A sharp sword", "min_damage": 10, "max_damage": 15, "price": 40},
-    {"type": "Weapon", "name": "Axe", "description": "A heavy axe", "min_damage": 12, "max_damage": 18, "price": 65},
-    {"type": "Weapon", "name": "Dagger", "description": "A quick dagger", "min_damage": 8, "max_damage": 12, "price": 35},
-    {"type": "Weapon", "name": "Warhammer", "description": "Crushes armor and bone", "min_damage": 14, "max_damage": 22, "price": 85},
-    {"type": "Weapon", "name": "Rapier", "description": "A slender, piercing blade", "min_damage": 9, "max_damage": 17, "price": 50},
-    {"type": "Weapon", "name": "Flame Blade", "description": "Glows with searing heat", "min_damage": 13, "max_damage": 20, "price": 95},
-    {"type": "Weapon", "name": "Crossbow", "description": "Ranged attack with bolts", "min_damage": 11, "max_damage": 19, "price": 60},
-    {"type": "Armor", "name": "Leather Armor", "description": "Basic protection", "defense": 2, "price": 30},
+    {"type": "Item", "name": "Health Potion", "description": "Restores 20 health", "price": 10, "rarity": "common"},
+    {"type": "Weapon", "name": "Sword", "description": "A sharp sword", "min_damage": 10, "max_damage": 15, "price": 40, "rarity": "common"},
+    {"type": "Weapon", "name": "Axe", "description": "A heavy axe", "min_damage": 12, "max_damage": 18, "price": 65, "rarity": "uncommon"},
+    {"type": "Weapon", "name": "Dagger", "description": "A quick dagger", "min_damage": 8, "max_damage": 12, "price": 35, "rarity": "common"},
+    {"type": "Weapon", "name": "Warhammer", "description": "Crushes armor and bone", "min_damage": 14, "max_damage": 22, "price": 85, "rarity": "rare"},
+    {"type": "Weapon", "name": "Rapier", "description": "A slender, piercing blade", "min_damage": 9, "max_damage": 17, "price": 50, "rarity": "uncommon"},
+    {"type": "Weapon", "name": "Flame Blade", "description": "Glows with searing heat", "min_damage": 13, "max_damage": 20, "price": 95, "rarity": "rare"},
+    {"type": "Weapon", "name": "Crossbow", "description": "Ranged attack with bolts", "min_damage": 11, "max_damage": 19, "price": 60, "rarity": "uncommon"},
+    {"type": "Armor", "name": "Leather Armor", "description": "Basic protection", "defense": 2, "price": 30, "rarity": "common"},
     {"type": "Trinket", "name": "Lucky Charm", "description": "A charm that brings luck", "effect": "blessed", "price": 25, "rarity": "rare"}
   ],
   "rare": [
-    {"type": "Weapon", "name": "Elven Longbow", "description": "Bow of unmatched accuracy.", "min_damage": 15, "max_damage": 25, "price": 0},
-    {"type": "Item", "name": "Blessed Charm", "description": "Said to bring good fortune."},
-    {"type": "Weapon", "name": "Dwarven Waraxe", "description": "Forged in the deep halls.", "min_damage": 12, "max_damage": 20, "price": 0},
-    {"type": "Item", "name": "Shadow Cloak", "description": "Grants an air of mystery"}
+    {"type": "Weapon", "name": "Elven Longbow", "description": "Bow of unmatched accuracy.", "min_damage": 15, "max_damage": 25, "price": 0, "rarity": "epic"},
+    {"type": "Item", "name": "Blessed Charm", "description": "Said to bring good fortune.", "rarity": "rare"},
+    {"type": "Weapon", "name": "Dwarven Waraxe", "description": "Forged in the deep halls.", "min_damage": 12, "max_damage": 20, "price": 0, "rarity": "epic"},
+    {"type": "Item", "name": "Shadow Cloak", "description": "Grants an air of mystery", "rarity": "rare"}
   ]
 }

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -330,6 +330,7 @@ class DungeonBase:
                 Item("Elixir of Insight", "Reveals hidden paths"),
             ]
         )
+        self.shop_inventory: list[Item] = []
         (
             self.random_events,
             self.random_event_weights,
@@ -1276,6 +1277,17 @@ class DungeonBase:
     def shop(self, input_func=input, output_func=print):
         shop_module.shop(self, input_func=input_func, output_func=output_func)
 
+    def restock_shop(self, count: int = 4) -> None:
+        """Refresh the available shop inventory."""
+
+        if not self.shop_items:
+            self.shop_inventory = []
+            return
+        base = self.shop_items[:1]
+        pool = self.shop_items[1:]
+        k = min(max(0, count - len(base)), len(pool))
+        self.shop_inventory = base + random.sample(pool, k)
+
     def get_sale_price(self, item):
         return shop_module.get_sale_price(item)
 
@@ -1337,6 +1349,7 @@ class DungeonBase:
             self.save_run_stats()
         if floor >= self.next_shop_floor:
             print(_("A traveling merchant sets up shop."))
+            self.restock_shop()
             self.shop()
             self.next_shop_floor = floor + random.randint(2, 3)
 

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -52,6 +52,7 @@ class MerchantEvent(BaseEvent):
     """Open the in-game shop."""
 
     def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
+        game.restock_shop()
         game.shop(input_func=input_func, output_func=output_func)
 
 

--- a/dungeoncrawler/hooks/merchant_hub.py
+++ b/dungeoncrawler/hooks/merchant_hub.py
@@ -12,5 +12,8 @@ class Hooks(FloorHooks):
         self.enabled = False
 
     def on_floor_start(self, state, floor_def) -> None:  # noqa: D401
-        """Read merchant hub configuration."""
+        """Read merchant hub configuration and trigger the shop."""
         self.enabled = bool(floor_def.rule_mods.get("merchant_hub"))
+        if self.enabled:
+            state.game.restock_shop()
+            state.game.shop()

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -189,7 +189,7 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
             )
             * config.enemy_dmg_mult
         )
-        gold = random.randint(15 + early_game_bonus + floor, 30 + floor * 2)
+        gold = random.randint(5 + early_game_bonus + floor, 15 + floor * 2)
 
         ability = game.enemy_abilities.get(name)
         weights = game.enemy_ai.get(name)

--- a/dungeoncrawler/shop.py
+++ b/dungeoncrawler/shop.py
@@ -20,16 +20,18 @@ def shop(
 ) -> None:
     """Interact with the shop allowing the player to buy or sell items."""
 
+    if not getattr(game, "shop_inventory", []):
+        game.restock_shop()
     output_func(_("Welcome to the Shop!"))
     output_func(_(f"Gold: {game.player.gold}"))
-    for i, item in enumerate(game.shop_items, 1):
+    for i, item in enumerate(game.shop_inventory, 1):
         if hasattr(item, "price"):
             base_price = item.price
         else:
             base_price = 10
         price = int(base_price * config.loot_mult)
         output_func(_(f"{i}. {item.name} - {price} Gold"))
-    sell_option = len(game.shop_items) + 1
+    sell_option = len(game.shop_inventory) + 1
     exit_option = sell_option + 1
     output_func(_(f"{sell_option}. Sell Items"))
     output_func(_(f"{exit_option}. Exit"))
@@ -37,8 +39,8 @@ def shop(
     choice = input_func(_("Choose an option:"))
     if choice.isdigit():
         choice = int(choice)
-        if 1 <= choice <= len(game.shop_items):
-            item = game.shop_items[choice - 1]
+        if 1 <= choice <= len(game.shop_inventory):
+            item = game.shop_inventory[choice - 1]
             if hasattr(item, "price"):
                 base_price = item.price
             else:

--- a/tests/test_shop.py
+++ b/tests/test_shop.py
@@ -1,4 +1,5 @@
 import os
+import random
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -52,3 +53,15 @@ def test_sell_unsellable():
     shop_module.sell_items(dungeon, input_func=lambda _: "1", output_func=lambda _msg: None)
     assert dungeon.player.gold == 0
     assert rare_weapon in dungeon.player.inventory
+
+
+def test_shop_inventory_deterministic():
+    random.seed(0)
+    dungeon = DungeonBase(1, 1)
+    random.seed(0)
+    dungeon.restock_shop()
+    first = [item.name for item in dungeon.shop_inventory]
+    random.seed(0)
+    dungeon.restock_shop()
+    second = [item.name for item in dungeon.shop_inventory]
+    assert first == second


### PR DESCRIPTION
## Summary
- assign base prices and rarity tiers to items
- restock shop inventory and trigger bazaar events
- tune gold drops and add deterministic shop tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ebb0e756083268c20df4594ee062e