### PR TITLE
Add Entropy floor mechanics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Elite enemies resist negative status effects for longer, halving durations applied to them.
 - Floor 12 "Hunted" hooks introducing Blood Torrent and Compression Sickness along with counter consumables.
 - Floor 13 "Anti-Magic" hooks adding Mana Lock, Hex of Dull Wards and the Suppression Ring item.
+- Floor 14 "Entropy" hooks introducing Entropic Debt, Spiteful Reflection and the Entropy Vent Stone item.
 
 ## [0.9.0b1] - 2025-08-11
 ### Added

--- a/data/floors/14_floor.json
+++ b/data/floors/14_floor.json
@@ -1,12 +1,15 @@
 {
   "$schema": "../../schemas/floor.json",
   "id": "14",
-  "name": "Floor",
+  "name": "Entropy",
   "map": [],
   "rule_mods": {},
   "objective": {
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor14"
+  ]
 }

--- a/data/items.json
+++ b/data/items.json
@@ -13,6 +13,7 @@
     {"type": "Item", "name": "Scent-mask Spray", "description": "Masks blood scent, clearing Blood Torrent", "price": 15, "rarity": "common"},
     {"type": "Item", "name": "Absorbent Gel", "description": "Soaks and removes Blood Torrent", "price": 20, "rarity": "uncommon"},
     {"type": "Item", "name": "Anti-Nausea Draught", "description": "Removes Compression Sickness", "price": 15, "rarity": "common"},
+    {"type": "Item", "name": "Entropy Vent Stone", "description": "Vents Entropic Debt stacks", "price": 25, "rarity": "uncommon"},
     {"type": "Trinket", "name": "Suppression Ring", "description": "Negates Mana Lock but may overheat", "price": 50, "rarity": "rare"}
   ],
   "rare": [

--- a/docs/gameplay_guide.rst
+++ b/docs/gameplay_guide.rst
@@ -89,7 +89,8 @@ retaining all previous debuffs.
 * **Floor 14 – “Entropy”**
   - *Entropic Debt* – Each action adds a stack dealing 1% of max HP per turn, up
     to 10 stacks. Skipping or bracing consumes two stacks. Venting or draining
-    the debt into a nearby totem clears stacks but may spawn an add.
+    the debt into a nearby totem or using an **Entropy Vent Stone** clears
+    stacks but may spawn an add.
   - *Spiteful Reflection* – 20% chance to bounce any new debuff back to its
     applier, including the player. Use proxies, pets or throwables to avoid
     self-infliction.

--- a/dungeoncrawler/combat.py
+++ b/dungeoncrawler/combat.py
@@ -164,6 +164,7 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
             enemy_turn(enemy, player, renderer, game.combat_log)
             game.stats_logger.record_damage(taken=before - player.health)
             game.stats_logger.record_turn()
+            game.last_action = "attack"
         elif choice == "2":
             enemy_before = enemy.health
             p_entity = CoreEntity(
@@ -197,12 +198,14 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
             enemy_turn(enemy, player, renderer, game.combat_log)
             game.stats_logger.record_damage(taken=before - player.health)
             game.stats_logger.record_turn()
+            game.last_action = "defend"
         elif choice == "3":
             player.use_health_potion()
             before = player.health
             enemy_turn(enemy, player, renderer, game.combat_log)
             game.stats_logger.record_damage(taken=before - player.health)
             game.stats_logger.record_turn()
+            game.last_action = "item"
         elif choice == "4":
             enemy_before = enemy.health
             skill_name = player.use_skill(enemy)
@@ -214,6 +217,7 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
             enemy_turn(enemy, player, renderer, game.combat_log)
             game.stats_logger.record_damage(taken=before - player.health)
             game.stats_logger.record_turn()
+            game.last_action = "skill"
         elif choice == "5":
             p_entity = CoreEntity(
                 player.name,
@@ -247,6 +251,7 @@ def battle(game: "DungeonBase", enemy: "Enemy", input_func=None) -> None:
             enemy_turn(enemy, player, renderer, game.combat_log)
             game.stats_logger.record_damage(taken=before - player.health)
             game.stats_logger.record_turn()
+            game.last_action = "flee"
         else:
             renderer.show_message(_(INVALID_KEY_MSG))
         player.decrement_cooldowns()

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -378,6 +378,7 @@ class DungeonBase:
         self.novice_luck_announced = False
         self.stairs_prompt_shown = False
         self.active_quest = None
+        self.last_action: str | None = None
         # Track guild trial completion when present
         self.completed_trials: set[str] = set()
         # Balance metrics logger and combat message buffer
@@ -1065,25 +1066,34 @@ class DungeonBase:
 
         if choice == "0":
             self.player.wait()
+            self.last_action = "wait"
         elif choice == "1":
             self.move_player("left")
+            self.last_action = "move"
         elif choice == "2":
             self.move_player("right")
+            self.last_action = "move"
         elif choice == "3":
             self.move_player("up")
+            self.last_action = "move"
         elif choice == "4":
             self.move_player("down")
+            self.last_action = "move"
         elif choice == "5":
             self.shop()
+            self.last_action = "other"
         elif choice == "6":
             self.show_inventory()
+            self.last_action = "other"
         elif choice == "7":
             self.renderer.show_message(_("Thanks for playing!"))
             return False
         elif choice == "8":
             self.view_map()
+            self.last_action = "other"
         elif choice == "9":
             self.view_leaderboard()
+            self.last_action = "other"
         elif config.enable_debug and choice.startswith(":god"):
             self.god_mode(choice)
         elif config.enable_debug and choice.startswith(":sim"):

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -365,6 +365,12 @@ class Player(Entity):
                 print(_("You steady your stomach."))
             else:
                 print(_("The anti-magic field suppresses the item!"))
+        elif name == "Entropy Vent Stone":
+            if not failed:
+                self.status_effects.pop("entropic_debt", None)
+                print(_("The stone dissipates your entropic debt."))
+            else:
+                print(_("The anti-magic field suppresses the item!"))
         else:
             print(_("Nothing happens."))
         self.inventory.remove(item)
@@ -450,12 +456,12 @@ class Player(Entity):
             effect = getattr(self.weapon, "effect", None)
             if effect:
                 duration = int(3 * RARITY_MODIFIERS.get(self.weapon.rarity, 1.0))
-                add_status_effect(enemy, effect, duration)
+                add_status_effect(enemy, effect, duration, source=self)
         if self.trinket:
             effect = getattr(self.trinket, "effect", None)
             if effect:
                 duration = int(2 * RARITY_MODIFIERS.get(self.trinket.rarity, 1.0))
-                add_status_effect(enemy, effect, duration)
+                add_status_effect(enemy, effect, duration, source=self)
 
     def process_enemy_defeat(self, enemy: Enemy) -> None:
         """Handle rewards for defeating ``enemy`` such as XP and credits."""

--- a/dungeoncrawler/hooks/floor14.py
+++ b/dungeoncrawler/hooks/floor14.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import random
+
+from dungeoncrawler.dungeon import FloorHooks
+from dungeoncrawler.status_effects import add_status_effect
+
+
+class Hooks(FloorHooks):
+    """Entropic Debt and Spiteful Reflection mechanics for Floor 14."""
+
+    def on_floor_start(self, state, floor):
+        player = state.player
+        if player:
+            # Apply Spiteful Reflection for the duration of the floor
+            add_status_effect(player, "spiteful_reflection", 1)
+
+    def on_turn(self, state, floor):
+        player = state.player
+        if not player:
+            return
+        action = getattr(state.game, "last_action", None)
+        stacks = player.status_effects.get("entropic_debt", 0)
+        if action in {"wait", "defend"}:
+            # skipping or bracing repays two stacks
+            stacks = max(0, stacks - 2)
+            if stacks:
+                player.status_effects["entropic_debt"] = stacks
+            else:
+                player.status_effects.pop("entropic_debt", None)
+        else:
+            player.status_effects["entropic_debt"] = min(10, stacks + 1)
+        if hasattr(state.game, "last_action"):
+            state.game.last_action = None
+
+    def vent_to_totem(self, state):
+        """Clear debt and possibly spawn an add. Returns True if an add spawns."""
+        player = state.player
+        if not player:
+            return False
+        had_debt = "entropic_debt" in player.status_effects
+        player.status_effects.pop("entropic_debt", None)
+        spawn = False
+        if had_debt and random.random() < 0.5:
+            spawn = True
+            state.queue_message("An add materializes!" if hasattr(state, "queue_message") else "")
+        return spawn

--- a/tests/test_floor14.py
+++ b/tests/test_floor14.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+from dungeoncrawler.entities import Player
+from dungeoncrawler.hooks import floor14
+from dungeoncrawler.status_effects import add_status_effect, apply_status_effects
+
+
+def make_state(player):
+    state = SimpleNamespace(player=player, log=[], game=SimpleNamespace(last_action=None))
+    state.queue_message = state.log.append
+    return state
+
+
+def test_debt_stacks_and_consumption():
+    player = Player("Hero")
+    state = make_state(player)
+    hook = floor14.Hooks()
+    for _ in range(12):
+        state.game.last_action = "move"
+        hook.on_turn(state, None)
+    assert player.status_effects["entropic_debt"] == 10
+    state.game.last_action = "wait"
+    hook.on_turn(state, None)
+    assert player.status_effects["entropic_debt"] == 8
+    state.game.last_action = "defend"
+    hook.on_turn(state, None)
+    assert player.status_effects["entropic_debt"] == 6
+    health = player.health
+    apply_status_effects(player)
+    assert player.health == health - 6
+
+
+def test_totem_clears_and_spawns_add(monkeypatch):
+    player = Player("Hero")
+    player.status_effects["entropic_debt"] = 5
+    state = make_state(player)
+    hook = floor14.Hooks()
+    monkeypatch.setattr("dungeoncrawler.hooks.floor14.random.random", lambda: 0.1)
+    spawned = hook.vent_to_totem(state)
+    assert spawned is True
+    assert "entropic_debt" not in player.status_effects
+
+
+def test_spiteful_reflection(monkeypatch):
+    attacker = Player("Atk")
+    defender = Player("Def")
+    defender.status_effects["spiteful_reflection"] = 1
+    monkeypatch.setattr("dungeoncrawler.status_effects.random.random", lambda: 0.1)
+    add_status_effect(defender, "poison", 3, source=attacker)
+    assert "poison" in attacker.status_effects
+    attacker2 = Player("Atk2")
+    defender2 = Player("Def2")
+    defender2.status_effects["spiteful_reflection"] = 1
+    monkeypatch.setattr("dungeoncrawler.status_effects.random.random", lambda: 0.9)
+    add_status_effect(defender2, "poison", 3, source=attacker2)
+    assert "poison" not in attacker2.status_effects


### PR DESCRIPTION
## Summary
- introduce Floor 14 hook with Entropic Debt and Spiteful Reflection
- add status handlers and reflection logic for new effects
- include Entropy Vent Stone item and documentation updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fcba6c8a88326a5011cc5323d476f