### PR TITLE
Handle detached HEAD in auto-format workflow

### DIFF
--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -42,8 +42,8 @@ jobs:
           title: ${{ github.event.pull_request.title }}
           body: ${{ github.event.pull_request.body }}
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          branch: ${{ github.event.pull_request.head.ref }}
-          base: ${{ github.event.pull_request.base.ref }}
+          branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          base: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
           push-to-fork: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Create or update PR with changes (same repo)
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
@@ -53,5 +53,5 @@ jobs:
           title: ${{ github.event.pull_request.title }}
           body: ${{ github.event.pull_request.body }}
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          branch: ${{ github.event.pull_request.head.ref }}
-          base: ${{ github.event.pull_request.base.ref }}
+          branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          base: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}


### PR DESCRIPTION
## Summary
- ensure format-pr workflow sets `branch` and `base` even when not triggered by a pull request

## Testing
- `isort --profile black --check-only .`
- `black --check .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0fe7837e0832696d85842efa71ae1