### PR TITLE
Sort imports and fix auto-format workflow

### DIFF
--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -42,7 +42,7 @@ jobs:
           title: ${{ github.event.pull_request.title }}
           body: ${{ github.event.pull_request.body }}
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          branch: ${{ github.head_ref }}
+          branch: ${{ github.event.pull_request.head.ref }}
           push-to-fork: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Create or update PR with changes (same repo)
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
@@ -52,4 +52,4 @@ jobs:
           title: ${{ github.event.pull_request.title }}
           body: ${{ github.event.pull_request.body }}
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          branch: ${{ github.head_ref }}
+          branch: ${{ github.event.pull_request.head.ref }}

--- a/tests/test_config_load_error.py
+++ b/tests/test_config_load_error.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import pytest
-
 from dungeoncrawler.config import Config, load_config
 
 
@@ -21,4 +19,3 @@ def test_load_config_handles_oserror(monkeypatch, tmp_path):
     monkeypatch.setattr(Path, "read_text", bad_read_text)
 
     assert load_config(cfg_file) == Config()
-

--- a/tests/test_no_companions.py
+++ b/tests/test_no_companions.py
@@ -3,7 +3,7 @@ import random
 from dungeoncrawler import map as dungeon_map
 from dungeoncrawler.data import load_floor_definitions
 from dungeoncrawler.dungeon import DungeonBase
-from dungeoncrawler.entities import Player, Companion
+from dungeoncrawler.entities import Companion, Player
 
 
 def test_generate_dungeon_without_companion(monkeypatch):
@@ -13,8 +13,4 @@ def test_generate_dungeon_without_companion(monkeypatch):
     game.player = Player("Tester")
     monkeypatch.setattr(dungeon_map, "load_companions", lambda: [])
     dungeon_map.generate_dungeon(game, floor=1)
-    assert all(
-        not isinstance(tile, Companion)
-        for row in game.rooms
-        for tile in row
-    )
+    assert all(not isinstance(tile, Companion) for row in game.rooms for tile in row)


### PR DESCRIPTION
## Summary
- fix isort failure in tests/test_no_companions.py by ordering Companion before Player
- remove unused import and format tests to satisfy black and flake8
- fix format-pr workflow branch reference so auto-formatting can update PRs

## Testing
- `isort --profile black --check-only .`
- `black --check .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f7b7c970832686491d1f6181d505