### PR TITLE
Scale floor 10 difficulty and bolster elite resistances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - Enemies now select weighted combat intents (Aggressive, Defensive or Unpredictable) and telegraph their actions to the player.
 - Console script entry point `dungeoncrawler`.
 - Defined project metadata (name, version, required Python) in `pyproject.toml`.
+- Entering floor 10 now increases enemy health and damage scaling unless debug mode is enabled.
+- Elite enemies resist negative status effects for longer, halving durations applied to them.
 
 ## [0.9.0b1] - 2025-08-11
 ### Added

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -390,6 +390,8 @@ class DungeonBase:
         self.floor_hooks: list[FloorHooks] = [FloorHooks()]
         self.floor_def: FloorDefinition | None = None
         self.current_floor = 0
+        # Track whether late-game scaling has been applied to avoid stacking
+        self._tier_two_scaled = False
 
     def queue_message(self, text: str, output_func=print):
         """Store ``text`` for later rendering and optionally display it."""
@@ -837,6 +839,15 @@ class DungeonBase:
         how the interactive game behaves and ensures the tests have access to a
         freshly saved state whenever a new floor is created.
         """
+
+        # Apply difficulty scaling when the player reaches the second tier of
+        # the dungeon.  This boosts enemy health and damage to keep later
+        # floors challenging.  Tests can disable this behaviour by enabling
+        # the ``debug`` flag in the configuration.
+        if floor >= 10 and not self._tier_two_scaled and not config.enable_debug:
+            config.enemy_hp_mult += 0.15
+            config.enemy_dmg_mult += 0.10
+            self._tier_two_scaled = True
 
         map_module.generate_dungeon(self, floor)
         self.generate_quest(floor)

--- a/dungeoncrawler/status_effects.py
+++ b/dungeoncrawler/status_effects.py
@@ -17,6 +17,13 @@ EFFECT_INFO = {
     "beetle_bane": "+5% hit chance vs beetles.",
 }
 
+# Multipliers applied to status effect durations based on enemy rarity.
+# Higher rarity foes resist negative conditions for fewer turns.
+RARITY_STATUS_RESISTANCE = {
+    "rare": 0.8,
+    "elite": 0.5,
+}
+
 
 def add_status_effect(entity, effect: str, duration: int) -> None:
     """Apply ``effect`` to ``entity`` and announce it."""
@@ -30,6 +37,9 @@ def add_status_effect(entity, effect: str, duration: int) -> None:
     if effects is None:
         effects = {}
         setattr(entity, "status_effects", effects)
+    rarity = getattr(entity, "rarity", "common")
+    modifier = RARITY_STATUS_RESISTANCE.get(rarity, 1.0)
+    duration = max(1, int(duration * modifier))
     effects[effect] = duration
     is_player = entity.__class__.__name__ == "Player"
     desc = EFFECT_INFO.get(effect, "")

--- a/tests/test_elite_resistance.py
+++ b/tests/test_elite_resistance.py
@@ -1,0 +1,9 @@
+from dungeoncrawler.entities import Enemy
+from dungeoncrawler.status_effects import add_status_effect
+
+
+def test_elite_status_resistance():
+    enemy = Enemy("Dummy", 10, 2, 0, 0)
+    enemy.rarity = "elite"
+    add_status_effect(enemy, "poison", 4)
+    assert enemy.status_effects["poison"] == 2

--- a/tests/test_floor_scaling.py
+++ b/tests/test_floor_scaling.py
@@ -1,0 +1,29 @@
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler import map as dungeon_map
+from dungeoncrawler.entities import Player
+from dungeoncrawler.config import config
+
+
+def test_floor10_scaling_applies(monkeypatch):
+    dungeon = DungeonBase(1, 1)
+    dungeon.player = Player("Tester")
+    monkeypatch.setattr(dungeon_map, "generate_dungeon", lambda *a, **k: None)
+    original_hp, original_dmg = config.enemy_hp_mult, config.enemy_dmg_mult
+    config.enable_debug = False
+    dungeon.generate_dungeon(10)
+    assert config.enemy_hp_mult == original_hp + 0.15
+    assert config.enemy_dmg_mult == original_dmg + 0.10
+    config.enemy_hp_mult = original_hp
+    config.enemy_dmg_mult = original_dmg
+
+
+def test_floor10_scaling_disabled_in_debug(monkeypatch):
+    dungeon = DungeonBase(1, 1)
+    dungeon.player = Player("Tester")
+    monkeypatch.setattr(dungeon_map, "generate_dungeon", lambda *a, **k: None)
+    original_hp, original_dmg = config.enemy_hp_mult, config.enemy_dmg_mult
+    config.enable_debug = True
+    dungeon.generate_dungeon(10)
+    assert config.enemy_hp_mult == original_hp
+    assert config.enemy_dmg_mult == original_dmg
+    config.enable_debug = False


### PR DESCRIPTION
## Summary
- boost enemy HP and damage when entering floor 10
- allow debug mode to disable late-game scaling
- reduce status effect duration on elite enemies

## Testing
- `flake8 && echo 'flake8 success'`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ebf5e75188326b4f450d2c06c52a4