### PR TITLE
Implement high floor debuffs

### DIFF
--- a/dungeoncrawler/core/combat.py
+++ b/dungeoncrawler/core/combat.py
@@ -162,6 +162,7 @@ def resolve_player_action(player: Entity, enemy: Entity, action: str) -> List[Ev
             player.inventory.remove("potion")
             potion = load_items().get("potion", {})
             heal = player.stats.get("potion_heal", potion.get("potion_heal", 20))
+            heal = int(heal * player.stats.get("heal_multiplier", 1))
             max_hp = player.stats.get("max_health", player.stats.get("health", 0))
             new_hp = min(max_hp, player.stats.get("health", 0) + heal)
             player.stats["health"] = new_hp

--- a/dungeoncrawler/core/events.py
+++ b/dungeoncrawler/core/events.py
@@ -99,7 +99,7 @@ class Fountain:
 
         action = action.lower()
         if action == "drink":
-            heal = random.randint(6, 10)
+            heal = int(random.randint(6, 10) * player.stats.get("heal_multiplier", 1))
             hp = player.stats.get("health", 0)
             max_hp = player.stats.get("max_health", hp)
             player.stats["health"] = min(max_hp, hp + heal)

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -392,6 +392,7 @@ class DungeonBase:
         self.current_floor = 0
         # Track whether late-game scaling has been applied to avoid stacking
         self._tier_two_scaled = False
+        self._base_trap_chance = config.trap_chance
 
     def queue_message(self, text: str, output_func=print):
         """Store ``text`` for later rendering and optionally display it."""
@@ -848,6 +849,18 @@ class DungeonBase:
             config.enemy_hp_mult += 0.15
             config.enemy_dmg_mult += 0.10
             self._tier_two_scaled = True
+
+        # Apply high floor debuffs
+        config.trap_chance = self._base_trap_chance
+        if floor >= 11:
+            config.trap_chance += 0.2
+        self.player.heal_multiplier = 0.5 if floor >= 10 else 1.0
+        if floor >= 12:
+            self.player.vision = 3
+        elif floor >= 10:
+            self.player.vision = 4
+        else:
+            self.player.vision = 6 if floor == 1 else 3 + floor // 2
 
         map_module.generate_dungeon(self, floor)
         self.generate_quest(floor)

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -152,8 +152,8 @@ class FountainEvent(BaseEvent):
             choice = input_func(_("Choice: ")).strip().lower()
             if choice == "d":
                 heal = random.randint(6, 10)
-                game.player.health = min(game.player.max_health, game.player.health + heal)
-                output_func(_(f"You feel refreshed and recover {heal} health."))
+                healed = game.player.heal(heal)
+                output_func(_(f"You feel refreshed and recover {healed} health."))
                 game.stats_logger.record_reward()
                 roll = random.random()
                 if roll < self.bless_chance:
@@ -263,8 +263,8 @@ class ShrineEvent(BaseEvent):
             output_func("     /\\")
             if random.random() < self.prayer_boon:
                 heal = random.randint(8, 12)
-                game.player.health = min(game.player.max_health, game.player.health + heal)
-                output_func(_(f"A warm light restores {heal} health."))
+                healed = game.player.heal(heal)
+                output_func(_(f"A warm light restores {healed} health."))
                 game.stats_logger.record_reward()
             else:
                 add_status_effect(game.player, "cursed", 30)

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -58,7 +58,13 @@ def update_visibility(game) -> List[TileDiscovered]:
     """
 
     game.visible = [[False for _ in range(game.width)] for _ in range(game.height)]
-    radius = 6 if getattr(game, "current_floor", 1) == 1 else 3 + game.current_floor // 2
+    floor = getattr(game, "current_floor", 1)
+    if floor >= 12:
+        radius = 3
+    elif floor >= 10:
+        radius = 4
+    else:
+        radius = 6 if floor == 1 else 3 + floor // 2
     events: List[TileDiscovered] = []
     for x, y in compute_visibility(game.rooms, game.player.x, game.player.y, radius):
         game.visible[y][x] = True

--- a/tests/test_high_floor_debuffs.py
+++ b/tests/test_high_floor_debuffs.py
@@ -1,0 +1,68 @@
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player
+from dungeoncrawler.items import Item
+from dungeoncrawler.map import update_visibility
+from dungeoncrawler.data import load_floor_definitions
+from dungeoncrawler.config import config
+
+
+def _open_game(floor: int) -> DungeonBase:
+    load_floor_definitions()
+    game = DungeonBase(20, 20)
+    game.player = Player("Tester")
+    game.current_floor = floor
+    game.width = game.height = 20
+    game.rooms = [["Empty" for _ in range(20)] for _ in range(20)]
+    game.discovered = [[False for _ in range(20)] for _ in range(20)]
+    game.visible = [[False for _ in range(20)] for _ in range(20)]
+    game.player.x = game.player.y = 10
+    return game
+
+
+def test_floor_10_halves_healing(monkeypatch):
+    game = DungeonBase(1, 1)
+    game.player = Player("Hero")
+    monkeypatch.setattr(DungeonBase, "save_game", lambda self, floor: None)
+    game.generate_dungeon(10)
+    game.player.health = game.player.max_health - 20
+    game.player.inventory.append(Item("Health Potion", ""))
+    game.player.use_health_potion()
+    assert game.player.health == game.player.max_health - 10
+
+
+def test_floor_11_trap_chance_increases(monkeypatch):
+    base = config.trap_chance
+    game = DungeonBase(1, 1)
+    game.player = Player("Hero")
+    monkeypatch.setattr(DungeonBase, "save_game", lambda self, floor: None)
+    game.generate_dungeon(11)
+    try:
+        assert config.trap_chance > base
+    finally:
+        config.trap_chance = base
+
+
+def test_floor_10_visibility_reduced():
+    game = _open_game(10)
+    update_visibility(game)
+    px, py = game.player.x, game.player.y
+    max_dist = max(
+        abs(x - px) + abs(y - py)
+        for y in range(game.height)
+        for x in range(game.width)
+        if game.visible[y][x]
+    )
+    assert max_dist == 4
+
+
+def test_floor_12_darkness_limits_visibility():
+    game = _open_game(12)
+    update_visibility(game)
+    px, py = game.player.x, game.player.y
+    max_dist = max(
+        abs(x - px) + abs(y - py)
+        for y in range(game.height)
+        for x in range(game.width)
+        if game.visible[y][x]
+    )
+    assert max_dist == 3


### PR DESCRIPTION
## Summary
- Halve player healing from floor 10 onward and adjust all healing skills and items to respect this multiplier
- Increase trap rates and reduce vision on high floors with floor 12 imposing darkness radius
- Add tests verifying healing reduction, trap chance scaling, and visibility limits

## Testing
- `pytest tests/test_high_floor_debuffs.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ec263de00832685a29cd8e5839f3c