### PR TITLE
Add Broadcast Finale floor hooks and items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Floor 15 "Pestilence" hooks introducing Brood Bloom infections, Miasma Carrier aura, Broodling enemies and mitigation consumables.
 - Floor 16 "Time Weirdness" hooks introducing Temporal Lag, Haste Dysphoria and the Anchor consumable.
 - Floor 17 "Oaths & Curses" hooks introducing Fester Mark and Soul Tax with altar donations to cleanse.
+- Floor 18 "Broadcast Finale" hooks introducing Spotlight and Audience Fatigue mechanics with Signal Jammer, Smoke Bomb and Rewrite consumables.
 
 ## [0.9.0b1] - 2025-08-11
 ### Added

--- a/data/floors/18_final.json
+++ b/data/floors/18_final.json
@@ -1,12 +1,15 @@
 {
   "$schema": "../../schemas/floor.json",
   "id": "18",
-  "name": "Final",
+  "name": "Broadcast Finale",
   "map": [],
   "rule_mods": {},
   "objective": {
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor18"
+  ]
 }

--- a/data/items.json
+++ b/data/items.json
@@ -17,6 +17,9 @@
     {"type": "Item", "name": "Filter Mask", "description": "Negates one Miasma aura", "price": 20, "rarity": "common"},
     {"type": "Item", "name": "Air Filter", "description": "Blocks one Miasma aura", "price": 30, "rarity": "uncommon"},
     {"type": "Item", "name": "Anchor", "description": "Clears Temporal Lag", "price": 30, "rarity": "uncommon"},
+    {"type": "Item", "name": "Signal Jammer", "description": "Scrambles Spotlight pings", "price": 30, "rarity": "uncommon"},
+    {"type": "Item", "name": "Smoke Bomb", "description": "Briefly hides you from the Spotlight", "price": 35, "rarity": "uncommon"},
+    {"type": "Item", "name": "Rewrite", "description": "Clears Audience Fatigue stacks", "price": 25, "rarity": "common"},
     {"type": "Trinket", "name": "Suppression Ring", "description": "Negates Mana Lock but may overheat", "price": 50, "rarity": "rare"}
   ],
   "rare": [

--- a/docs/gameplay_guide.rst
+++ b/docs/gameplay_guide.rst
@@ -117,8 +117,9 @@ retaining all previous debuffs.
     stacks.
 * **Floor 18 – “Broadcast Finale”**
   - *Spotlight* – Entering a room pings your location on the floor map; elites
-    home in with +10% damage. A jammer or brief stealth breaks the ping.
+    home in with +10% damage. A **Signal Jammer** or **Smoke Bomb** breaks the
+    ping.
   - *Audience Fatigue* – Using the same ability three or more times in five
     turns applies −10% damage/healing for three turns, stacking to −40%. Rotate
-    skills or use a Rewrite consumable to clear it.
+    skills or use a **Rewrite** consumable to clear it.
 

--- a/dungeoncrawler/hooks/floor18.py
+++ b/dungeoncrawler/hooks/floor18.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dungeoncrawler.dungeon import FloorHooks
+
+
+class Hooks(FloorHooks):
+    """Spotlight and Audience Fatigue mechanics for Floor 18."""
+
+    def on_floor_start(self, state, floor):
+        self.history: list[str] = []
+        if state:
+            state.spotlight_ping = None
+
+    def on_turn(self, state, floor):
+        player = state.player
+        if not player:
+            return
+        # Spotlight ping tracking
+        if "spotlight_ping" in player.status_effects:
+            state.spotlight_ping = (getattr(player, "x", 0), getattr(player, "y", 0))
+            enemies = getattr(state, "enemies", [])
+            for enemy in enemies:
+                if getattr(enemy, "rarity", "") == "elite":
+                    base = getattr(enemy, "_spotlight_base", enemy.attack_power)
+                    if not getattr(enemy, "_spotlight_buffed", False):
+                        enemy._spotlight_base = base
+                        enemy.attack_power = int(base * 1.1)
+                        enemy._spotlight_buffed = True
+        else:
+            state.spotlight_ping = None
+            enemies = getattr(state, "enemies", [])
+            for enemy in enemies:
+                if getattr(enemy, "_spotlight_buffed", False):
+                    enemy.attack_power = getattr(enemy, "_spotlight_base", enemy.attack_power)
+                    enemy._spotlight_buffed = False
+        # Audience Fatigue tracking
+        action = getattr(state.game, "last_action", None)
+        if action:
+            history = self.history
+            history.append(action)
+            if len(history) > 5:
+                history.pop(0)
+            if history.count(action) >= 3:
+                timers = getattr(player, "_audience_fatigue_timers", [])
+                if len(timers) < 4:
+                    timers.append(3)
+                    player._audience_fatigue_timers = timers
+                    player.status_effects["audience_fatigue"] = len(timers)
+        
+    # Item hooks
+    def use_jammer(self, state):
+        player = state.player
+        if not player:
+            return False
+        player.status_effects.pop("spotlight_ping", None)
+        state.spotlight_ping = None
+        for enemy in getattr(state, "enemies", []):
+            if getattr(enemy, "_spotlight_buffed", False):
+                enemy.attack_power = getattr(enemy, "_spotlight_base", enemy.attack_power)
+                enemy._spotlight_buffed = False
+        if hasattr(state, "queue_message"):
+            state.queue_message("The signal jammer muffles your trail.")
+        return True
+
+    def use_stealth(self, state):
+        player = state.player
+        if not player:
+            return False
+        player.status_effects.pop("spotlight_ping", None)
+        state.spotlight_ping = None
+        if hasattr(state, "queue_message"):
+            state.queue_message("You vanish into the shadows.")
+        return True
+
+    def use_rewrite(self, state):
+        player = state.player
+        if not player:
+            return False
+        player.status_effects.pop("audience_fatigue", None)
+        player._audience_fatigue_timers = []
+        if hasattr(state, "queue_message"):
+            state.queue_message("The rewrite clears the audience's fatigue.")
+        return True

--- a/tests/test_floor18.py
+++ b/tests/test_floor18.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+from dungeoncrawler.entities import Enemy, Player
+from dungeoncrawler.hooks import floor18
+from dungeoncrawler.status_effects import add_status_effect, apply_status_effects
+
+
+def make_state(player, enemies=None):
+    enemies = enemies or []
+    game = SimpleNamespace(last_action=None)
+    state = SimpleNamespace(player=player, enemies=enemies, game=game, log=[])
+    state.queue_message = state.log.append
+    return state
+
+
+def test_spotlight_ping_and_counters():
+    player = Player("Hero")
+    enemy = Enemy("Goblin", 10, 10, 0, 0)
+    enemy.rarity = "elite"
+    state = make_state(player, [enemy])
+    hook = floor18.Hooks()
+    hook.on_floor_start(state, None)
+    add_status_effect(player, "spotlight_ping", 1)
+    player.x, player.y = 2, 3
+    base = enemy.attack_power
+    hook.on_turn(state, None)
+    assert state.spotlight_ping == (2, 3)
+    assert enemy.attack_power == int(base * 1.1)
+    hook.use_jammer(state)
+    hook.on_turn(state, None)
+    assert state.spotlight_ping is None
+    assert enemy.attack_power == base
+    add_status_effect(player, "spotlight_ping", 1)
+    hook.on_turn(state, None)
+    assert enemy.attack_power == int(base * 1.1)
+    hook.use_stealth(state)
+    hook.on_turn(state, None)
+    assert state.spotlight_ping is None
+    assert enemy.attack_power == base
+
+
+def test_audience_fatigue_stacks_and_rewrite():
+    player = Player("Hero")
+    state = make_state(player)
+    hook = floor18.Hooks()
+    hook.on_floor_start(state, None)
+    for _ in range(6):
+        state.game.last_action = "Fireball"
+        hook.on_turn(state, None)
+    assert player.status_effects["audience_fatigue"] == 4
+    assert getattr(player, "_audience_fatigue_timers", []) == [3, 3, 3, 3]
+    apply_status_effects(player)
+    assert player.status_effects["audience_fatigue"] == 4
+    hook.use_rewrite(state)
+    assert "audience_fatigue" not in player.status_effects
+    assert getattr(player, "_audience_fatigue_timers", []) == []


### PR DESCRIPTION
## Summary
- Implement Spotlight pings and Audience Fatigue mechanics for floor 18
- Add Signal Jammer, Smoke Bomb, and Rewrite consumables
- Document Broadcast Finale floor and update changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a003837e048326ad0d817147a05b82