### PR TITLE
Add retirement scoring and tier-two scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ entries are written to `~/.dungeon_crawler` in your home directory.
 - Rack up the highest score on the in-game leaderboard. Runs can be ranked by
   score, deepest floor reached or fastest completion time.
 
+## Retiring & Scoring
+
+Upon reaching Floor 9 you may **retire** from the run to lock in your score or
+descend toward the final gauntlet. Choosing to retire records your current
+score to `~/.dungeon_crawler/scores.json` and deletes the active save file,
+returning you to the title screen. Continuing downward restores the save and
+applies the usual floor scaling.
+
 ## Features
 
 - Gradual character creation that unlocks classes, guilds and races as you

--- a/docs/gameplay_guide.rst
+++ b/docs/gameplay_guide.rst
@@ -7,6 +7,14 @@ At any time choose **8. Show Map** to display the dungeon grid. The map marks yo
 
 Progress is automatically saved whenever you clear a floor.
 
+Retiring & Scoring
+------------------
+Upon reaching the end of Floor 9 you may retire early to bank your score or
+descend toward the late-game debuffs. Retiring immediately records your current
+score and writes a breakdown to ``~/.dungeon_crawler/scores.json`` before
+returning you to the title screen and clearing the active save. Descending keeps
+the adventure going and applies standard floor scaling.
+
 Classes, Guilds and Races
 -------------------------
 Characters grow through three axes of customization.  A **class** supplies a

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -203,6 +203,7 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
         ai = IntentAI(**weights) if weights else None
         traits = game.enemy_traits.get(name)
         enemy = Enemy(name, health, attack, defense, credits, ability, ai, traits=traits)
+        enemy.floor = floor
         enemy.xp = max(5, (health + attack + defense) // 15)
 
         place(enemy)
@@ -227,6 +228,7 @@ def generate_dungeon(game: "DungeonBase", floor: int = 1) -> None:
             ai=boss_ai,
             traits=game.boss_traits.get(name),
         )
+        boss.floor = floor
         place(boss)
         boss_drop = game.boss_loot.get(name, [])
         if boss_drop:

--- a/dungeoncrawler/status_effects.py
+++ b/dungeoncrawler/status_effects.py
@@ -79,6 +79,8 @@ def add_status_effect(entity, effect: str, duration: int, source=None, _reflecte
         setattr(entity, "status_effects", effects)
     rarity = getattr(entity, "rarity", "common")
     modifier = RARITY_STATUS_RESISTANCE.get(rarity, 1.0)
+    if rarity == "elite" and getattr(entity, "floor", 1) < 10:
+        modifier = 1.0
     duration = max(1, int(duration * modifier))
     effects[effect] = duration
     is_player = entity.__class__.__name__ == "Player"

--- a/tests/test_early_exit_save.py
+++ b/tests/test_early_exit_save.py
@@ -1,3 +1,5 @@
+import json
+
 import dungeoncrawler.dungeon as dungeon_module
 from dungeoncrawler.dungeon import DungeonBase
 from dungeoncrawler.entities import Player
@@ -25,3 +27,28 @@ def test_retire_removes_save_file(tmp_path, monkeypatch):
 
     assert status is None
     assert not save_path.exists()
+    data = json.loads(score_path.read_text())
+    assert data and "breakdown" in data[0]
+
+
+def test_descend_proceeds(tmp_path, monkeypatch):
+    save_path = tmp_path / "save.json"
+    score_path = tmp_path / "scores.json"
+    monkeypatch.setattr(dungeon_module, "SAVE_FILE", save_path)
+    monkeypatch.setattr(dungeon_module, "SCORE_FILE", score_path)
+
+    dungeon = DungeonBase(1, 1)
+    player = Player("Tester")
+    player.inventory.append(Item("Key", ""))
+    dungeon.player = player
+    dungeon.exit_coords = (0, 0)
+    player.x = 0
+    player.y = 0
+
+    save_path.write_text("{}")
+
+    monkeypatch.setattr("builtins.input", lambda _: "d")
+    floor, status = dungeon.check_floor_completion(9)
+
+    assert (floor, status) == (10, False)
+    assert save_path.exists()

--- a/tests/test_elite_resistance.py
+++ b/tests/test_elite_resistance.py
@@ -2,8 +2,12 @@ from dungeoncrawler.entities import Enemy
 from dungeoncrawler.status_effects import add_status_effect
 
 
-def test_elite_status_resistance():
+def test_elite_status_resistance_activates_after_floor10():
     enemy = Enemy("Dummy", 10, 2, 0, 0)
     enemy.rarity = "elite"
+    enemy.floor = 9
     add_status_effect(enemy, "poison", 4)
-    assert enemy.status_effects["poison"] == 2
+    assert enemy.status_effects["poison"] == 4
+    enemy.floor = 10
+    add_status_effect(enemy, "burn", 4)
+    assert enemy.status_effects["burn"] == 2

--- a/tests/test_floor_scaling.py
+++ b/tests/test_floor_scaling.py
@@ -1,29 +1,57 @@
 from dungeoncrawler import map as dungeon_map
 from dungeoncrawler.config import config
+import pytest
+
+from dungeoncrawler import map as dungeon_map
+from dungeoncrawler.config import config
 from dungeoncrawler.dungeon import DungeonBase
 from dungeoncrawler.entities import Player
 
 
-def test_floor10_scaling_applies(monkeypatch):
+def _setup(monkeypatch):
     dungeon = DungeonBase(1, 1)
     dungeon.player = Player("Tester")
     monkeypatch.setattr(dungeon_map, "generate_dungeon", lambda *a, **k: None)
+    return dungeon
+
+
+def test_per_floor_scaling(monkeypatch):
+    dungeon = _setup(monkeypatch)
     original_hp, original_dmg = config.enemy_hp_mult, config.enemy_dmg_mult
-    config.enable_debug = False
+    dungeon.generate_dungeon(3)
+    try:
+        assert config.enemy_hp_mult == pytest.approx(1 + 0.05 * 2)
+        assert config.enemy_dmg_mult == pytest.approx(1 + 0.04 * 2)
+    finally:
+        config.enemy_hp_mult = original_hp
+        config.enemy_dmg_mult = original_dmg
+
+
+def test_hard_band_boost(monkeypatch):
+    dungeon = _setup(monkeypatch)
+    original_hp, original_dmg = config.enemy_hp_mult, config.enemy_dmg_mult
     dungeon.generate_dungeon(10)
-    assert config.enemy_hp_mult == original_hp + 0.15
-    assert config.enemy_dmg_mult == original_dmg + 0.10
-    config.enemy_hp_mult = original_hp
-    config.enemy_dmg_mult = original_dmg
+    first_hp, first_dmg = config.enemy_hp_mult, config.enemy_dmg_mult
+    dungeon.generate_dungeon(11)
+    try:
+        assert first_hp == pytest.approx(1 + 0.05 * 9 + 0.15)
+        assert first_dmg == pytest.approx(1 + 0.04 * 9 + 0.10)
+        assert config.enemy_hp_mult == pytest.approx(1 + 0.05 * 10 + 0.15)
+        assert config.enemy_dmg_mult == pytest.approx(1 + 0.04 * 10 + 0.10)
+    finally:
+        config.enemy_hp_mult = original_hp
+        config.enemy_dmg_mult = original_dmg
 
 
-def test_floor10_scaling_disabled_in_debug(monkeypatch):
-    dungeon = DungeonBase(1, 1)
-    dungeon.player = Player("Tester")
-    monkeypatch.setattr(dungeon_map, "generate_dungeon", lambda *a, **k: None)
+def test_scaling_disabled_in_debug(monkeypatch):
+    dungeon = _setup(monkeypatch)
     original_hp, original_dmg = config.enemy_hp_mult, config.enemy_dmg_mult
     config.enable_debug = True
     dungeon.generate_dungeon(10)
-    assert config.enemy_hp_mult == original_hp
-    assert config.enemy_dmg_mult == original_dmg
-    config.enable_debug = False
+    try:
+        assert config.enemy_hp_mult == original_hp
+        assert config.enemy_dmg_mult == original_dmg
+    finally:
+        config.enable_debug = False
+        config.enemy_hp_mult = original_hp
+        config.enemy_dmg_mult = original_dmg

--- a/tests/test_high_floor_debuffs.py
+++ b/tests/test_high_floor_debuffs.py
@@ -1,6 +1,9 @@
 from dungeoncrawler.config import config
 from dungeoncrawler.data import load_floor_definitions
 from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.config import config
+from dungeoncrawler.data import load_floor_definitions
+from dungeoncrawler.dungeon import DungeonBase
 from dungeoncrawler.entities import Player
 from dungeoncrawler.items import Item
 from dungeoncrawler.map import update_visibility
@@ -23,23 +26,31 @@ def test_floor_10_halves_healing(monkeypatch):
     game = DungeonBase(1, 1)
     game.player = Player("Hero")
     monkeypatch.setattr(DungeonBase, "save_game", lambda self, floor: None)
+    orig_hp, orig_dmg = config.enemy_hp_mult, config.enemy_dmg_mult
     game.generate_dungeon(10)
     game.player.health = game.player.max_health - 20
     game.player.inventory.append(Item("Health Potion", ""))
     game.player.use_health_potion()
-    assert game.player.health == game.player.max_health - 10
+    try:
+        assert game.player.health == game.player.max_health - 10
+    finally:
+        config.enemy_hp_mult = orig_hp
+        config.enemy_dmg_mult = orig_dmg
 
 
 def test_floor_11_trap_chance_increases(monkeypatch):
-    base = config.trap_chance
+    base_trap = config.trap_chance
+    orig_hp, orig_dmg = config.enemy_hp_mult, config.enemy_dmg_mult
     game = DungeonBase(1, 1)
     game.player = Player("Hero")
     monkeypatch.setattr(DungeonBase, "save_game", lambda self, floor: None)
     game.generate_dungeon(11)
     try:
-        assert config.trap_chance > base
+        assert config.trap_chance > base_trap
     finally:
-        config.trap_chance = base
+        config.trap_chance = base_trap
+        config.enemy_hp_mult = orig_hp
+        config.enemy_dmg_mult = orig_dmg
 
 
 def test_floor_10_visibility_reduced():

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -22,6 +22,7 @@ def test_record_score_persistence(tmp_path, monkeypatch):
     assert data[0]["seed"] == 1234
     assert data[0]["run_duration"] == 10
     assert "epitaph" in data[0]
+    assert "breakdown" in data[0]
 
 
 def test_view_leaderboard_display(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- Rework floor scaling to apply per-floor multipliers with a hard band from floor 10
- Gate elite status resistance to high floors and track enemy floors for effects
- Add retirement option at floor 9 and document scoring flow

## Testing
- `pytest tests/test_floor_scaling.py tests/test_elite_resistance.py tests/test_early_exit_save.py tests/test_leaderboard.py tests/test_high_floor_debuffs.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a027b6f4f88326a59e8c0a4b96c694