### PR TITLE
Add wound soft cap mechanics and augment combo hints

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -16,5 +16,8 @@
   "retire_bonus_per_floor": 0.08,
   "death_penalty": 0.15,
   "no_death_bonus": 0.10,
-  "enable_debug": false
+  "enable_debug": false,
+  "wounds_soft_cap_last_n_floors": 3,
+  "wounds_soft_cap_ratio": 0.30,
+  "wounds_decay_per_floor": 0.10
 }

--- a/config.json
+++ b/config.json
@@ -16,5 +16,8 @@
   "retire_bonus_per_floor": 0.08,
   "death_penalty": 0.15,
   "no_death_bonus": 0.10,
-  "enable_debug": false
+  "enable_debug": false,
+  "wounds_soft_cap_last_n_floors": 3,
+  "wounds_soft_cap_ratio": 0.30,
+  "wounds_decay_per_floor": 0.10
 }

--- a/data/items.json
+++ b/data/items.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../schemas/items.json",
   "shop": [
     {"type": "Item", "name": "Health Potion", "description": "Restores 20 health", "price": 10, "rarity": "common"},
     {"type": "Weapon", "name": "Sword", "description": "A sharp sword", "min_damage": 10, "max_damage": 15, "price": 40, "rarity": "common"},
@@ -21,7 +22,7 @@
     {"type": "Item", "name": "Smoke Bomb", "description": "Briefly hides you from the Spotlight", "price": 35, "rarity": "uncommon"},
     {"type": "Item", "name": "Rewrite", "description": "Clears Audience Fatigue stacks", "price": 25, "rarity": "common"},
     {"type": "Trinket", "name": "Suppression Ring", "description": "Negates Mana Lock but may overheat", "price": 50, "rarity": "rare"},
-    {"type": "Augment", "name": "Battle Stim", "description": "Gain +2 attack, lose 5 max health", "attack_bonus": 2, "health_penalty": 5, "max_stacks": 2, "price": 40, "rarity": "uncommon"}
+    {"type": "Augment", "name": "Battle Stim", "description": "Gain +2 attack, lose 5 max health", "attack_bonus": 2, "health_penalty": 5, "max_stacks": 2, "price": 40, "rarity": "uncommon", "combos_with": ["Bleed", "Poison"]}
   ],
   "rare": [
     {"type": "Weapon", "name": "Elven Longbow", "description": "Bow of unmatched accuracy.", "min_damage": 15, "max_damage": 25, "price": 0, "rarity": "epic"},

--- a/dungeoncrawler/config.py
+++ b/dungeoncrawler/config.py
@@ -39,6 +39,9 @@ class Config:
     death_penalty: float = 0.15
     no_death_bonus: float = 0.10
     enable_debug: bool = False
+    wounds_soft_cap_last_n_floors: int | None = None
+    wounds_soft_cap_ratio: float = 0.0
+    wounds_decay_per_floor: float = 0.0
     extras: dict[str, Any] = field(default_factory=dict)
 
 
@@ -115,6 +118,21 @@ def load_config(path: Path = CONFIG_PATH) -> Config:
                         raise ValueError(f"{key} must be a number, got {type(value).__name__}")
                     if float(value) < 0:
                         raise ValueError(f"{key} must be greater than or equal to 0, got {value}")
+                    value = float(value)
+                elif key == "wounds_soft_cap_last_n_floors":
+                    if value is None:
+                        value = None
+                    elif not isinstance(value, int):
+                        raise ValueError(f"{key} must be an integer, got {type(value).__name__}")
+                    elif value < 0:
+                        raise ValueError(f"{key} must be greater than or equal to 0, got {value}")
+                    else:
+                        value = int(value)
+                elif key in {"wounds_soft_cap_ratio", "wounds_decay_per_floor"}:
+                    if not isinstance(value, (int, float)):
+                        raise ValueError(f"{key} must be a number, got {type(value).__name__}")
+                    if not 0 <= float(value) <= 1:
+                        raise ValueError(f"{key} must be between 0 and 1, got {value}")
                     value = float(value)
                 setattr(cfg, key, value)
             else:

--- a/dungeoncrawler/data.py
+++ b/dungeoncrawler/data.py
@@ -94,6 +94,7 @@ def load_items() -> Tuple[List[Item], List[Item]]:
                 cfg.get("max_stacks", 1),
                 cfg.get("price", 0),
                 cfg.get("rarity", "common"),
+                cfg.get("combos_with"),
             )
         return Item(cfg["name"], cfg.get("description", ""))
 

--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -1223,6 +1223,7 @@ class DungeonBase:
         state = self._make_state(floor)
         for hook in self.floor_hooks:
             if hook.on_objective_check(state, self.floor_def):
+                self.player.decay_wounds()
                 floor += 1
                 self.player.temp_strength = 0
                 self.player.temp_intelligence = 0
@@ -1240,6 +1241,7 @@ class DungeonBase:
                 prompt = _("Retire for score or Descend (r/d): ")
                 choice = input(prompt).strip().lower()
                 if choice.startswith("d"):
+                    self.player.decay_wounds()
                     floor += 1
                     self.player.temp_strength = 0
                     self.player.temp_intelligence = 0
@@ -1276,6 +1278,7 @@ class DungeonBase:
             else:
                 proceed = input(_("Would you like to descend to the next floor? (y/n): ")).lower()
                 if proceed == "y":
+                    self.player.decay_wounds()
                     floor += 1
                     # Reset temporary floor buffs
                     self.player.temp_strength = 0

--- a/dungeoncrawler/items.py
+++ b/dungeoncrawler/items.py
@@ -61,3 +61,11 @@ class Augment(Item):
     max_stacks: int = 1
     price: int = 0
     rarity: str = "common"
+    combos_with: Optional[list[str]] = None
+
+    def describe(self) -> str:
+        base = self.description
+        if self.combos_with:
+            combo = ", ".join(self.combos_with)
+            base = f"{base} Combos with: {combo}"
+        return base

--- a/dungeoncrawler/shop.py
+++ b/dungeoncrawler/shop.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from .config import config
 from .constants import INVALID_KEY_MSG
-from .items import Armor, Item, Trinket, Weapon
+from .items import Armor, Item, Trinket, Weapon, Augment
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from .dungeon import DungeonBase
@@ -30,7 +30,11 @@ def shop(
         else:
             base_price = 10
         price = int(base_price * config.loot_mult)
-        output_func(_(f"{i}. {item.name} - {price} Credits"))
+        name = item.name
+        if isinstance(item, Augment) and item.combos_with:
+            if set(item.combos_with) & set(game.player.status_effects):
+                name = f"[{name}]"
+        output_func(_(f"{i}. {name} - {price} Credits"))
     sell_option = len(game.shop_inventory) + 1
     exit_option = sell_option + 1
     output_func(_(f"{sell_option}. Sell Items"))
@@ -138,7 +142,11 @@ def show_inventory(
         equipped = ""
         if item == game.player.weapon or item == game.player.armor or item == game.player.trinket:
             equipped = " (Equipped)"
-        output_func(_(f"{i}. {item.name}{equipped} - {item.description}"))
+        name = item.name
+        if isinstance(item, Augment) and item.combos_with:
+            if set(item.combos_with) & set(game.player.status_effects):
+                name = f"[{name}]"
+        output_func(_(f"{i}. {name}{equipped} - {item.description}"))
 
     choice = input_func(_("Enter item number to equip weapon, or press Enter to go back: "))
     if choice.isdigit():

--- a/schemas/items.json
+++ b/schemas/items.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "shop": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/item"}
+    },
+    "rare": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/item"}
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "item": {
+      "type": "object",
+      "properties": {
+        "type": {"type": "string"},
+        "name": {"type": "string"},
+        "description": {"type": "string"},
+        "attack_bonus": {"type": "number"},
+        "health_penalty": {"type": "number"},
+        "max_stacks": {"type": "number"},
+        "price": {"type": "number"},
+        "rarity": {"type": "string"},
+        "combos_with": {
+          "type": "array",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        }
+      },
+      "required": ["type", "name"],
+      "additionalProperties": true
+    }
+  }
+}

--- a/tests/test_augments.py
+++ b/tests/test_augments.py
@@ -18,3 +18,16 @@ def test_augment_stacking_rules():
     assert player.apply_augment(aug) is False
     assert player.attack_power == 14
     assert player.max_health == 90
+
+
+def test_augment_description_includes_combos():
+    aug = Augment(
+        "Battle Stim",
+        "Gain +2 attack, lose 5 max health",
+        attack_bonus=2,
+        health_penalty=5,
+        max_stacks=2,
+        combos_with=["Bleed", "Poison"],
+    )
+    desc = aug.describe()
+    assert "Combos with: Bleed, Poison" in desc

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import json
 
 import dungeoncrawler.data as data_module
 from dungeoncrawler.dungeon import DungeonBase

--- a/tests/test_wounds.py
+++ b/tests/test_wounds.py
@@ -1,4 +1,6 @@
+import dungeoncrawler.entities as entities
 from dungeoncrawler.entities import Player
+from dungeoncrawler.config import Config
 
 
 def test_wounds_reduce_and_cleanse():
@@ -8,3 +10,23 @@ def test_wounds_reduce_and_cleanse():
     assert p.max_health == base - 10
     p.cleanse_wounds()
     assert p.max_health == base
+
+
+def test_wound_soft_cap_and_decay(monkeypatch):
+    cfg = Config(
+        wounds_soft_cap_last_n_floors=1,
+        wounds_soft_cap_ratio=0.30,
+        wounds_decay_per_floor=0.5,
+    )
+    monkeypatch.setattr(entities, "config", cfg)
+    p = Player("Hero")
+    base = p.max_health
+    p.apply_wound(10)
+    assert p.wounds == 6
+    assert p.max_health == base - 30
+    p.decay_wounds()
+    assert p.wounds == 3
+    assert p.max_health == base - 15
+    p.apply_wound(10)
+    assert p.wounds == 9
+    assert p.max_health == base - 45


### PR DESCRIPTION
## Summary
- add wound soft-cap and decay configuration and mechanics
- allow augments to declare combo status effects and show hints in UI
- expand items schema and tests for augments and wounds

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a10d167e8c83268654c970d7d9a300