### PR TITLE
Sort imports in test_no_companions

### DIFF
--- a/tests/test_no_companions.py
+++ b/tests/test_no_companions.py
@@ -3,7 +3,7 @@ import random
 from dungeoncrawler import map as dungeon_map
 from dungeoncrawler.data import load_floor_definitions
 from dungeoncrawler.dungeon import DungeonBase
-from dungeoncrawler.entities import Player, Companion
+from dungeoncrawler.entities import Companion, Player
 
 
 def test_generate_dungeon_without_companion(monkeypatch):


### PR DESCRIPTION
## Summary
- fix isort failure in tests/test_no_companions.py by ordering Companion before Player

## Testing
- `isort tests/test_no_companions.py --profile black --check-only`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f7b7c970832686491d1f6181d505