### PR TITLE
Replace gold with credits

### DIFF
--- a/data/core_events.json
+++ b/data/core_events.json
@@ -7,7 +7,7 @@
   },
   "locked_cache": {
     "rarity": "rare",
-    "loot": "gold",
+    "loot": "credits",
     "key_name": "cache_key"
   }
 }

--- a/dungeoncrawler/core/events.py
+++ b/dungeoncrawler/core/events.py
@@ -161,7 +161,7 @@ class LockedCache:
     style :class:`Event` message is returned to hint at its location.
     """
 
-    loot: str = EVENT_DATA.get("locked_cache", {}).get("loot", "gold")
+    loot: str = EVENT_DATA.get("locked_cache", {}).get("loot", "credits")
     key_name: str = EVENT_DATA.get("locked_cache", {}).get("key_name", "cache_key")
     opened: bool = False
     key_spawned: bool = False

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -64,7 +64,7 @@ LEADERBOARD_SORT_KEYS = {
 # [
 #   {
 #     "name": str,
-#     "stats": [hp, atk, defense, gold],
+#     "stats": [hp, atk, defense, credits],
 #     "ability": "optional",
 #     "loot": [
 #       {
@@ -156,8 +156,8 @@ def load_bosses():
     traits = {}
     for cfg in data:
         name = cfg["name"]
-        hp, atk, dfs, gold = cfg["stats"]
-        stats[name] = (hp, atk, dfs, gold, cfg.get("ability"))
+        hp, atk, dfs, credits = cfg["stats"]
+        stats[name] = (hp, atk, dfs, credits, cfg.get("ability"))
         if "loot" in cfg:
             loot[name] = [Weapon(**item) for item in cfg["loot"]]
         if cfg.get("ai"):
@@ -459,7 +459,7 @@ class DungeonBase:
                 "max_health": self.player.max_health,
                 "attack_power": self.player.attack_power,
                 "xp": self.player.xp,
-                "gold": self.player.gold,
+                "credits": self.player.credits,
                 "class": self.player.class_type,
                 "stamina": self.player.stamina,
                 "temp_strength": getattr(self.player, "temp_strength", 0),
@@ -499,7 +499,7 @@ class DungeonBase:
             self.player.max_health = p["max_health"]
             self.player.attack_power = p["attack_power"]
             self.player.xp = p["xp"]
-            self.player.gold = p["gold"]
+            self.player.credits = p["credits"]
             self.player.stamina = p.get("stamina", self.player.max_stamina)
             self.player.temp_strength = p.get("temp_strength", 0)
             self.player.temp_intelligence = p.get("temp_intelligence", 0)
@@ -615,7 +615,7 @@ class DungeonBase:
         self.renderer.show_message(_("Score Breakdown:"))
         self.renderer.show_message(_(f"  Level: {breakdown['level']}"))
         self.renderer.show_message(_(f"  Inventory: {breakdown['inventory']}"))
-        self.renderer.show_message(_(f"  Gold: {breakdown['gold']}"))
+        self.renderer.show_message(_(f"  Credits: {breakdown['credits']}"))
         for name, bonus in breakdown["style"].items():
             label = name.replace("_", " ").title()
             self.renderer.show_message(_(f"  {label}: {bonus}"))
@@ -917,12 +917,12 @@ class DungeonBase:
                     quest.hint_given = True
             if quest.is_complete(self):
                 print(_("Quest complete!"))
-                self.player.gold += quest.reward
+                self.player.credits += quest.reward
                 self.active_quest = None
         elif isinstance(quest, HuntQuest):
             if quest.is_complete(self):
                 print(_("Quest complete!"))
-                self.player.gold += quest.reward
+                self.player.credits += quest.reward
                 self.active_quest = None
         elif isinstance(quest, EscortQuest):
             npc = quest.npc
@@ -942,7 +942,7 @@ class DungeonBase:
                 npc.x, npc.y = self.player.x, self.player.y
             if quest.is_complete(self):
                 print(_("Quest complete!"))
-                self.player.gold += quest.reward
+                self.player.credits += quest.reward
                 self.active_quest = None
 
     def play_game(self) -> None:
@@ -1304,8 +1304,8 @@ class DungeonBase:
         response = input(_("Answer: ")).strip().lower()
         if response == answer:
             reward = 50
-            print(_(f"Correct! You receive {reward} gold."))
-            self.player.gold += reward
+            print(_(f"Correct! You receive {reward} credits."))
+            self.player.credits += reward
         else:
             print(_("Incorrect! The sage vanishes in disappointment."))
 

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -222,7 +222,7 @@ class Player(Entity):
         super().__init__(name, "The player")
         self.level = 1
         self.xp = 0
-        self.gold = 0
+        self.credits = 0
         self.inventory = []
         self.companions = []
         self.guild = None
@@ -344,7 +344,7 @@ class Player(Entity):
     def attack(self, enemy: Enemy) -> None:
         """Attack ``enemy`` using the equipped weapon or base attack power.
 
-        Applies any weapon effects and awards experience and gold if the enemy
+        Applies any weapon effects and awards experience and credits if the enemy
         is defeated.
         """
         hit_chance = 85
@@ -411,14 +411,14 @@ class Player(Entity):
                 add_status_effect(enemy, effect, duration)
 
     def process_enemy_defeat(self, enemy: Enemy) -> None:
-        """Handle rewards for defeating ``enemy`` such as XP and gold."""
+        """Handle rewards for defeating ``enemy`` such as XP and credits."""
         self.xp += enemy.xp
-        gold_dropped = enemy.drop_gold()
+        credits_dropped = enemy.drop_credits()
         if self.level >= 3:
-            gold_dropped += 5
-        self.gold += gold_dropped
+            credits_dropped += 5
+        self.credits += credits_dropped
         print(_(f"You defeated the {enemy.name}!"))
-        print(_(f"You gained {enemy.xp} XP and {gold_dropped} gold."))
+        print(_(f"You gained {enemy.xp} XP and {credits_dropped} credits."))
         while self.xp >= self.level * 20:
             self.xp -= self.level * 20
             self.level_up()
@@ -639,7 +639,7 @@ class Player(Entity):
         print(_(f"Attack Power increased to {self.attack_power}"))
         print(random.choice(ANNOUNCER_LINES))
         if self.level == 3:
-            print(_("You've unlocked Gold Finder: +5 gold after each kill."))
+            print(_("You've unlocked Credit Finder: +5 credits after each kill."))
         if self.level == 5:
             print(_("You've unlocked Passive Regen: Heal 1 HP per move."))
 
@@ -726,24 +726,24 @@ class Player(Entity):
         """Return a detailed score breakdown.
 
         The base score is computed from the player's level, inventory size and
-        gold.  Style bonuses reward particular achievements such as completing a
-        run without taking damage or leaving the dungeon wealthy.  The result is
+        credits. Style bonuses reward particular achievements such as completing a
+        run without taking damage or leaving the dungeon wealthy. The result is
         returned as a dictionary detailing each component and the grand total.
         """
 
         breakdown = {
             "level": self.level * 100,
             "inventory": len(self.inventory) * 10,
-            "gold": self.gold,
+            "credits": self.credits,
             "style": {},
         }
 
         if self.health == self.max_health:
             breakdown["style"]["no_damage"] = 50
-        if self.gold >= 100:
+        if self.credits >= 100:
             breakdown["style"]["rich"] = 50
 
-        total = breakdown["level"] + breakdown["inventory"] + breakdown["gold"]
+        total = breakdown["level"] + breakdown["inventory"] + breakdown["credits"]
         total += sum(breakdown["style"].values())
         breakdown["total"] = total
         return breakdown
@@ -766,7 +766,7 @@ class Enemy(Entity):
         health,
         attack_power,
         defense,
-        gold,
+        credits,
         ability=None,
         ai=None,
         speed=10,
@@ -777,7 +777,7 @@ class Enemy(Entity):
         self.max_health = health
         self.attack_power = attack_power
         self.defense = defense
-        self.gold = gold
+        self.credits = credits
         self.ability = ability
         self.ai = ai
         self.xp = 10
@@ -801,8 +801,8 @@ class Enemy(Entity):
             print(_(f"The {self.name}'s armor softens the blow!"))
         self.health = max(0, self.health - damage)
 
-    def drop_gold(self):
-        return self.gold
+    def drop_credits(self):
+        return self.credits
 
     def apply_status_effects(self):
         """Delegate to the shared status effect helper and traits."""

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -57,7 +57,7 @@ class MerchantEvent(BaseEvent):
 
 
 class PuzzleEvent(BaseEvent):
-    """Present a riddle that rewards gold when solved."""
+    """Present a riddle that rewards credits when solved."""
 
     def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
         # ``random.choice`` raises ``IndexError`` when ``game.riddles`` is empty.
@@ -72,8 +72,8 @@ class PuzzleEvent(BaseEvent):
         response = input_func(_("Answer: ")).strip().lower()
         if response == answer:
             reward = 50
-            output_func(_(f"Correct! You receive {reward} gold."))
-            game.player.gold += reward
+            output_func(_(f"Correct! You receive {reward} credits."))
+            game.player.credits += reward
             game.stats_logger.record_reward()
         else:
             output_func(_("Incorrect! The sage vanishes in disappointment."))
@@ -173,7 +173,7 @@ class FountainEvent(BaseEvent):
 
 
 class CacheEvent(BaseEvent):
-    """Hidden cache that rewards gold."""
+    """Hidden cache that rewards credits."""
 
     def trigger(self, game: "DungeonBase", input_func=input, output_func=print) -> None:
         intros = [
@@ -182,9 +182,9 @@ class CacheEvent(BaseEvent):
             _("You notice a small cache tucked away."),
         ]
         output_func(random.choice(intros))
-        gold = random.randint(15, 30)
-        game.player.gold += gold
-        output_func(_(f"You discover a hidden cache containing {gold} gold."))
+        credits = random.randint(15, 30)
+        game.player.credits += credits
+        output_func(_(f"You discover a hidden cache containing {credits} credits."))
         game.stats_logger.record_reward()
 
 
@@ -281,7 +281,7 @@ class MiniQuestHookEvent(BaseEvent):
         if quest:
             if quest.is_complete(game):
                 output_func(_("Quest complete!"))
-                game.player.gold += quest.reward
+                game.player.credits += quest.reward
                 if getattr(game, "stats_logger", None):
                     game.stats_logger.record_reward()
                 game.active_quest = None

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -189,13 +189,13 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
             )
             * config.enemy_dmg_mult
         )
-        gold = random.randint(5 + early_game_bonus + floor, 15 + floor * 2)
+        credits = random.randint(5 + early_game_bonus + floor, 15 + floor * 2)
 
         ability = game.enemy_abilities.get(name)
         weights = game.enemy_ai.get(name)
         ai = IntentAI(**weights) if weights else None
         traits = game.enemy_traits.get(name)
-        enemy = Enemy(name, health, attack, defense, gold, ability, ai, traits=traits)
+        enemy = Enemy(name, health, attack, defense, credits, ability, ai, traits=traits)
         enemy.xp = max(5, (health + attack + defense) // 15)
 
         place(enemy)
@@ -206,7 +206,7 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
         if not boss_pool:
             break
         name = random.choice(boss_pool)
-        hp, atk, dfs, gold, ability = game.boss_stats[name]
+        hp, atk, dfs, credits, ability = game.boss_stats[name]
         game.queue_message(_(f"A powerful boss guards this floor! The {name} lurks nearby..."))
         boss_weights = game.boss_ai.get(name)
         boss_ai = IntentAI(**boss_weights) if boss_weights else None
@@ -215,7 +215,7 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
             int((hp + floor * 10) * config.enemy_hp_mult),
             int((atk + floor) * config.enemy_dmg_mult),
             dfs + floor // 2,
-            gold + floor * 5,
+            credits + floor * 5,
             ability=ability,
             ai=boss_ai,
             traits=game.boss_traits.get(name),
@@ -318,9 +318,9 @@ def handle_room(game: "DungeonBase", x: int, y: int) -> None:
         if room.name == "Key":
             game.room_names[y][x] = "Hidden Niche"
     elif room == "Treasure":
-        gold = random.randint(20, 50)
-        game.player.gold += gold
-        game.queue_message(_(f"You found a treasure chest with {gold} gold!"))
+        credits = random.randint(20, 50)
+        game.player.credits += credits
+        game.queue_message(_(f"You found a treasure chest with {credits} credits!"))
         if random.random() < 0.3:
             loot = random.choice(game.rare_loot)
             game.queue_message(_(f"Inside you also discover {loot.name}!"))
@@ -332,23 +332,23 @@ def handle_room(game: "DungeonBase", x: int, y: int) -> None:
         game.queue_message(_("You enter a glowing chamber with ancient runes etched in the stone."))
         if game.player.weapon:
             game.queue_message(_(f"Your current weapon is: {game.player.weapon.name}"))
-            game.queue_message(_("You may enchant it with a status effect for 30 gold."))
+            game.queue_message(_("You may enchant it with a status effect for 30 credits."))
             game.queue_message(_("1. Poison  2. Burn  3. Freeze  4. Cancel"))
             choice = input(_("Choose enchantment: "))
             if game.player.weapon.effect:
                 game.queue_message(
                     _("Your weapon is already enchanted! You can't add another enchantment.")
                 )
-            elif game.player.gold >= 30 and choice in ["1", "2", "3"]:
+            elif game.player.credits >= 30 and choice in ["1", "2", "3"]:
                 effect = {"1": "poison", "2": "burn", "3": "freeze"}[choice]
                 game.player.weapon.description += f" (Enchanted: {effect})"
                 game.player.weapon.effect = effect
-                game.player.gold -= 30
+                game.player.credits -= 30
                 game.queue_message(_(f"Your weapon is now enchanted with {effect}!"))
             elif choice == "4":
                 game.queue_message(_("You leave the enchantment chamber untouched."))
             else:
-                game.queue_message(_("Not enough gold or invalid choice."))
+                game.queue_message(_("Not enough credits or invalid choice."))
         else:
             game.queue_message(_("You need a weapon to enchant."))
         game.rooms[y][x] = None
@@ -362,16 +362,16 @@ def handle_room(game: "DungeonBase", x: int, y: int) -> None:
                 )
             )
             game.queue_message(
-                _("Would you like to upgrade your weapon for 50 gold? +3 min/max damage")
+                _("Would you like to upgrade your weapon for 50 credits? +3 min/max damage")
             )
             confirm = input(_("Upgrade? (y/n): "))
-            if confirm.lower() == "y" and game.player.gold >= 50:
+            if confirm.lower() == "y" and game.player.credits >= 50:
                 game.player.weapon.min_damage += 3
                 game.player.weapon.max_damage += 3
-                game.player.gold -= 50
+                game.player.credits -= 50
                 game.queue_message(_("Your weapon has been reforged and is stronger!"))
-            elif game.player.gold < 50:
-                game.queue_message(_("You don't have enough gold."))
+            elif game.player.credits < 50:
+                game.queue_message(_("You don't have enough credits."))
             else:
                 game.queue_message(_("Maybe next time."))
         else:

--- a/dungeoncrawler/shop.py
+++ b/dungeoncrawler/shop.py
@@ -23,14 +23,14 @@ def shop(
     if not getattr(game, "shop_inventory", []):
         game.restock_shop()
     output_func(_("Welcome to the Shop!"))
-    output_func(_(f"Gold: {game.player.gold}"))
+    output_func(_(f"Credits: {game.player.credits}"))
     for i, item in enumerate(game.shop_inventory, 1):
         if hasattr(item, "price"):
             base_price = item.price
         else:
             base_price = 10
         price = int(base_price * config.loot_mult)
-        output_func(_(f"{i}. {item.name} - {price} Gold"))
+        output_func(_(f"{i}. {item.name} - {price} Credits"))
     sell_option = len(game.shop_inventory) + 1
     exit_option = sell_option + 1
     output_func(_(f"{sell_option}. Sell Items"))
@@ -46,12 +46,12 @@ def shop(
             else:
                 base_price = 10
             price = int(base_price * config.loot_mult)
-            if game.player.gold >= price:
+            if game.player.credits >= price:
                 game.player.collect_item(item)
-                game.player.gold -= price
+                game.player.credits -= price
                 output_func(_(f"You bought {item.name}."))
             else:
-                output_func(_("Not enough gold."))
+                output_func(_("Not enough credits."))
         elif choice == sell_option:
             sell_items(game, input_func=input_func, output_func=output_func)
         elif choice == exit_option:
@@ -92,7 +92,7 @@ def sell_items(
         if sale_price is None:
             output_func(_(f"{i}. {item.name} - Cannot sell"))
         else:
-            output_func(_(f"{i}. {item.name} - {sale_price} Gold"))
+            output_func(_(f"{i}. {item.name} - {sale_price} Credits"))
     output_func(_(f"{len(game.player.inventory)+1}. Back"))
 
     choice = input_func(_("Sell what?"))
@@ -104,10 +104,10 @@ def sell_items(
             if sale_price is None:
                 output_func(_("You can't sell that item."))
                 return
-            confirm = input_func(_(f"Sell {item.name} for {sale_price} gold? (y/n) "))
+            confirm = input_func(_(f"Sell {item.name} for {sale_price} credits? (y/n) "))
             if confirm.lower() == "y":
                 game.player.inventory.pop(choice - 1)
-                game.player.gold += sale_price
+                game.player.credits += sale_price
                 output_func(_(f"You sold {item.name}."))
         elif choice == len(game.player.inventory) + 1:
             return

--- a/dungeoncrawler/ui/terminal.py
+++ b/dungeoncrawler/ui/terminal.py
@@ -125,7 +125,7 @@ class Renderer:
         table.add_row("Health", f"[green]{player.health}/{player.max_health}")
         table.add_row("STA", f"{player.stamina}/{player.max_stamina}")
         table.add_row("XP", str(player.xp))
-        table.add_row("Gold", str(player.gold))
+        table.add_row("Credits", str(player.credits))
         table.add_row("Level", str(player.level))
         table.add_row("Floor", str(game_state.current_floor))
 
@@ -143,7 +143,7 @@ class Renderer:
         self.console.print(table)
         status_template = _(
             "Health: {health}/{max_health} | STA: {stamina}/{max_stamina} | "
-            "XP: {xp} | Gold: {gold} | Level: {level} | Floor: {floor} | "
+            "XP: {xp} | Credits: {credits} | Level: {level} | Floor: {floor} | "
             "Quest: {quest}"
         )
         status = status_template.format(
@@ -152,7 +152,7 @@ class Renderer:
             stamina=player.stamina,
             max_stamina=player.max_stamina,
             xp=player.xp,
-            gold=player.gold,
+            credits=player.credits,
             level=player.level,
             floor=game_state.current_floor,
             quest=quest_status,

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -82,8 +82,8 @@ msgstr "{game.player.name} obtained {room.name}!"
 
 #: dungeoncrawler/map.py:255
 #, python-brace-format
-msgid "You found a treasure chest with {gold} gold!"
-msgstr "You found a treasure chest with {gold} gold!"
+msgid "You found a treasure chest with {credits} credits!"
+msgstr "You found a treasure chest with {credits} credits!"
 
 #: dungeoncrawler/map.py:258
 #, python-brace-format
@@ -105,8 +105,8 @@ msgid "Your current weapon is: {game.player.weapon.name}"
 msgstr "Your current weapon is: {game.player.weapon.name}"
 
 #: dungeoncrawler/map.py:267
-msgid "You may enchant it with a status effect for 30 gold."
-msgstr "You may enchant it with a status effect for 30 gold."
+msgid "You may enchant it with a status effect for 30 credits."
+msgstr "You may enchant it with a status effect for 30 credits."
 
 #: dungeoncrawler/map.py:268
 msgid "1. Poison  2. Burn  3. Freeze  4. Cancel"
@@ -130,8 +130,8 @@ msgid "You leave the enchantment chamber untouched."
 msgstr "You leave the enchantment chamber untouched."
 
 #: dungeoncrawler/map.py:281
-msgid "Not enough gold or invalid choice."
-msgstr "Not enough gold or invalid choice."
+msgid "Not enough credits or invalid choice."
+msgstr "Not enough credits or invalid choice."
 
 #: dungeoncrawler/map.py:283
 msgid "You need a weapon to enchant."
@@ -151,8 +151,8 @@ msgstr ""
 "({game.player.weapon.min_damage}-{game.player.weapon.max_damage})"
 
 #: dungeoncrawler/map.py:292
-msgid "Would you like to upgrade your weapon for 50 gold? +3 min/max damage"
-msgstr "Would you like to upgrade your weapon for 50 gold? +3 min/max damage"
+msgid "Would you like to upgrade your weapon for 50 credits? +3 min/max damage"
+msgstr "Would you like to upgrade your weapon for 50 credits? +3 min/max damage"
 
 #: dungeoncrawler/map.py:293
 msgid "Upgrade? (y/n): "
@@ -163,8 +163,8 @@ msgid "Your weapon has been reforged and is stronger!"
 msgstr "Your weapon has been reforged and is stronger!"
 
 #: dungeoncrawler/map.py:300
-msgid "You don't have enough gold."
-msgstr "You don't have enough gold."
+msgid "You don't have enough credits."
+msgstr "You don't have enough credits."
 
 #: dungeoncrawler/map.py:302
 msgid "Maybe next time."
@@ -247,13 +247,13 @@ msgstr "Welcome to the Shop!"
 
 #: dungeoncrawler/shop.py:18
 #, python-brace-format
-msgid "Gold: {game.player.gold}"
-msgstr "Gold: {game.player.gold}"
+msgid "Credits: {game.player.credits}"
+msgstr "Credits: {game.player.credits}"
 
 #: dungeoncrawler/shop.py:21
 #, python-brace-format
-msgid "{i}. {item.name} - {price} Gold"
-msgstr "{i}. {item.name} - {price} Gold"
+msgid "{i}. {item.name} - {price} Credits"
+msgstr "{i}. {item.name} - {price} Credits"
 
 #: dungeoncrawler/shop.py:24
 #, python-brace-format
@@ -275,8 +275,8 @@ msgid "You bought {item.name}."
 msgstr "You bought {item.name}."
 
 #: dungeoncrawler/shop.py:38
-msgid "Not enough gold."
-msgstr "Not enough gold."
+msgid "Not enough credits."
+msgstr "Not enough credits."
 
 #: dungeoncrawler/shop.py:42
 msgid "Leaving the shop."
@@ -305,8 +305,8 @@ msgstr "{i}. {item.name} - Cannot sell"
 
 #: dungeoncrawler/shop.py:75
 #, python-brace-format
-msgid "{i}. {item.name} - {sale_price} Gold"
-msgstr "{i}. {item.name} - {sale_price} Gold"
+msgid "{i}. {item.name} - {sale_price} Credits"
+msgstr "{i}. {item.name} - {sale_price} Credits"
 
 #: dungeoncrawler/shop.py:76
 msgid "{len(game.player.inventory)+1}. Back"
@@ -322,8 +322,8 @@ msgstr "You can't sell that item."
 
 #: dungeoncrawler/shop.py:87
 #, python-brace-format
-msgid "Sell {item.name} for {sale_price} gold? (y/n) "
-msgstr "Sell {item.name} for {sale_price} gold? (y/n) "
+msgid "Sell {item.name} for {sale_price} credits? (y/n) "
+msgstr "Sell {item.name} for {sale_price} credits? (y/n) "
 
 #: dungeoncrawler/shop.py:91
 #, python-brace-format
@@ -447,8 +447,8 @@ msgstr "You defeated the {enemy.name}!"
 
 #: dungeoncrawler/entities.py:144
 #, python-brace-format
-msgid "You gained {enemy.xp} XP and {gold_dropped} gold."
-msgstr "You gained {enemy.xp} XP and {gold_dropped} gold."
+msgid "You gained {enemy.xp} XP and {credits_dropped} credits."
+msgstr "You gained {enemy.xp} XP and {credits_dropped} credits."
 
 #: dungeoncrawler/entities.py:152
 #, python-brace-format
@@ -591,8 +591,8 @@ msgid "Attack Power increased to {self.attack_power}"
 msgstr "Attack Power increased to {self.attack_power}"
 
 #: dungeoncrawler/entities.py:323
-msgid "You've unlocked Gold Finder: +5 gold after each kill."
-msgstr "You've unlocked Gold Finder: +5 gold after each kill."
+msgid "You've unlocked Credits Finder: +5 credits after each kill."
+msgstr "You've unlocked Credits Finder: +5 credits after each kill."
 
 #: dungeoncrawler/entities.py:325
 msgid "You've unlocked Passive Regen: Heal 1 HP per move."
@@ -820,12 +820,12 @@ msgstr ""
 #: dungeoncrawler/dungeon.py:710
 #, python-brace-format
 msgid ""
-"Health: {self.player.health} | XP: {self.player.xp} | Gold: "
-"{self.player.gold} | Level: {self.player.level} | Floor: {floor} | Skill CD:"
+"Health: {self.player.health} | XP: {self.player.xp} | Credits: "
+"{self.player.credits} | Level: {self.player.level} | Floor: {floor} | Skill CD:"
 " {self.player.skill_cooldown}"
 msgstr ""
-"Health: {self.player.health} | XP: {self.player.xp} | Gold: "
-"{self.player.gold} | Level: {self.player.level} | Floor: {floor} | Skill CD:"
+"Health: {self.player.health} | XP: {self.player.xp} | Credits: "
+"{self.player.credits} | Level: {self.player.level} | Floor: {floor} | Skill CD:"
 " {self.player.skill_cooldown}"
 
 #: dungeoncrawler/dungeon.py:713
@@ -894,8 +894,8 @@ msgstr "A sage poses a riddle:\n"
 
 #: dungeoncrawler/dungeon.py:831 dungeoncrawler/events.py:36
 #, python-brace-format
-msgid "Correct! You receive {reward} gold."
-msgstr "Correct! You receive {reward} gold."
+msgid "Correct! You receive {reward} credits."
+msgstr "Correct! You receive {reward} credits."
 
 #: dungeoncrawler/dungeon.py:834 dungeoncrawler/events.py:39
 msgid "Incorrect! The sage vanishes in disappointment."

--- a/locale/es/LC_MESSAGES/messages.po
+++ b/locale/es/LC_MESSAGES/messages.po
@@ -82,7 +82,7 @@ msgstr ""
 
 #: dungeoncrawler/map.py:255
 #, python-brace-format
-msgid "You found a treasure chest with {gold} gold!"
+msgid "You found a treasure chest with {credits} credits!"
 msgstr ""
 
 #: dungeoncrawler/map.py:258
@@ -105,7 +105,7 @@ msgid "Your current weapon is: {game.player.weapon.name}"
 msgstr ""
 
 #: dungeoncrawler/map.py:267
-msgid "You may enchant it with a status effect for 30 gold."
+msgid "You may enchant it with a status effect for 30 credits."
 msgstr ""
 
 #: dungeoncrawler/map.py:268
@@ -130,7 +130,7 @@ msgid "You leave the enchantment chamber untouched."
 msgstr ""
 
 #: dungeoncrawler/map.py:281
-msgid "Not enough gold or invalid choice."
+msgid "Not enough credits or invalid choice."
 msgstr ""
 
 #: dungeoncrawler/map.py:283
@@ -149,7 +149,7 @@ msgid ""
 msgstr ""
 
 #: dungeoncrawler/map.py:292
-msgid "Would you like to upgrade your weapon for 50 gold? +3 min/max damage"
+msgid "Would you like to upgrade your weapon for 50 credits? +3 min/max damage"
 msgstr ""
 
 #: dungeoncrawler/map.py:293
@@ -161,7 +161,7 @@ msgid "Your weapon has been reforged and is stronger!"
 msgstr ""
 
 #: dungeoncrawler/map.py:300
-msgid "You don't have enough gold."
+msgid "You don't have enough credits."
 msgstr ""
 
 #: dungeoncrawler/map.py:302
@@ -243,12 +243,12 @@ msgstr ""
 
 #: dungeoncrawler/shop.py:18
 #, python-brace-format
-msgid "Gold: {game.player.gold}"
+msgid "Credits: {game.player.credits}"
 msgstr ""
 
 #: dungeoncrawler/shop.py:21
 #, python-brace-format
-msgid "{i}. {item.name} - {price} Gold"
+msgid "{i}. {item.name} - {price} Credits"
 msgstr ""
 
 #: dungeoncrawler/shop.py:24
@@ -271,7 +271,7 @@ msgid "You bought {item.name}."
 msgstr ""
 
 #: dungeoncrawler/shop.py:38
-msgid "Not enough gold."
+msgid "Not enough credits."
 msgstr ""
 
 #: dungeoncrawler/shop.py:42
@@ -301,7 +301,7 @@ msgstr ""
 
 #: dungeoncrawler/shop.py:75
 #, python-brace-format
-msgid "{i}. {item.name} - {sale_price} Gold"
+msgid "{i}. {item.name} - {sale_price} Credits"
 msgstr ""
 
 #: dungeoncrawler/shop.py:76
@@ -318,7 +318,7 @@ msgstr ""
 
 #: dungeoncrawler/shop.py:87
 #, python-brace-format
-msgid "Sell {item.name} for {sale_price} gold? (y/n) "
+msgid "Sell {item.name} for {sale_price} credits? (y/n) "
 msgstr ""
 
 #: dungeoncrawler/shop.py:91
@@ -440,7 +440,7 @@ msgstr ""
 
 #: dungeoncrawler/entities.py:144
 #, python-brace-format
-msgid "You gained {enemy.xp} XP and {gold_dropped} gold."
+msgid "You gained {enemy.xp} XP and {credits_dropped} credits."
 msgstr ""
 
 #: dungeoncrawler/entities.py:152
@@ -581,7 +581,7 @@ msgid "Attack Power increased to {self.attack_power}"
 msgstr ""
 
 #: dungeoncrawler/entities.py:323
-msgid "You've unlocked Gold Finder: +5 gold after each kill."
+msgid "You've unlocked Credits Finder: +5 credits after each kill."
 msgstr ""
 
 #: dungeoncrawler/entities.py:325
@@ -808,8 +808,8 @@ msgstr ""
 #: dungeoncrawler/dungeon.py:710
 #, python-brace-format
 msgid ""
-"Health: {self.player.health} | XP: {self.player.xp} | Gold: {self.player."
-"gold} | Level: {self.player.level} | Floor: {floor} | Skill CD: {self.player."
+"Health: {self.player.health} | XP: {self.player.xp} | Credits: {self.player."
+"credits} | Level: {self.player.level} | Floor: {floor} | Skill CD: {self.player."
 "skill_cooldown}"
 msgstr ""
 
@@ -877,7 +877,7 @@ msgstr ""
 
 #: dungeoncrawler/dungeon.py:831 dungeoncrawler/events.py:36
 #, python-brace-format
-msgid "Correct! You receive {reward} gold."
+msgid "Correct! You receive {reward} credits."
 msgstr ""
 
 #: dungeoncrawler/dungeon.py:834 dungeoncrawler/events.py:39

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -82,7 +82,7 @@ msgstr ""
 
 #: dungeoncrawler/map.py:255
 #, python-brace-format
-msgid "You found a treasure chest with {gold} gold!"
+msgid "You found a treasure chest with {credits} credits!"
 msgstr ""
 
 #: dungeoncrawler/map.py:258
@@ -105,7 +105,7 @@ msgid "Your current weapon is: {game.player.weapon.name}"
 msgstr ""
 
 #: dungeoncrawler/map.py:267
-msgid "You may enchant it with a status effect for 30 gold."
+msgid "You may enchant it with a status effect for 30 credits."
 msgstr ""
 
 #: dungeoncrawler/map.py:268
@@ -130,7 +130,7 @@ msgid "You leave the enchantment chamber untouched."
 msgstr ""
 
 #: dungeoncrawler/map.py:281
-msgid "Not enough gold or invalid choice."
+msgid "Not enough credits or invalid choice."
 msgstr ""
 
 #: dungeoncrawler/map.py:283
@@ -149,7 +149,7 @@ msgid ""
 msgstr ""
 
 #: dungeoncrawler/map.py:292
-msgid "Would you like to upgrade your weapon for 50 gold? +3 min/max damage"
+msgid "Would you like to upgrade your weapon for 50 credits? +3 min/max damage"
 msgstr ""
 
 #: dungeoncrawler/map.py:293
@@ -161,7 +161,7 @@ msgid "Your weapon has been reforged and is stronger!"
 msgstr ""
 
 #: dungeoncrawler/map.py:300
-msgid "You don't have enough gold."
+msgid "You don't have enough credits."
 msgstr ""
 
 #: dungeoncrawler/map.py:302
@@ -243,12 +243,12 @@ msgstr ""
 
 #: dungeoncrawler/shop.py:18
 #, python-brace-format
-msgid "Gold: {game.player.gold}"
+msgid "Credits: {game.player.credits}"
 msgstr ""
 
 #: dungeoncrawler/shop.py:21
 #, python-brace-format
-msgid "{i}. {item.name} - {price} Gold"
+msgid "{i}. {item.name} - {price} Credits"
 msgstr ""
 
 #: dungeoncrawler/shop.py:24
@@ -271,7 +271,7 @@ msgid "You bought {item.name}."
 msgstr ""
 
 #: dungeoncrawler/shop.py:38
-msgid "Not enough gold."
+msgid "Not enough credits."
 msgstr ""
 
 #: dungeoncrawler/shop.py:42
@@ -301,7 +301,7 @@ msgstr ""
 
 #: dungeoncrawler/shop.py:75
 #, python-brace-format
-msgid "{i}. {item.name} - {sale_price} Gold"
+msgid "{i}. {item.name} - {sale_price} Credits"
 msgstr ""
 
 #: dungeoncrawler/shop.py:76
@@ -318,7 +318,7 @@ msgstr ""
 
 #: dungeoncrawler/shop.py:87
 #, python-brace-format
-msgid "Sell {item.name} for {sale_price} gold? (y/n) "
+msgid "Sell {item.name} for {sale_price} credits? (y/n) "
 msgstr ""
 
 #: dungeoncrawler/shop.py:91
@@ -440,7 +440,7 @@ msgstr ""
 
 #: dungeoncrawler/entities.py:144
 #, python-brace-format
-msgid "You gained {enemy.xp} XP and {gold_dropped} gold."
+msgid "You gained {enemy.xp} XP and {credits_dropped} credits."
 msgstr ""
 
 #: dungeoncrawler/entities.py:152
@@ -581,7 +581,7 @@ msgid "Attack Power increased to {self.attack_power}"
 msgstr ""
 
 #: dungeoncrawler/entities.py:323
-msgid "You've unlocked Gold Finder: +5 gold after each kill."
+msgid "You've unlocked Credits Finder: +5 credits after each kill."
 msgstr ""
 
 #: dungeoncrawler/entities.py:325
@@ -808,8 +808,8 @@ msgstr ""
 #: dungeoncrawler/dungeon.py:710
 #, python-brace-format
 msgid ""
-"Health: {self.player.health} | XP: {self.player.xp} | Gold: {self.player."
-"gold} | Level: {self.player.level} | Floor: {floor} | Skill CD: {self.player."
+"Health: {self.player.health} | XP: {self.player.xp} | Credits: {self.player."
+"credits} | Level: {self.player.level} | Floor: {floor} | Skill CD: {self.player."
 "skill_cooldown}"
 msgstr ""
 
@@ -877,7 +877,7 @@ msgstr ""
 
 #: dungeoncrawler/dungeon.py:831 dungeoncrawler/events.py:36
 #, python-brace-format
-msgid "Correct! You receive {reward} gold."
+msgid "Correct! You receive {reward} credits."
 msgstr ""
 
 #: dungeoncrawler/dungeon.py:834 dungeoncrawler/events.py:39

--- a/tests/test_boss_loot.py
+++ b/tests/test_boss_loot.py
@@ -42,8 +42,8 @@ def test_boss_regenerates_trait():
     game = DungeonBase(1, 1)
     game.player = Player("Hero")
     name = "Glacier Fiend"
-    hp, atk, dfs, gold, ability = game.boss_stats[name]
-    enemy = Enemy(name, hp, atk, dfs, gold, ability, traits=BOSS_TRAITS[name])
+    hp, atk, dfs, credits, ability = game.boss_stats[name]
+    enemy = Enemy(name, hp, atk, dfs, credits, ability, traits=BOSS_TRAITS[name])
     enemy.health -= 10
     before = enemy.health
     enemy.apply_status_effects()

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -30,7 +30,7 @@ def test_player_attack_defeats_enemy(player, enemy):
     player.attack(enemy)
     assert enemy.health == 0
     assert player.xp == 5
-    assert player.gold == 10
+    assert player.credits == 10
 
 
 def test_enemy_attack_applies_status(player):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -35,13 +35,13 @@ def test_puzzle_event_rewards_on_correct_answer():
     game = setup_game()
     event = PuzzleEvent()
     with patch("dungeoncrawler.events.random.choice", return_value=("riddle", "answer")):
-        gold_before = game.player.gold
+        credits_before = game.player.credits
         event.trigger(
             game,
             input_func=lambda _: "answer",
             output_func=lambda _msg: None,
         )
-        assert game.player.gold == gold_before + 50
+        assert game.player.credits == credits_before + 50
 
 
 def test_puzzle_event_handles_no_riddles():

--- a/tests/test_god_mode.py
+++ b/tests/test_god_mode.py
@@ -30,7 +30,7 @@ def test_god_set(monkeypatch, game):
     monkeypatch.setattr(config, "enable_debug", True)
     messages = []
     monkeypatch.setattr(game.renderer, "show_message", messages.append)
-    game.player.gold = 1
-    game.handle_input(":god set gold 99")
-    assert game.player.gold == 99
-    assert any("Set gold to 99" in m for m in messages)
+    game.player.credits = 1
+    game.handle_input(":god set credits 99")
+    assert game.player.credits == 99
+    assert any("Set credits to 99" in m for m in messages)

--- a/tests/test_round_trip_save_load.py
+++ b/tests/test_round_trip_save_load.py
@@ -18,7 +18,7 @@ def test_round_trip_save_load(tmp_path, monkeypatch):
 
     dungeon = DungeonBase(1, 1)
     dungeon.player = Player("Hero")
-    dungeon.player.gold = 99
+    dungeon.player.credits = 99
     dungeon.save_game(floor=2)
 
     with open(save_path) as f:

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -15,7 +15,7 @@ def test_save_and_load(tmp_path, monkeypatch):
 
     dungeon = DungeonBase(1, 1)
     dungeon.player = Player("Saver")
-    dungeon.player.gold = 42
+    dungeon.player.credits = 42
     potion = Item("Potion", "Heals")
     dungeon.player.collect_item(potion)
     sword = Weapon("Sword", "Sharp", 3, 5)
@@ -30,7 +30,7 @@ def test_save_and_load(tmp_path, monkeypatch):
     floor = new_dungeon.load_game()
     assert floor == 3
     assert new_dungeon.player.name == "Saver"
-    assert new_dungeon.player.gold == 42
+    assert new_dungeon.player.credits == 42
     assert len(new_dungeon.player.inventory) == 1
     loaded_item = new_dungeon.player.inventory[0]
     assert isinstance(loaded_item, Item)

--- a/tests/test_score_calculation.py
+++ b/tests/test_score_calculation.py
@@ -4,14 +4,14 @@ from dungeoncrawler.entities import Player
 def test_score_style_bonuses():
     player = Player("Tester")
     player.level = 2
-    player.gold = 120
+    player.credits = 120
     player.inventory.extend([object(), object()])
     player.health = player.max_health
 
     breakdown = player.get_score_breakdown()
     assert breakdown["level"] == 200
     assert breakdown["inventory"] == 20
-    assert breakdown["gold"] == 120
+    assert breakdown["credits"] == 120
     assert breakdown["style"]["no_damage"] == 50
     assert breakdown["style"]["rich"] == 50
     assert breakdown["total"] == 440

--- a/tests/test_shop.py
+++ b/tests/test_shop.py
@@ -13,9 +13,9 @@ from dungeoncrawler.items import Item, Weapon
 def test_shop_purchase():
     dungeon = DungeonBase(1, 1)
     dungeon.player = Player("Buyer")
-    dungeon.player.gold = 20
+    dungeon.player.credits = 20
     shop_module.shop(dungeon, input_func=lambda _: "1", output_func=lambda _msg: None)
-    assert dungeon.player.gold == 10
+    assert dungeon.player.credits == 10
     assert any(item.name == "Health Potion" for item in dungeon.player.inventory)
 
 
@@ -28,7 +28,7 @@ def test_sell_weapon():
     shop_module.sell_items(
         dungeon, input_func=lambda _: next(inputs), output_func=lambda _msg: None
     )
-    assert dungeon.player.gold == 20
+    assert dungeon.player.credits == 20
     assert weapon not in dungeon.player.inventory
 
 
@@ -41,7 +41,7 @@ def test_sell_item():
     shop_module.sell_items(
         dungeon, input_func=lambda _: next(inputs), output_func=lambda _msg: None
     )
-    assert dungeon.player.gold == 5
+    assert dungeon.player.credits == 5
     assert potion not in dungeon.player.inventory
 
 
@@ -51,7 +51,7 @@ def test_sell_unsellable():
     rare_weapon = Weapon("Elven Longbow", "Bow", 15, 25, 0)
     dungeon.player.collect_item(rare_weapon)
     shop_module.sell_items(dungeon, input_func=lambda _: "1", output_func=lambda _msg: None)
-    assert dungeon.player.gold == 0
+    assert dungeon.player.credits == 0
     assert rare_weapon in dungeon.player.inventory
 
 


### PR DESCRIPTION
## Summary
- rename currency from gold to credits across entities, events, and UI
- update treasure, shop, and save data handling to work with credits
- adjust tests and translations for the new credits terminology

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ebd0a3930832696f54ff4a72b3a69