### PR TITLE
Handle file read errors when loading config

### DIFF
--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -65,7 +65,7 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
     if path.exists():
         try:
             data: Any = json.loads(path.read_text())
-        except json.JSONDecodeError:
+        except (OSError, json.JSONDecodeError):
             return cfg
         if not isinstance(data, dict):
             return cfg

--- a/tests/test_config_load_error.py
+++ b/tests/test_config_load_error.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pytest
+
+from dungeoncrawler.config import Config, load_config
+
+
+def test_load_config_handles_oserror(monkeypatch, tmp_path):
+    """``load_config`` should gracefully handle file read errors.
+
+    If reading the configuration file raises ``OSError`` the function should
+    fall back to default settings instead of propagating the exception.
+    """
+
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text("{}")
+
+    def bad_read_text(self, *args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(Path, "read_text", bad_read_text)
+
+    assert load_config(cfg_file) == Config()
+


### PR DESCRIPTION
## Summary
- Gracefully handle `OSError` while reading configuration files
- Test load_config behaviour when file read fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0eacd9d408326a3cd9e2c8954f7d3