### PR TITLE
chore: adjust formatting workflow for pull requests

### DIFF
--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -2,10 +2,8 @@ name: Auto-format via PR
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 8 * * 1-5'  # weekdays 08:00 UTC
-  push:
-    branches: [main]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: write
@@ -22,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -38,9 +37,9 @@ jobs:
       - name: Create or update PR with changes
         uses: peter-evans/create-pull-request@v6
         with:
-          branch: ci/formatting
-          title: "Apply Black and isort formatting"
           commit-message: "Apply Black and isort formatting"
+          title: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          body: "Automated formatting (Black + isort)."
-          delete-branch: true
+          branch: ${{ github.head_ref }}
+          push-to-fork: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
## Summary
- run formatting workflow on `pull_request_target`
- commit formatting fixes back to the contributor's branch

## Testing
- `pytest` *(fails: KeyboardInterrupt)*
- `pytest tests/test_hard_mode.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e704c7c883269cb2c11a50317241