### PR TITLE
Add floor 16 time distortion mechanics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Floor 13 "Anti-Magic" hooks adding Mana Lock, Hex of Dull Wards and the Suppression Ring item.
 - Floor 14 "Entropy" hooks introducing Entropic Debt, Spiteful Reflection and the Entropy Vent Stone item.
 - Floor 15 "Pestilence" hooks introducing Brood Bloom infections, Miasma Carrier aura, Broodling enemies and mitigation consumables.
+- Floor 16 "Time Weirdness" hooks introducing Temporal Lag, Haste Dysphoria and the Anchor consumable.
 
 ## [0.9.0b1] - 2025-08-11
 ### Added

--- a/data/floors/16_floor.json
+++ b/data/floors/16_floor.json
@@ -1,12 +1,15 @@
 {
   "$schema": "../../schemas/floor.json",
   "id": "16",
-  "name": "Floor",
+  "name": "Time Weirdness",
   "map": [],
   "rule_mods": {},
   "objective": {
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor16"
+  ]
 }

--- a/data/items.json
+++ b/data/items.json
@@ -16,6 +16,7 @@
     {"type": "Item", "name": "Entropy Vent Stone", "description": "Vents Entropic Debt stacks", "price": 25, "rarity": "uncommon"},
     {"type": "Item", "name": "Filter Mask", "description": "Negates one Miasma aura", "price": 20, "rarity": "common"},
     {"type": "Item", "name": "Air Filter", "description": "Blocks one Miasma aura", "price": 30, "rarity": "uncommon"},
+    {"type": "Item", "name": "Anchor", "description": "Clears Temporal Lag", "price": 30, "rarity": "uncommon"},
     {"type": "Trinket", "name": "Suppression Ring", "description": "Negates Mana Lock but may overheat", "price": 50, "rarity": "rare"}
   ],
   "rare": [

--- a/docs/gameplay_guide.rst
+++ b/docs/gameplay_guide.rst
@@ -105,7 +105,7 @@ retaining all previous debuffs.
 * **Floor 16 – “Time Weirdness”**
   - *Temporal Lag* – 15% chance your last action repeats on the next turn with a
     new target, refunding resources but wasting the turn. Taking short,
-    deliberate turns or using an Anchor consumable counters it.
+    deliberate turns or consuming an **Anchor** clears it.
   - *Haste Dysphoria* – Speed buffs invert into a penalty if total haste exceeds
     25%. Cap haste or purge to avoid the slowdown.
 * **Floor 17 – “Oaths & Curses”**

--- a/dungeoncrawler/hooks/floor16.py
+++ b/dungeoncrawler/hooks/floor16.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dungeoncrawler.dungeon import FloorHooks
+from dungeoncrawler.status_effects import add_status_effect, temporal_lag_trigger
+
+
+class Hooks(FloorHooks):
+    """Temporal Lag and Haste Dysphoria mechanics for Floor 16."""
+
+    def on_floor_start(self, state, floor):
+        player = state.player
+        if player:
+            add_status_effect(player, "temporal_lag", 1)
+            add_status_effect(player, "haste_dysphoria", 1)
+            player._haste_dysphoria_base = player.speed
+
+    def on_turn(self, state, floor):
+        player = state.player
+        if not player:
+            return
+        action = getattr(state.game, "last_action", None)
+        cost = getattr(state.game, "last_cost", 0)
+        temporal_lag_trigger(player, state, action, "stamina", cost)
+
+    def use_anchor(self, state):
+        player = state.player
+        if not player:
+            return False
+        player.status_effects.pop("temporal_lag", None)
+        if hasattr(state, "queue_message"):
+            state.queue_message("The Anchor steadies time.")
+        return True

--- a/tests/test_floor16.py
+++ b/tests/test_floor16.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from dungeoncrawler.entities import Player, Enemy
+from dungeoncrawler.hooks import floor16
+from dungeoncrawler.status_effects import apply_status_effects
+
+
+def make_state(player, enemies=None):
+    enemies = enemies or []
+    game = SimpleNamespace(last_action=None, last_cost=0, repeat_action=None, repeat_target=None)
+    state = SimpleNamespace(player=player, enemies=enemies, game=game, log=[])
+    state.queue_message = state.log.append
+    return state
+
+
+def test_temporal_lag_repeats_and_refunds(monkeypatch):
+    player = Player("Hero")
+    enemy = Enemy("Goblin", 10, 2, 0, 0)
+    state = make_state(player, [enemy])
+    hook = floor16.Hooks()
+    hook.on_floor_start(state, None)
+    state.game.last_action = "attack"
+    state.game.last_cost = 10
+    player.stamina -= 10
+    monkeypatch.setattr("dungeoncrawler.status_effects.random.random", lambda: 0.1)
+    hook.on_turn(state, None)
+    assert state.game.repeat_action == "attack"
+    assert state.game.repeat_target in {player, enemy}
+    assert player.stamina == 100
+
+
+def test_anchor_clears_temporal_lag(monkeypatch):
+    player = Player("Hero")
+    state = make_state(player)
+    hook = floor16.Hooks()
+    hook.on_floor_start(state, None)
+    hook.use_anchor(state)
+    state.game.last_action = "attack"
+    state.game.last_cost = 10
+    player.stamina -= 10
+    monkeypatch.setattr("dungeoncrawler.status_effects.random.random", lambda: 0.1)
+    hook.on_turn(state, None)
+    assert state.game.repeat_action is None
+    assert player.stamina == 90
+
+
+def test_haste_dysphoria_inverts_speed():
+    player = Player("Hero")
+    state = make_state(player)
+    hook = floor16.Hooks()
+    hook.on_floor_start(state, None)
+    apply_status_effects(player)
+    player.speed = 13
+    apply_status_effects(player)
+    assert player.speed == 7


### PR DESCRIPTION
## Summary
- introduce Floor 16 hook with Temporal Lag and Haste Dysphoria effects
- implement status handlers for lag and haste inversion with Anchor counter item
- document new floor mechanics and add regression tests

## Testing
- `pytest tests/test_floor16.py tests/test_floor_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_689ffc1e3824832699ba0f327a0715ce