### PR TITLE
feat: add floor 17 curses and soul taxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Floor 14 "Entropy" hooks introducing Entropic Debt, Spiteful Reflection and the Entropy Vent Stone item.
 - Floor 15 "Pestilence" hooks introducing Brood Bloom infections, Miasma Carrier aura, Broodling enemies and mitigation consumables.
 - Floor 16 "Time Weirdness" hooks introducing Temporal Lag, Haste Dysphoria and the Anchor consumable.
+- Floor 17 "Oaths & Curses" hooks introducing Fester Mark and Soul Tax with altar donations to cleanse.
 
 ## [0.9.0b1] - 2025-08-11
 ### Added

--- a/data/floors/17_floor.json
+++ b/data/floors/17_floor.json
@@ -1,12 +1,15 @@
 {
   "$schema": "../../schemas/floor.json",
   "id": "17",
-  "name": "Floor",
+  "name": "Oaths & Curses",
   "map": [],
   "rule_mods": {},
   "objective": {
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor17"
+  ]
 }

--- a/docs/gameplay_guide.rst
+++ b/docs/gameplay_guide.rst
@@ -113,7 +113,8 @@ retaining all previous debuffs.
     the overheal each turn for five turns. Small, frequent heals or cleansing
     mitigate it.
   - *Soul Tax* – Each kill while taxed reduces your primary stat by one for 10
-    turns but increases loot chance. Donate at an altar to remove stacks.
+    turns but increases loot chance. Donate 50 credits at an altar to remove
+    stacks.
 * **Floor 18 – “Broadcast Finale”**
   - *Spotlight* – Entering a room pings your location on the floor map; elites
     home in with +10% damage. A jammer or brief stealth breaks the ping.

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -316,10 +316,18 @@ class Player(Entity):
     def heal(self, amount: int) -> int:
         """Restore ``amount`` health adjusted by ``heal_multiplier``."""
 
+        from dungeoncrawler.status_effects import add_status_effect
+
         amount = int(amount * getattr(self, "heal_multiplier", 1))
-        healed = min(amount, self.max_health - self.health)
+        missing = self.max_health - self.health
+        healed = min(amount, missing)
+        overheal = amount - healed
         if healed > 0:
             self.health += healed
+        if getattr(self, "fester_mark_active", False) and overheal > amount * 0.5:
+            damage = max(1, int(overheal * 0.05))
+            add_status_effect(self, "fester_mark", 5)
+            self._fester_mark_damage = damage
         return healed
 
     def use_health_potion(self):

--- a/dungeoncrawler/events.py
+++ b/dungeoncrawler/events.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from .items import Item
 from .quests import EscortNPC, EscortQuest
-from .status_effects import add_status_effect
+from .status_effects import add_status_effect, clear_soul_tax
 
 # pylint: disable=too-few-public-methods
 
@@ -248,6 +248,8 @@ class ShrineEvent(BaseEvent):
         output_func(_("[V] Altar of Valor (+1 STR until next floor)"))
         output_func(_("[W] Altar of Wisdom (+1 INT until next floor)"))
         output_func(_("[P] Pray (60% boon / 40% curse)"))
+        if getattr(game.player, "_soul_tax_timers", []):
+            output_func(_("[D] Donate 50 credits to cleanse Soul Tax"))
         choice = input_func(_("Choice: ")).strip().lower()
         if choice == "v":
             game.player.temp_strength += 1
@@ -269,6 +271,13 @@ class ShrineEvent(BaseEvent):
             else:
                 add_status_effect(game.player, "cursed", 30)
                 output_func(_("A dark chill leaves you cursed."))
+        elif choice == "d" and getattr(game.player, "_soul_tax_timers", []):
+            if game.player.credits >= 50:
+                game.player.credits -= 50
+                clear_soul_tax(game.player)
+                output_func(_("Your donation lifts the soul tax."))
+            else:
+                output_func(_("You lack the credits to donate."))
         else:
             output_func(_("You leave the shrine undisturbed."))
 

--- a/dungeoncrawler/hooks/floor17.py
+++ b/dungeoncrawler/hooks/floor17.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dungeoncrawler.dungeon import FloorHooks
+from dungeoncrawler.status_effects import add_status_effect, clear_soul_tax
+
+
+class Hooks(FloorHooks):
+    """Fester Mark and Soul Tax mechanics for Floor 17."""
+
+    def on_floor_start(self, state, floor):
+        player = state.player
+        if player:
+            player.fester_mark_active = True
+            player._soul_tax_state = state
+            player._soul_tax_timers = []
+            player._soul_tax_base_loot = state.config.loot_mult
+        self.prev_enemy_count = len(getattr(state, "enemies", []))
+
+    def on_turn(self, state, floor):
+        player = state.player
+        if not player:
+            return
+        enemies = getattr(state, "enemies", [])
+        prev = getattr(self, "prev_enemy_count", 0)
+        kills = max(0, prev - len(enemies))
+        for _ in range(kills):
+            add_status_effect(player, "soul_tax", 10)
+            timers = getattr(player, "_soul_tax_timers", [])
+            timers.append(10)
+            player._soul_tax_timers = timers
+            player.attack_power -= 1
+            state.config.loot_mult += 0.05
+        self.prev_enemy_count = len(enemies)
+
+    def on_floor_end(self, state, floor):
+        player = state.player
+        if player:
+            player.fester_mark_active = False
+            clear_soul_tax(player)
+            player.__dict__.pop("_soul_tax_state", None)

--- a/tests/test_floor17.py
+++ b/tests/test_floor17.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+from types import SimpleNamespace
+
+from dungeoncrawler.entities import Player, Enemy
+from dungeoncrawler.hooks import floor17
+from dungeoncrawler.status_effects import apply_status_effects
+from dungeoncrawler.events import ShrineEvent
+
+
+def make_state(player, enemies=None, config=None):
+    enemies = enemies or []
+    game = SimpleNamespace(last_action=None, last_cost=0)
+    state = SimpleNamespace(player=player, enemies=enemies, game=game, config=config or SimpleNamespace(loot_mult=1.0))
+    return state
+
+
+def test_fester_mark_overheal():
+    player = Player("Hero")
+    state = make_state(player)
+    hook = floor17.Hooks()
+    hook.on_floor_start(state, None)
+    player.health = player.max_health - 1
+    healed = player.heal(10)
+    assert healed == 1
+    assert "fester_mark" in player.status_effects
+    apply_status_effects(player)
+    assert player.health == player.max_health - player._fester_mark_damage
+
+
+def test_soul_tax_stack_and_expire():
+    player = Player("Hero")
+    enemy = Enemy("Goblin", 10, 2, 0, 0)
+    base_attack = player.attack_power
+    config = SimpleNamespace(loot_mult=1.0)
+    state = make_state(player, [enemy], config)
+    hook = floor17.Hooks()
+    hook.on_floor_start(state, None)
+    state.enemies = []
+    hook.on_turn(state, None)
+    assert player.attack_power == base_attack - 1
+    assert config.loot_mult > 1.0
+    for _ in range(10):
+        apply_status_effects(player)
+    assert player.attack_power == base_attack
+    assert config.loot_mult == 1.0
+
+
+def test_altar_donation_clears_soul_tax():
+    player = Player("Hero")
+    enemy = Enemy("Goblin", 10, 2, 0, 0)
+    config = SimpleNamespace(loot_mult=1.0)
+    state = make_state(player, [enemy], config)
+    hook = floor17.Hooks()
+    hook.on_floor_start(state, None)
+    base_attack = player.attack_power
+    state.enemies = []
+    hook.on_turn(state, None)
+    player.credits = 100
+    event = ShrineEvent()
+    game = SimpleNamespace(player=player, stats_logger=SimpleNamespace(record_reward=lambda: None), config=config)
+    event.trigger(game, input_func=lambda *_: "d", output_func=lambda *a, **k: None)
+    assert player.attack_power == base_attack and not player._soul_tax_timers
+    assert config.loot_mult == player._soul_tax_base_loot
+    assert player.credits == 50


### PR DESCRIPTION
## Summary
- implement Floor 17 hooks with Fester Mark and Soul Tax mechanics
- allow altar donations to cleanse Soul Tax
- document Oaths & Curses and add tests for new effects

## Testing
- `pytest tests/test_floor17.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689fff4078508326bbc846aa0c756f46