### PR TITLE
Update Pages workflow for docs deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,9 @@ name: docs
 on:
   push:
     branches: [ main ]
+    paths:
+      - docs/**
+      - '**/*.py'
   workflow_dispatch:
 
 permissions:
@@ -11,7 +14,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: true
 
 jobs:
@@ -22,10 +25,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+          cache: 'pip'
       - name: Install dependencies
-        run: pip install sphinx
+        run: pip install ".[dev]" sphinx
       - name: Build docs
-        run: sphinx-build -b html docs docs/_build/html
+        working-directory: docs
+        run: sphinx-build -b html . _build/html
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -39,8 +44,8 @@ jobs:
       id-token: write
     environment:
       name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - id: deploy
+      - id: deployment
         uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
## Summary
- update Pages workflow to cache pip, install dev dependencies with Sphinx, build docs, and deploy via deploy-pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689faefc2df08326af9c38ab78b20195