### PR TITLE
feat: add contextual tips system

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -34,6 +34,8 @@ from .plugins import apply_enemy_plugins, apply_item_plugins
 from .quests import EscortNPC, EscortQuest, FetchQuest, HuntQuest
 from .rendering import Renderer, render_map_string
 from .stats_logger import StatsLogger
+from .tutorial import Tip, TipsManager
+from .ui.terminal import render_tips_panel
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- rename interactive tutorial module and introduce tips framework
- surface map legend helper and tip panel renderer
- persist and toggle tips with new `TipsManager`

## Testing
- `pytest tests/test_tutorial.py tests/test_tips.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1068f19c88326bb0712d439561d16