### PR TITLE
Handle non-fork PRs in format workflow

### DIFF
--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -34,7 +34,8 @@ jobs:
         run: |
           black .
           isort --profile black .
-      - name: Create or update PR with changes
+      - name: Create or update PR with changes (fork)
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "Apply Black and isort formatting"
@@ -43,3 +44,12 @@ jobs:
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           branch: ${{ github.head_ref }}
           push-to-fork: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Create or update PR with changes (same repo)
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Apply Black and isort formatting"
+          title: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          branch: ${{ github.head_ref }}


### PR DESCRIPTION
## Summary
- fix auto-format workflow failing when pull request originates from main repo
- conditionally configure create-pull-request for forked vs same-repo branches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f5cebc9c8326a9232b286a191bf7