### PR TITLE
Fix shop inventory not updating after purchase

### DIFF
--- a/dungeoncrawler/shop.py
+++ b/dungeoncrawler/shop.py
@@ -49,6 +49,11 @@ def shop(
             if game.player.credits >= price:
                 game.player.collect_item(item)
                 game.player.credits -= price
+                # Remove the purchased item from the shop so it cannot be bought
+                # repeatedly during the same visit. Previously the item remained
+                # in ``game.shop_inventory`` allowing unlimited purchases of the
+                # same entry which is not the intended behaviour.
+                del game.shop_inventory[choice - 1]
                 output_func(_(f"You bought {item.name}."))
             else:
                 output_func(_("Not enough credits."))

--- a/tests/test_shop.py
+++ b/tests/test_shop.py
@@ -13,6 +13,8 @@ def test_shop_purchase():
     shop_module.shop(dungeon, input_func=lambda _: "1", output_func=lambda _msg: None)
     assert dungeon.player.credits == 10
     assert any(item.name == "Health Potion" for item in dungeon.player.inventory)
+    # purchased item should no longer be in the shop inventory
+    assert all(item.name != "Health Potion" for item in dungeon.shop_inventory)
 
 
 def test_sell_weapon():


### PR DESCRIPTION
## Summary
- remove purchased items from shop inventory to prevent repeated purchases
- test that shop inventory updates after a purchase

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0eacd9d408326a3cd9e2c8954f7d3