### PR TITLE
Add augment item type and tweak floor 16 spawns

### DIFF
--- a/data/floors.json
+++ b/data/floors.json
@@ -341,6 +341,15 @@
       "Shade",
       "Giant Spider"
     ],
+    "enemy_pool": [
+      "Harpy",
+      "Harpy",
+      "Shade",
+      "Shade",
+      "Giant Spider",
+      "Giant Spider",
+      "Demon"
+    ],
     "bosses": [
       "Feral Juggernaut"
     ],

--- a/data/items.json
+++ b/data/items.json
@@ -20,7 +20,8 @@
     {"type": "Item", "name": "Signal Jammer", "description": "Scrambles Spotlight pings", "price": 30, "rarity": "uncommon"},
     {"type": "Item", "name": "Smoke Bomb", "description": "Briefly hides you from the Spotlight", "price": 35, "rarity": "uncommon"},
     {"type": "Item", "name": "Rewrite", "description": "Clears Audience Fatigue stacks", "price": 25, "rarity": "common"},
-    {"type": "Trinket", "name": "Suppression Ring", "description": "Negates Mana Lock but may overheat", "price": 50, "rarity": "rare"}
+    {"type": "Trinket", "name": "Suppression Ring", "description": "Negates Mana Lock but may overheat", "price": 50, "rarity": "rare"},
+    {"type": "Augment", "name": "Battle Stim", "description": "Gain +2 attack, lose 5 max health", "attack_bonus": 2, "health_penalty": 5, "max_stacks": 2, "price": 40, "rarity": "uncommon"}
   ],
   "rare": [
     {"type": "Weapon", "name": "Elven Longbow", "description": "Bow of unmatched accuracy.", "min_damage": 15, "max_damage": 25, "price": 0, "rarity": "epic"},

--- a/dungeoncrawler/data.py
+++ b/dungeoncrawler/data.py
@@ -25,7 +25,7 @@ from .events import (
     ShrineGauntletEvent,
     TrapEvent,
 )
-from .items import Armor, Item, Trinket, Weapon
+from .items import Armor, Item, Trinket, Weapon, Augment
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 
@@ -82,6 +82,16 @@ def load_items() -> Tuple[List[Item], List[Item]]:
                 cfg["name"],
                 cfg.get("description", ""),
                 cfg.get("effect"),
+                cfg.get("price", 0),
+                cfg.get("rarity", "common"),
+            )
+        if t == "Augment":
+            return Augment(
+                cfg["name"],
+                cfg.get("description", ""),
+                cfg.get("attack_bonus", 0),
+                cfg.get("health_penalty", 0),
+                cfg.get("max_stacks", 1),
                 cfg.get("price", 0),
                 cfg.get("rarity", "common"),
             )

--- a/dungeoncrawler/items.py
+++ b/dungeoncrawler/items.py
@@ -45,3 +45,19 @@ class Trinket(Item):
     effect: Optional[str] = None
     price: int = 30
     rarity: str = "common"
+
+
+@dataclass
+class Augment(Item):
+    """Item that grants a bonus at a permanent cost.
+
+    Augments offer a risk-reward choice by increasing attack power while
+    reducing maximum health. Multiple copies of the same augment may stack up
+    to ``max_stacks`` times to amplify both the benefit and the drawback.
+    """
+
+    attack_bonus: int
+    health_penalty: int
+    max_stacks: int = 1
+    price: int = 0
+    rarity: str = "common"

--- a/tests/test_augments.py
+++ b/tests/test_augments.py
@@ -1,0 +1,20 @@
+from dungeoncrawler.entities import Player
+from dungeoncrawler.items import Augment
+
+
+def test_augment_stacking_rules():
+    player = Player("Hero")
+    aug = Augment("Battle Stim", "", attack_bonus=2, health_penalty=5, max_stacks=2)
+
+    assert player.apply_augment(aug) is True
+    assert player.attack_power == 12
+    assert player.max_health == 95
+
+    assert player.apply_augment(aug) is True
+    assert player.attack_power == 14
+    assert player.max_health == 90
+
+    # third application should fail due to stack limit
+    assert player.apply_augment(aug) is False
+    assert player.attack_power == 14
+    assert player.max_health == 90


### PR DESCRIPTION
## Summary
- introduce Augment item class with risk-reward bonuses
- weight floor 16 enemy pool to reduce elite frequency
- test stacking rules for Augment items

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0106553a88326ad3a6aa349b2edf5