### PR TITLE
Validate IntentAI weights

### DIFF
--- a/dungeoncrawler/ai.py
+++ b/dungeoncrawler/ai.py
@@ -55,11 +55,25 @@ class IntentAI:
     }
 
     def __init__(self, aggressive=1, defensive=1, unpredictable=1):
+        """Create a new intent controller.
+
+        Parameters
+        ----------
+        aggressive, defensive, unpredictable:
+            Relative weights for selecting each intent. All weights must be
+            non-negative and at least one must be greater than zero.
+        """
+
         self.weights = {
             "aggressive": aggressive,
             "defensive": defensive,
             "unpredictable": unpredictable,
         }
+
+        if any(w < 0 for w in self.weights.values()):
+            raise ValueError("Intent weights must be non-negative")
+        if sum(self.weights.values()) == 0:
+            raise ValueError("At least one intent weight must be greater than zero")
 
     # ------------------------------------------------------------------
     def choose_intent(self, enemy, player):

--- a/tests/test_intent_system.py
+++ b/tests/test_intent_system.py
@@ -1,5 +1,7 @@
 import random
 
+import pytest
+
 from dungeoncrawler.ai import IntentAI
 from dungeoncrawler.entities import Enemy
 
@@ -22,3 +24,8 @@ def test_intent_field_and_delayed_resolution():
     enemy.take_turn(player)
     assert "shield" in enemy.status_effects
     assert enemy.intent is None
+
+
+def test_intent_ai_requires_positive_weight():
+    with pytest.raises(ValueError):
+        IntentAI(0, 0, 0)


### PR DESCRIPTION
## Summary
- validate that IntentAI weights are non-negative and not all zero
- document weight requirements and add coverage for invalid weights

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f4f83cf88326b3b8f3a5ff04526a