### PR TITLE
Sort imports to satisfy isort check

### DIFF
--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -14,7 +14,9 @@ from .items import RARITY_MODIFIERS, Armor, Item, Trinket, Weapon
 from .status_effects import (
     add_status_effect,
     adjust_skill_cost,
-    apply_status_effects as apply_effects,
+)
+from .status_effects import apply_status_effects as apply_effects
+from .status_effects import (
     cleansing_fails,
     shield_block,
 )

--- a/dungeoncrawler/status_effects.py
+++ b/dungeoncrawler/status_effects.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from gettext import gettext as _
 import random
+from gettext import gettext as _
 
 EFFECT_INFO = {
     "poison": "Lose 3 HP/turn.",

--- a/tests/test_floor13.py
+++ b/tests/test_floor13.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 
-from dungeoncrawler.entities import Player, Enemy
+from dungeoncrawler.entities import Enemy, Player
 from dungeoncrawler.hooks import floor13
 from dungeoncrawler.items import Item, Trinket
 


### PR DESCRIPTION
## Summary
- Reorder imports in tests and status modules to match Black's isort profile

## Testing
- `isort --profile black --check .`
- `pytest tests/test_floor13.py -q`
- ⚠️ `pytest` *(partial run, interrupted after ~28 minutes with 147 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_689fee15ea308326846be1adcaa909e2