### PR TITLE
Seedable dungeon generation with property-based tests

### DIFF
--- a/dungeoncrawler/entities.py
+++ b/dungeoncrawler/entities.py
@@ -11,15 +11,9 @@ from pathlib import Path
 from .config import config
 from .constants import ANNOUNCER_LINES
 from .items import RARITY_MODIFIERS, Armor, Augment, Item, Trinket, Weapon
-from .status_effects import (
-    add_status_effect,
-    adjust_skill_cost,
-)
+from .status_effects import add_status_effect, adjust_skill_cost
 from .status_effects import apply_status_effects as apply_effects
-from .status_effects import (
-    cleansing_fails,
-    shield_block,
-)
+from .status_effects import cleansing_fails, shield_block
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 
@@ -339,7 +333,7 @@ class Player(Entity):
         cap_ratio = getattr(config, "wounds_soft_cap_ratio", 0) or 0
         window = getattr(config, "wounds_soft_cap_last_n_floors", None)
         if cap_ratio and window:
-            history_sum = sum(self._wound_history[-(window - 1):]) if window > 1 else 0
+            history_sum = sum(self._wound_history[-(window - 1) :]) if window > 1 else 0
             recent = history_sum + self._floor_wound_hp
             cap_hp = int(self.base_max_health * cap_ratio)
             available = max(0, cap_hp - recent)
@@ -369,7 +363,7 @@ class Player(Entity):
             if window <= 1:
                 self._wound_history = []
             elif len(self._wound_history) > window - 1:
-                self._wound_history = self._wound_history[-(window - 1):]
+                self._wound_history = self._wound_history[-(window - 1) :]
         self._floor_wound_hp = 0
         decay = getattr(config, "wounds_decay_per_floor", 0) or 0
         if decay and self.wounds:

--- a/dungeoncrawler/scoring.py
+++ b/dungeoncrawler/scoring.py
@@ -9,7 +9,7 @@ containing the contribution of each component and the final total.  A helper
 """
 
 from dataclasses import dataclass
-from typing import Mapping, Any
+from typing import Any, Mapping
 
 from .config import config
 

--- a/dungeoncrawler/shop.py
+++ b/dungeoncrawler/shop.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from .config import config
 from .constants import INVALID_KEY_MSG
-from .items import Armor, Item, Trinket, Weapon, Augment
+from .items import Armor, Augment, Item, Trinket, Weapon
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from .dungeon import DungeonBase

--- a/dungeoncrawler/tutorial.py
+++ b/dungeoncrawler/tutorial.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from gettext import gettext as _
 from dataclasses import dataclass, field
+from gettext import gettext as _
 
 from .input.keys import Action, get_action
 from .ui.terminal import Renderer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dev = [
   "isort==6.0.1",
   "pytest==8.4.1",
   "jsonschema==4.23.0",
+  "hypothesis==6.112.0",
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ black==24.8.0
 isort==5.13.2
 flake8==7.1.1
 pytest==8.4.1
+hypothesis==6.112.0

--- a/tests/test_boss_loot.py
+++ b/tests/test_boss_loot.py
@@ -2,11 +2,7 @@ import random
 
 from dungeoncrawler import map as dungeon_map
 from dungeoncrawler.data import load_floor_definitions
-from dungeoncrawler.dungeon import (
-    BOSS_LOOT,
-    BOSS_TRAITS,
-    DungeonBase,
-)
+from dungeoncrawler.dungeon import BOSS_LOOT, BOSS_TRAITS, DungeonBase
 from dungeoncrawler.entities import Enemy, Player
 
 

--- a/tests/test_data_loading.py
+++ b/tests/test_data_loading.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-import json
 
 import dungeoncrawler.data as data_module
 from dungeoncrawler.dungeon import DungeonBase

--- a/tests/test_generation_properties.py
+++ b/tests/test_generation_properties.py
@@ -1,16 +1,19 @@
 from collections import deque
 
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from dungeoncrawler import map as dungeon_map
+from dungeoncrawler.data import load_floor_definitions
 from dungeoncrawler.dungeon import DungeonBase
 from dungeoncrawler.entities import Enemy, Player
 from dungeoncrawler.events import BaseEvent
-from dungeoncrawler.data import load_floor_definitions
 
 
 @settings(deadline=None)
-@given(seed=st.integers(min_value=0, max_value=2**32 - 1), floor=st.integers(min_value=1, max_value=18))
+@given(
+    seed=st.integers(min_value=0, max_value=2**32 - 1), floor=st.integers(min_value=1, max_value=18)
+)
 def test_generation_properties(seed, floor):
     load_floor_definitions()
     dungeon = DungeonBase(1, 1, seed=seed)
@@ -32,10 +35,7 @@ def test_generation_properties(seed, floor):
                     queue.append((nx, ny))
 
     carved = {
-        (x, y)
-        for y in range(height)
-        for x in range(width)
-        if dungeon.rooms[y][x] is not None
+        (x, y) for y in range(height) for x in range(width) if dungeon.rooms[y][x] is not None
     }
     assert visited == carved
     assert dungeon.exit_coords in visited
@@ -49,13 +49,9 @@ def test_generation_properties(seed, floor):
     expected_bosses = dungeon.floor_configs[floor].get("boss_slots", 1)
     assert len(bosses) == expected_bosses
 
-    events = [
-        obj for row in dungeon.rooms for obj in row if isinstance(obj, BaseEvent)
-    ]
+    events = [obj for row in dungeon.rooms for obj in row if isinstance(obj, BaseEvent)]
     expected_events = 2 if floor == 1 else 1
     assert len(events) == expected_events
 
-    total_xp = sum(
-        obj.xp for row in dungeon.rooms for obj in row if isinstance(obj, Enemy)
-    )
+    total_xp = sum(obj.xp for row in dungeon.rooms for obj in row if isinstance(obj, Enemy))
     assert total_xp <= dungeon.width * dungeon.height * 2

--- a/tests/test_generation_properties.py
+++ b/tests/test_generation_properties.py
@@ -1,0 +1,61 @@
+from collections import deque
+
+from hypothesis import given, settings, strategies as st
+
+from dungeoncrawler import map as dungeon_map
+from dungeoncrawler.dungeon import DungeonBase
+from dungeoncrawler.entities import Enemy, Player
+from dungeoncrawler.events import BaseEvent
+from dungeoncrawler.data import load_floor_definitions
+
+
+@settings(deadline=None)
+@given(seed=st.integers(min_value=0, max_value=2**32 - 1), floor=st.integers(min_value=1, max_value=18))
+def test_generation_properties(seed, floor):
+    load_floor_definitions()
+    dungeon = DungeonBase(1, 1, seed=seed)
+    dungeon.player = Player("Tester")
+    dungeon_map.generate_dungeon(dungeon, floor)
+
+    start = (dungeon.player.x, dungeon.player.y)
+    width, height = dungeon.width, dungeon.height
+
+    visited = {start}
+    queue = deque([start])
+    while queue:
+        x, y = queue.popleft()
+        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < width and 0 <= ny < height:
+                if dungeon.rooms[ny][nx] is not None and (nx, ny) not in visited:
+                    visited.add((nx, ny))
+                    queue.append((nx, ny))
+
+    carved = {
+        (x, y)
+        for y in range(height)
+        for x in range(width)
+        if dungeon.rooms[y][x] is not None
+    }
+    assert visited == carved
+    assert dungeon.exit_coords in visited
+
+    bosses = [
+        obj
+        for row in dungeon.rooms
+        for obj in row
+        if isinstance(obj, Enemy) and obj.name in dungeon.boss_stats
+    ]
+    expected_bosses = dungeon.floor_configs[floor].get("boss_slots", 1)
+    assert len(bosses) == expected_bosses
+
+    events = [
+        obj for row in dungeon.rooms for obj in row if isinstance(obj, BaseEvent)
+    ]
+    expected_events = 2 if floor == 1 else 1
+    assert len(events) == expected_events
+
+    total_xp = sum(
+        obj.xp for row in dungeon.rooms for obj in row if isinstance(obj, Enemy)
+    )
+    assert total_xp <= dungeon.width * dungeon.height * 2

--- a/tests/test_wounds.py
+++ b/tests/test_wounds.py
@@ -1,6 +1,6 @@
 import dungeoncrawler.entities as entities
-from dungeoncrawler.entities import Player
 from dungeoncrawler.config import Config
+from dungeoncrawler.entities import Player
 
 
 def test_wounds_reduce_and_cleanse():


### PR DESCRIPTION
## Summary
- Allow `DungeonBase` to be seeded and use its own `random.Random`
- Add Hypothesis as a development dependency
- Test dungeon generation properties with Hypothesis

## Testing
- `pip install hypothesis==6.112.0`
- `pytest tests/test_generation_properties.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a13ea0b74883269c05f6d2580f5ecc