### PR TITLE
Add Floor 15 Pestilence mechanics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Floor 12 "Hunted" hooks introducing Blood Torrent and Compression Sickness along with counter consumables.
 - Floor 13 "Anti-Magic" hooks adding Mana Lock, Hex of Dull Wards and the Suppression Ring item.
 - Floor 14 "Entropy" hooks introducing Entropic Debt, Spiteful Reflection and the Entropy Vent Stone item.
+- Floor 15 "Pestilence" hooks introducing Brood Bloom infections, Miasma Carrier aura, Broodling enemies and mitigation consumables.
 
 ## [0.9.0b1] - 2025-08-11
 ### Added

--- a/data/enemies.json
+++ b/data/enemies.json
@@ -385,5 +385,17 @@
     ],
     "ai": {},
     "traits": ["poisonous"]
+  },
+  {
+    "name": "Broodling",
+    "stats": [
+      20,
+      30,
+      5,
+      10,
+      1
+    ],
+    "ai": {},
+    "traits": ["fire_vulnerable"]
   }
 ]

--- a/data/floors/15_floor.json
+++ b/data/floors/15_floor.json
@@ -1,12 +1,15 @@
 {
   "$schema": "../../schemas/floor.json",
   "id": "15",
-  "name": "Floor",
+  "name": "Pestilence",
   "map": [],
   "rule_mods": {},
   "objective": {
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor15"
+  ]
 }

--- a/data/items.json
+++ b/data/items.json
@@ -14,6 +14,8 @@
     {"type": "Item", "name": "Absorbent Gel", "description": "Soaks and removes Blood Torrent", "price": 20, "rarity": "uncommon"},
     {"type": "Item", "name": "Anti-Nausea Draught", "description": "Removes Compression Sickness", "price": 15, "rarity": "common"},
     {"type": "Item", "name": "Entropy Vent Stone", "description": "Vents Entropic Debt stacks", "price": 25, "rarity": "uncommon"},
+    {"type": "Item", "name": "Filter Mask", "description": "Negates one Miasma aura", "price": 20, "rarity": "common"},
+    {"type": "Item", "name": "Air Filter", "description": "Blocks one Miasma aura", "price": 30, "rarity": "uncommon"},
     {"type": "Trinket", "name": "Suppression Ring", "description": "Negates Mana Lock but may overheat", "price": 50, "rarity": "rare"}
   ],
   "rare": [

--- a/docs/gameplay_guide.rst
+++ b/docs/gameplay_guide.rst
@@ -95,12 +95,13 @@ retaining all previous debuffs.
     applier, including the player. Use proxies, pets or throwables to avoid
     self-infliction.
 * **Floor 15 – “Pestilence”**
-  - *Brood Bloom* – Timered infection that spawns a Broodling on expiry and
+  - *Brood Bloom* – Timed infection that spawns a Broodling on expiry and
     reapplies a weaker stack. Cleansing only delays the spawn; fire dispatches
     Broodlings quickly.
   - *Miasma Carrier* – Entering a room applies a one-turn −50% healing received
-    aura to nearby allies and enemies. Masks or filters mitigate it; ring
-    suppression protects the wearer only.
+    aura to nearby allies and enemies. **Filter Masks** or **Air Filters**
+    consume on entry to negate it; suppression rings protect only their
+    bearer.
 * **Floor 16 – “Time Weirdness”**
   - *Temporal Lag* – 15% chance your last action repeats on the next turn with a
     new target, refunding resources but wasting the turn. Taking short,

--- a/dungeoncrawler/hooks/floor15.py
+++ b/dungeoncrawler/hooks/floor15.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dungeoncrawler.dungeon import FloorHooks
+from dungeoncrawler.status_effects import add_status_effect
+
+
+class Hooks(FloorHooks):
+    """Brood Bloom infections and Miasma Carrier aura for Floor 15."""
+
+    def infect(self, entity, duration, spawn_callback):
+        """Apply Brood Bloom to ``entity`` and register spawn callback."""
+        entity.brood_spawn = spawn_callback
+        entity.brood_bloom_stack = duration
+        add_status_effect(entity, "brood_bloom", duration)
+
+    def _protected(self, entity):
+        trinket = getattr(entity, "trinket", None)
+        if trinket and getattr(trinket, "name", "") == "Suppression Ring":
+            return True
+        inventory = list(getattr(entity, "inventory", []))
+        for item in inventory:
+            name = getattr(item, "name", "")
+            if name in {"Filter Mask", "Air Filter"}:
+                entity.inventory.remove(item)
+                return True
+        return False
+
+    def on_turn(self, state, floor):
+        game = state.game
+        player = state.player
+        if not player:
+            return
+        x, y = player.x, player.y
+        if 0 <= y < game.height and 0 <= x < game.width:
+            room = game.rooms[y][x]
+            if room == "Miasma Carrier":
+                targets = [player] + getattr(player, "companions", [])
+                for ent in targets:
+                    if not self._protected(ent):
+                        add_status_effect(ent, "miasma_aura", 2)

--- a/tests/test_floor15.py
+++ b/tests/test_floor15.py
@@ -1,0 +1,77 @@
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Player, Enemy, Companion, Item
+from dungeoncrawler.hooks import floor15
+from dungeoncrawler.status_effects import add_status_effect, apply_status_effects
+
+
+def test_brood_bloom_spawns_and_reapplies():
+    host = Enemy("Host", 30, 5, 0, 0)
+    spawned = []
+    hook = floor15.Hooks()
+    hook.infect(host, 2, lambda e: spawned.append(e.name))
+    apply_status_effects(host)
+    assert host.status_effects["brood_bloom"] == 1
+    apply_status_effects(host)
+    assert len(spawned) == 1
+    assert host.status_effects["brood_bloom"] == 1
+    apply_status_effects(host)
+    assert len(spawned) == 2
+    assert "brood_bloom" not in host.status_effects
+
+
+def test_miasma_aura_and_mitigation():
+    game = DungeonBase(1, 1)
+    player = Player("Tester")
+    companion = Companion("Ally")
+    player.companions.append(companion)
+    game.player = player
+    game.rooms = [["Miasma Carrier"]]
+    hook = floor15.Hooks()
+    state = game._make_state(15)
+
+    player.health = player.max_health - 10
+    hook.on_turn(state, None)
+    apply_status_effects(player)
+    apply_status_effects(companion)
+    assert player.heal_multiplier == 0.5
+    healed = player.heal(10)
+    assert healed == 5
+    assert companion.heal_multiplier == 0.5
+
+    # clear remaining aura
+    apply_status_effects(player)
+    apply_status_effects(companion)
+
+    player.heal_multiplier = 1.0
+    companion.heal_multiplier = 1.0
+    player.status_effects.clear()
+    companion.status_effects.clear()
+    player.inventory.append(Item("Filter Mask", ""))
+    hook.on_turn(state, None)
+    apply_status_effects(player)
+    apply_status_effects(companion)
+    assert player.heal_multiplier == 1.0
+    assert companion.heal_multiplier == 0.5
+    assert not any(i.name == "Filter Mask" for i in player.inventory)
+
+    # clear aura again
+    apply_status_effects(player)
+    apply_status_effects(companion)
+
+    player.trinket = Item("Suppression Ring", "")
+    player.status_effects.clear()
+    companion.status_effects.clear()
+    player.heal_multiplier = 1.0
+    companion.heal_multiplier = 1.0
+    hook.on_turn(state, None)
+    apply_status_effects(player)
+    apply_status_effects(companion)
+    assert player.heal_multiplier == 1.0
+    assert companion.heal_multiplier == 0.5
+
+
+def test_broodling_fire_vulnerability():
+    broodling = Enemy("Broodling", 20, 5, 0, 0, traits=["fire_vulnerable"])
+    add_status_effect(broodling, "burn", 1)
+    apply_status_effects(broodling)
+    assert broodling.health == 12


### PR DESCRIPTION
## Summary
- implement Brood Bloom infection and Miasma Carrier aura for floor 15
- add brood_bloom and miasma_aura status effects with fire-vulnerable Broodlings
- introduce Filter Mask and Air Filter items for aura mitigation

## Testing
- `pytest tests/test_floor15.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689febbbbe708326a4c3b37ac9cb5cf9