### PR TITLE
Add configurable scoring bonuses and tips auto-disable test

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -12,5 +12,9 @@
   "enemy_hp_mult": 1.0,
   "enemy_dmg_mult": 1.0,
   "loot_mult": 1.0,
+  "retire_floor": 9,
+  "retire_bonus_per_floor": 0.08,
+  "death_penalty": 0.15,
+  "no_death_bonus": 0.10,
   "enable_debug": false
 }

--- a/config.json
+++ b/config.json
@@ -12,5 +12,9 @@
   "enemy_hp_mult": 1.0,
   "enemy_dmg_mult": 1.0,
   "loot_mult": 1.0,
+  "retire_floor": 9,
+  "retire_bonus_per_floor": 0.08,
+  "death_penalty": 0.15,
+  "no_death_bonus": 0.10,
   "enable_debug": false
 }

--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -34,6 +34,10 @@ class Config:
     enemy_hp_mult: float = 1.0
     enemy_dmg_mult: float = 1.0
     loot_mult: float = 1.0
+    retire_floor: int = 9
+    retire_bonus_per_floor: float = 0.08
+    death_penalty: float = 0.15
+    no_death_bonus: float = 0.10
     enable_debug: bool = False
     extras: dict[str, Any] = field(default_factory=dict)
 
@@ -96,6 +100,17 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
                     value = float(value)
                     key = "loot_mult" if key == "loot_multiplier" else key
                 elif key == "key_repeat_delay":
+                    if not isinstance(value, (int, float)):
+                        raise ValueError(f"{key} must be a number, got {type(value).__name__}")
+                    if float(value) < 0:
+                        raise ValueError(f"{key} must be greater than or equal to 0, got {value}")
+                    value = float(value)
+                elif key == "retire_floor":
+                    if not isinstance(value, int):
+                        raise ValueError(f"{key} must be an integer, got {type(value).__name__}")
+                    if value <= 0:
+                        raise ValueError(f"{key} must be greater than 0, got {value}")
+                elif key in {"retire_bonus_per_floor", "death_penalty", "no_death_bonus"}:
                     if not isinstance(value, (int, float)):
                         raise ValueError(f"{key} must be a number, got {type(value).__name__}")
                     if float(value) < 0:

--- a/dungeoncrawler/map.py
+++ b/dungeoncrawler/map.py
@@ -457,9 +457,13 @@ def handle_room(game: "DungeonBase", x: int, y: int) -> None:
             game.stairs_prompt_shown = True
         if game.player.has_item("Key"):
             game.queue_message(_("🎉 You unlocked the exit and escaped the dungeon!"))
-            breakdown = game.player.get_score_breakdown()
+            from .scoring import compute_score_breakdown, format_score_breakdown
+
+            base_score = game.player.get_score()
+            floor = getattr(game, "current_floor", 0)
+            breakdown = compute_score_breakdown({"base": base_score, "floor": floor, "died": False})
             game.queue_message(_(f"Final Score: {breakdown['total']}"))
-            for line in game.player.format_score_breakdown(breakdown):
+            for line in format_score_breakdown(breakdown):
                 game.queue_message(line)
             exit()
         else:

--- a/dungeoncrawler/scoring.py
+++ b/dungeoncrawler/scoring.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Utility helpers for computing final run scores.
+
+The scoring system applies a number of configurable bonuses and penalties to
+an underlying base score.  ``compute_score_breakdown`` returns a dictionary
+containing the contribution of each component and the final total.  A helper
+``format_score_breakdown`` converts that dictionary into human readable lines.
+"""
+
+from dataclasses import dataclass
+from typing import Mapping, Any
+
+from .config import config
+
+
+@dataclass
+class ScoreBreakdown:
+    base: int
+    retire_bonus: int
+    no_death_bonus: int
+    death_penalty: int
+    total: int
+    floors_early: int = 0
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "base": self.base,
+            "retire_bonus": self.retire_bonus,
+            "no_death_bonus": self.no_death_bonus,
+            "death_penalty": self.death_penalty,
+            "total": self.total,
+            "floors_early": self.floors_early,
+        }
+
+
+def compute_score_breakdown(state: Mapping[str, Any]) -> dict[str, int]:
+    """Compute a final score breakdown for ``state``.
+
+    Parameters
+    ----------
+    state:
+        Mapping with at least ``base`` (base score), ``floor`` (floor reached)
+        and ``died`` (truthy if the run ended in death).
+    """
+
+    base = int(state.get("base", 0))
+    floor = int(state.get("floor", 0))
+    died = bool(state.get("died", False))
+
+    cfg = config
+    floors_early = max(cfg.retire_floor - floor, 0) if not died and floor < cfg.retire_floor else 0
+    retire_bonus = round(base * cfg.retire_bonus_per_floor * floors_early)
+    no_death_bonus = round(base * cfg.no_death_bonus) if not died else 0
+    death_penalty = round(base * cfg.death_penalty) if died else 0
+    total = base + retire_bonus + no_death_bonus - death_penalty
+
+    breakdown = ScoreBreakdown(
+        base=base,
+        retire_bonus=int(retire_bonus),
+        no_death_bonus=int(no_death_bonus),
+        death_penalty=int(death_penalty),
+        total=int(total),
+        floors_early=int(floors_early),
+    )
+    return breakdown.to_dict()
+
+
+def format_score_breakdown(breakdown: Mapping[str, int]) -> list[str]:
+    """Return a list of human readable score breakdown lines."""
+
+    cfg = config
+    floors = breakdown.get("floors_early", 0)
+    lines = [
+        f"Base score: {breakdown.get('base', 0)}",
+        (
+            "Early retire bonus: +{bonus} (retired {floors} floors before Floor {rf} @ {pct}%/floor)".format(
+                bonus=breakdown.get("retire_bonus", 0),
+                floors=floors,
+                rf=cfg.retire_floor,
+                pct=int(cfg.retire_bonus_per_floor * 100),
+            )
+        ),
+        f"No-death bonus: +{breakdown.get('no_death_bonus', 0)}",
+        f"Death penalty: -{breakdown.get('death_penalty', 0)}",
+        f"TOTAL: {breakdown.get('total', 0)}",
+    ]
+    return lines

--- a/dungeoncrawler/tutorial.py
+++ b/dungeoncrawler/tutorial.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from gettext import gettext as _
+from dataclasses import dataclass, field
 
 from .input.keys import Action, get_action
 from .ui.terminal import Renderer
@@ -53,10 +54,19 @@ def run(game_inst, input_func=input, renderer: Renderer | None = None) -> None:
     game_inst.tutorial_complete = True
 
 
-if __name__ == "__main__":  # pragma: no cover - convenience script
-    from .config import load_config
-    from .dungeon import DungeonBase
-    from .main import build_character
+@dataclass
+class Tip:
+    """A small snippet of instructional text tied to a floor."""
+
+    name: str
+    lines: list[str]
+    floor: int = 1
+
+
+BASIC_TIPS = [
+    Tip("movement", ["Use the movement keys to explore."], floor=1),
+    Tip("combat", ["Engage enemies to gain experience."], floor=2),
+]
 
 # ``LEGEND_TIP`` does not store lines directly to keep translations fresh.
 LEGEND_TIP = Tip("legend", [], floor=1)

--- a/dungeoncrawler/ui/terminal.py
+++ b/dungeoncrawler/ui/terminal.py
@@ -192,4 +192,10 @@ class Renderer:
 
 
 # Public API
-__all__ = ["Renderer"]
+def render_tips_panel(lines: list[str]) -> str:
+    """Return a simple formatted tips panel string."""
+
+    return "\n".join(lines)
+
+
+__all__ = ["Renderer", "render_tips_panel"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,6 +67,10 @@ def test_new_keys_default(tmp_path):
     assert cfg.loot_mult == 1.0
     assert cfg.enemy_hp_mult == 1.0
     assert cfg.enemy_dmg_mult == 1.0
+    assert cfg.retire_floor == 9
+    assert cfg.retire_bonus_per_floor == 0.08
+    assert cfg.death_penalty == 0.15
+    assert cfg.no_death_bonus == 0.10
     assert cfg.verbose_combat is False
     assert cfg.slow_messages is False
     assert cfg.key_repeat_delay == 0.5

--- a/tests/test_score_breakdown.py
+++ b/tests/test_score_breakdown.py
@@ -1,0 +1,12 @@
+from dungeoncrawler.scoring import compute_score_breakdown
+
+
+def test_early_retire_bonus_applies_before_floor_9():
+    state = {"base": 1000, "floor": 5, "died": False}
+    breakdown = compute_score_breakdown(state)
+    # 4 floors before retire floor at 8% each -> 32% of base
+    assert breakdown["retire_bonus"] == 320
+    # No death bonus applies
+    assert breakdown["no_death_bonus"] == 100
+    assert breakdown["death_penalty"] == 0
+    assert breakdown["total"] == 1420

--- a/tests/test_tips.py
+++ b/tests/test_tips.py
@@ -1,0 +1,13 @@
+from dungeoncrawler.tutorial import TipsManager
+
+
+def test_tips_auto_disable_after_floor_two():
+    tm = TipsManager()
+    assert tm.enabled is True
+    # Access tips for early floors which should still be enabled
+    tm.for_floor(1)
+    tm.for_floor(2)
+    # Accessing floor 3 should auto disable future tips
+    tm.for_floor(3)
+    assert tm.enabled is False
+    assert tm.for_floor(4) == []


### PR DESCRIPTION
## Summary
- add configurable retire/death bonuses to config
- implement score breakdown computation and display
- ensure tips auto-disable after floor two and cover with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a10b8ba0f483269ddbcfe533a6150e