### PR TITLE
Add Floor 12 debuffs and consumable counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Defined project metadata (name, version, required Python) in `pyproject.toml`.
 - Entering floor 10 now increases enemy health and damage scaling unless debug mode is enabled.
 - Elite enemies resist negative status effects for longer, halving durations applied to them.
+- Floor 12 "Hunted" hooks introducing Blood Torrent and Compression Sickness along with counter consumables.
 
 ## [0.9.0b1] - 2025-08-11
 ### Added

--- a/data/floors/12_floor.json
+++ b/data/floors/12_floor.json
@@ -1,12 +1,15 @@
 {
   "$schema": "../../schemas/floor.json",
   "id": "12",
-  "name": "Floor",
+  "name": "Hunted",
   "map": [],
   "rule_mods": {},
   "objective": {
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor12"
+  ]
 }

--- a/data/items.json
+++ b/data/items.json
@@ -9,7 +9,10 @@
     {"type": "Weapon", "name": "Flame Blade", "description": "Glows with searing heat", "min_damage": 13, "max_damage": 20, "price": 95, "rarity": "rare"},
     {"type": "Weapon", "name": "Crossbow", "description": "Ranged attack with bolts", "min_damage": 11, "max_damage": 19, "price": 60, "rarity": "uncommon"},
     {"type": "Armor", "name": "Leather Armor", "description": "Basic protection", "defense": 2, "price": 30, "rarity": "common"},
-    {"type": "Trinket", "name": "Lucky Charm", "description": "A charm that brings luck", "effect": "blessed", "price": 25, "rarity": "rare"}
+    {"type": "Trinket", "name": "Lucky Charm", "description": "A charm that brings luck", "effect": "blessed", "price": 25, "rarity": "rare"},
+    {"type": "Item", "name": "Scent-mask Spray", "description": "Masks blood scent, clearing Blood Torrent", "price": 15, "rarity": "common"},
+    {"type": "Item", "name": "Absorbent Gel", "description": "Soaks and removes Blood Torrent", "price": 20, "rarity": "uncommon"},
+    {"type": "Item", "name": "Anti-Nausea Draught", "description": "Removes Compression Sickness", "price": 15, "rarity": "common"}
   ],
   "rare": [
     {"type": "Weapon", "name": "Elven Longbow", "description": "Bow of unmatched accuracy.", "min_damage": 15, "max_damage": 25, "price": 0, "rarity": "epic"},

--- a/docs/gameplay_guide.rst
+++ b/docs/gameplay_guide.rst
@@ -72,12 +72,12 @@ retaining all previous debuffs.
 * **Floor 12 – “Hunted”**
   - *Blood Torrent* – Minor DoT that persists through healing; enemies gain
     increased vision and aggro radius while active. Stacks to three, each
-    intensifying the trail and damage. Counter with scent-mask spray or
-    absorbent gel; bandaging ends the DoT but leaves a faint trail for three
+    intensifying the trail and damage. Counter with Scent-mask Spray or
+    Absorbent Gel; bandaging ends the DoT but leaves a faint trail for three
     turns.
   - *Compression Sickness* – After teleportation, blinking or using launch pads
     suffer −10% speed, −10% accuracy and increased fumble chance for five
-    turns. Waiting a turn halves the remaining duration; anti-nausea draught
+    turns. Waiting a turn halves the remaining duration; an Anti-Nausea Draught
     removes it.
 * **Floor 13 – “Anti-Magic”**
   - *Mana Lock* – Spells cost 50% more resources and cleanse or dispel effects

--- a/dungeoncrawler/hooks/floor12.py
+++ b/dungeoncrawler/hooks/floor12.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dungeoncrawler.dungeon import FloorHooks
+from dungeoncrawler.status_effects import add_status_effect
+
+
+class Hooks(FloorHooks):
+    """Blood Torrent and Compression Sickness mechanics for Floor 12."""
+
+    def on_floor_start(self, state, floor):
+        state.enemy_vision_bonus = 0
+
+    def apply_blood_torrent(self, state):
+        player = state.player
+        if not player:
+            return
+        stacks = player.status_effects.get("blood_torrent", 0)
+        player.status_effects["blood_torrent"] = min(3, stacks + 1)
+
+    def trigger_compression_sickness(self, state):
+        player = state.player
+        if player:
+            add_status_effect(player, "compression_sickness", 5)
+
+    def on_turn(self, state, floor):
+        player = state.player
+        if not player:
+            return
+        stacks = player.status_effects.get("blood_torrent", 0)
+        trail = player.status_effects.get("blood_scent", 0)
+        state.enemy_vision_bonus = max(stacks, trail)

--- a/tests/test_floor12.py
+++ b/tests/test_floor12.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+from dungeoncrawler.entities import Player
+from dungeoncrawler.items import Item
+from dungeoncrawler.status_effects import apply_status_effects
+
+from dungeoncrawler.hooks import floor12
+
+
+def test_blood_torrent_stacks_and_vision_bonus():
+    player = Player("Hero")
+    state = SimpleNamespace(player=player, enemy_vision_bonus=0)
+    hook = floor12.Hooks()
+    hook.apply_blood_torrent(state)
+    hook.apply_blood_torrent(state)
+    hook.apply_blood_torrent(state)
+    hook.apply_blood_torrent(state)  # cap at 3
+    assert player.status_effects["blood_torrent"] == 3
+    health = player.health
+    apply_status_effects(player)
+    assert player.health == health - 3
+    player.heal(5)
+    assert "blood_torrent" in player.status_effects
+    hook.on_turn(state, None)
+    assert state.enemy_vision_bonus == 3
+
+
+def test_compression_sickness_penalty_and_wait():
+    player = Player("Hero")
+    state = SimpleNamespace(player=player)
+    hook = floor12.Hooks()
+    hook.trigger_compression_sickness(state)
+    apply_status_effects(player)
+    assert player.speed == 9
+    assert player.status_effects["compression_sickness"] == 4
+    player.wait()
+    assert player.status_effects["compression_sickness"] == 2
+
+
+def test_items_clear_effects():
+    player = Player("Hero")
+    player.status_effects["blood_torrent"] = 2
+    player.inventory.append(Item("Scent-mask Spray", ""))
+    player.use_item("Scent-mask Spray")
+    assert "blood_torrent" not in player.status_effects
+    player.status_effects["blood_torrent"] = 1
+    player.inventory.append(Item("Absorbent Gel", ""))
+    player.use_item("Absorbent Gel")
+    assert "blood_torrent" not in player.status_effects
+    hook = floor12.Hooks()
+    state = SimpleNamespace(player=player)
+    hook.trigger_compression_sickness(state)
+    apply_status_effects(player)
+    player.inventory.append(Item("Anti-Nausea Draught", ""))
+    player.use_item("Anti-Nausea Draught")
+    assert "compression_sickness" not in player.status_effects
+    assert player.speed == 10


### PR DESCRIPTION
## Summary
- Implement Blood Torrent and Compression Sickness mechanics for Floor 12
- Add status handlers, consumable items, and player actions to counter new debuffs
- Document Floor 12 "Hunted" and wire hooks into floor configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ece9cae0883268ecd28717855d29a