### PR TITLE
Enforce hooks field for floor definitions

### DIFF
--- a/data/floors/02_floor.json
+++ b/data/floors/02_floor.json
@@ -8,5 +8,6 @@
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": []
 }

--- a/data/floors/03_floor.json
+++ b/data/floors/03_floor.json
@@ -8,5 +8,6 @@
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": []
 }

--- a/data/floors/04_floor.json
+++ b/data/floors/04_floor.json
@@ -8,5 +8,6 @@
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": []
 }

--- a/data/floors/05_floor.json
+++ b/data/floors/05_floor.json
@@ -8,5 +8,6 @@
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": []
 }

--- a/data/floors/06_floor.json
+++ b/data/floors/06_floor.json
@@ -8,5 +8,6 @@
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": []
 }

--- a/data/floors/07_floor.json
+++ b/data/floors/07_floor.json
@@ -8,5 +8,6 @@
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": []
 }

--- a/data/floors/08_floor.json
+++ b/data/floors/08_floor.json
@@ -8,5 +8,6 @@
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": []
 }

--- a/data/floors/09_floor.json
+++ b/data/floors/09_floor.json
@@ -8,5 +8,6 @@
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": []
 }

--- a/data/floors/10_floor.json
+++ b/data/floors/10_floor.json
@@ -8,5 +8,6 @@
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": []
 }

--- a/data/floors/11_floor.json
+++ b/data/floors/11_floor.json
@@ -8,5 +8,6 @@
     "type": "none"
   },
   "spawns": [],
-  "ui": {}
+  "ui": {},
+  "hooks": []
 }

--- a/schemas/floor.json
+++ b/schemas/floor.json
@@ -9,7 +9,8 @@
     "rule_mods",
     "objective",
     "spawns",
-    "ui"
+    "ui",
+    "hooks"
   ],
   "properties": {
     "id": {

--- a/tests/test_floor_schema.py
+++ b/tests/test_floor_schema.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 import pytest
-from jsonschema import Draft7Validator
+from jsonschema import Draft7Validator, ValidationError
 
 ROOT = Path(__file__).resolve().parent.parent
 SCHEMA = json.loads((ROOT / "schemas" / "floor.json").read_text())
@@ -14,3 +14,18 @@ def test_floor_files_conform_to_schema(floor_path):
     data = json.loads(floor_path.read_text())
     data.pop("$schema", None)
     Draft7Validator(SCHEMA).validate(data)
+
+
+def test_missing_hooks_field_is_invalid():
+    """Floor entries lacking the required hooks list should fail validation."""
+    invalid = {
+        "id": "00",
+        "name": "Invalid",
+        "map": [],
+        "rule_mods": {},
+        "objective": {},
+        "spawns": [],
+        "ui": {},
+    }
+    with pytest.raises(ValidationError):
+        Draft7Validator(SCHEMA).validate(invalid)


### PR DESCRIPTION
## Summary
- Require floor definitions to include a `hooks` list and update schema
- Populate hooks arrays for early floors
- Add schema test ensuring missing hooks fails validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a022b1e5d88326b078d2f557e98dd1