### PR TITLE
Display score breakdown after runs

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -616,13 +616,8 @@ class DungeonBase:
         breakdown = self.player.get_score_breakdown()
 
         self.renderer.show_message(_(f"Final Score: {breakdown['total']}"))
-        self.renderer.show_message(_("Score Breakdown:"))
-        self.renderer.show_message(_(f"  Level: {breakdown['level']}"))
-        self.renderer.show_message(_(f"  Inventory: {breakdown['inventory']}"))
-        self.renderer.show_message(_(f"  Credits: {breakdown['credits']}"))
-        for name, bonus in breakdown["style"].items():
-            label = name.replace("_", " ").title()
-            self.renderer.show_message(_(f"  {label}: {bonus}"))
+        for line in self.player.format_score_breakdown(breakdown):
+            self.renderer.show_message(line)
 
         records.append(
             {
@@ -1048,7 +1043,6 @@ class DungeonBase:
         self.renderer.show_message(
             _(f"Fell on Floor {floor} to '{self.player.cause_of_death or 'Unknown'}'")
         )
-        self.renderer.show_message(_(f"Final Score: {self.player.get_score()}"))
         self.record_score(floor)
         self.stats_logger.finalize(self, self.player.cause_of_death or "Unknown")
         if os.path.exists(SAVE_FILE):
@@ -1244,14 +1238,19 @@ class DungeonBase:
                     return floor, False
                 self.renderer.show_message(_("You retire from the dungeon."))
             elif floor == 18:
-                keys = sum(1 for item in self.player.inventory if getattr(item, "name", "") == "Key")
+                keys = sum(
+                    1
+                    for item in self.player.inventory
+                    if getattr(item, "name", "") == "Key"
+                )
                 slots = self.floor_configs.get(18, {}).get("boss_slots", 1)
                 if keys < slots:
-                    proceed = input(_("Exit the dungeon or continue fighting? (y/n): ")).strip().lower()
+                    proceed = input(
+                        _("Exit the dungeon or continue fighting? (y/n): ")
+                    ).strip().lower()
                     if proceed != "y":
                         return floor, True
                 self.player.score_buff += keys * 100
-                self.renderer.show_message(_(f"Final Score: {self.player.get_score()}"))
                 self.record_score(floor)
                 if os.path.exists(SAVE_FILE):
                     try:

--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -867,6 +867,20 @@ class Player(Entity):
         """Compatibility wrapper returning only the total score."""
         return self.get_score_breakdown()["total"]
 
+    def format_score_breakdown(self, breakdown=None):
+        """Return a list of human-readable score breakdown lines."""
+        breakdown = breakdown or self.get_score_breakdown()
+        lines = [
+            _('Score Breakdown:'),
+            _(f'  Level: {breakdown["level"]}'),
+            _(f'  Inventory: {breakdown["inventory"]}'),
+            _(f'  Credits: {breakdown["credits"]}'),
+        ]
+        for name, bonus in breakdown['style'].items():
+            label = name.replace('_', ' ').title()
+            lines.append(_(f'  {label}: {bonus}'))
+        return lines
+
 
 class Enemy(Entity):
     """Adversary encountered within the dungeon.

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -419,7 +419,10 @@ def handle_room(game: "DungeonBase", x: int, y: int) -> None:
             game.stairs_prompt_shown = True
         if game.player.has_item("Key"):
             game.queue_message(_("🎉 You unlocked the exit and escaped the dungeon!"))
-            game.queue_message(_(f"Final Score: {game.player.get_score()}"))
+            breakdown = game.player.get_score_breakdown()
+            game.queue_message(_(f"Final Score: {breakdown['total']}"))
+            for line in game.player.format_score_breakdown(breakdown):
+                game.queue_message(line)
             exit()
         else:
             game.queue_message(_("The exit is locked. You need a key!"))

--- a/tests/test_score_calculation.py
+++ b/tests/test_score_calculation.py
@@ -15,3 +15,20 @@ def test_score_style_bonuses():
     assert breakdown["style"]["no_damage"] == 50
     assert breakdown["style"]["rich"] == 50
     assert breakdown["total"] == 440
+
+
+def test_format_score_breakdown_lines():
+    player = Player("Tester")
+    player.level = 1
+    player.inventory.append(object())
+    player.credits = 5
+    player.health = player.max_health
+
+    lines = player.format_score_breakdown()
+    assert lines == [
+        "Score Breakdown:",
+        "  Level: 100",
+        "  Inventory: 10",
+        "  Credits: 5",
+        "  No Damage: 50",
+    ]


### PR DESCRIPTION
## Summary
- add Player.format_score_breakdown for consistent score summary output
- show score breakdown after run ends and when exiting via dungeon map
- test score breakdown formatting

## Testing
- `flake8 dungeoncrawler/entities.py dungeoncrawler/dungeon.py dungeoncrawler/map.py tests/test_score_calculation.py`
- `pytest tests/test_score_calculation.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0178ba8608326b74866fbee754aa5