### PR TITLE
Specify base branch in auto-format workflow

### DIFF
--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -43,6 +43,7 @@ jobs:
           body: ${{ github.event.pull_request.body }}
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           branch: ${{ github.event.pull_request.head.ref }}
+          base: ${{ github.event.pull_request.base.ref }}
           push-to-fork: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Create or update PR with changes (same repo)
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
@@ -53,3 +54,4 @@ jobs:
           body: ${{ github.event.pull_request.body }}
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           branch: ${{ github.event.pull_request.head.ref }}
+          base: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
## Summary
- provide `base` input to create-pull-request in the format-pr workflow so it can operate when checked out at a commit

## Testing
- `isort --profile black --check-only .`
- `black --check .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0fbb1df108326a4fdbf67e47fc3d6