### PR TITLE
ci: run isort with black profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           pip install black isort flake8
       - name: Run linters
         run: |
-          isort --check-only .
+          isort --profile black --check-only .
           black --check .
           flake8 .
 

--- a/tests/test_floor12.py
+++ b/tests/test_floor12.py
@@ -1,10 +1,9 @@
 from types import SimpleNamespace
 
 from dungeoncrawler.entities import Player
+from dungeoncrawler.hooks import floor12
 from dungeoncrawler.items import Item
 from dungeoncrawler.status_effects import apply_status_effects
-
-from dungeoncrawler.hooks import floor12
 
 
 def test_blood_torrent_stacks_and_vision_bonus():

--- a/tests/test_hard_mode.py
+++ b/tests/test_hard_mode.py
@@ -45,4 +45,6 @@ def test_loot_multiplier_scales_treasure(monkeypatch):
         assert treasure_count == 2
     finally:
         config.loot_mult = base_loot
+
+
 # End of file


### PR DESCRIPTION
## Summary
- ensure CI uses isort with the Black profile
- tidy test imports and formatting for floor 12 and hard mode tests

## Testing
- `isort --profile black --check-only . --verbose | head -n 20`
- `black --check .`
- `flake8 .` *(fails: many E501 line too long and E402 import-order errors)*
- `pytest tests/test_floor12.py`
- `pytest tests/test_hard_mode.py` *(keyboard interrupt before completion)*

------
https://chatgpt.com/codex/tasks/task_e_689fb7e077488326a6afb618a6c60219