### PR TITLE
Fix flake8 W391 in hard mode test

### DIFF
--- a/tests/test_hard_mode.py
+++ b/tests/test_hard_mode.py
@@ -45,3 +45,4 @@ def test_loot_multiplier_scales_treasure(monkeypatch):
         assert treasure_count == 2
     finally:
         config.loot_mult = base_loot
+# End of file


### PR DESCRIPTION
## Summary
- ensure `tests/test_hard_mode.py` ends with a non-blank line to satisfy flake8

## Testing
- `flake8 .`
- `pytest tests/test_hard_mode.py::test_enemy_stats_scaled_by_config -q` *(fails: KeyboardInterrupt in dungeoncrawler/map.py)*

------
https://chatgpt.com/codex/tasks/task_e_689ecbf10790832682e400788ab77f26