### PR TITLE
chore(ci): run workflow only on pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,6 @@ on:
       - 'docs/**'
       - 'coverage.svg'
       - '.github/workflows/pages.yml'
-  push:
-    branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - 'coverage.svg'
-      - '.github/workflows/pages.yml'
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary
- remove push trigger from CI workflow so it runs only on pull requests

## Testing
- `isort --profile black --check-only .`
- `black --check .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e0b6ef7083269562c3693ba74dc5