### PR TITLE
Add balance simulation and balance matrix tests

### DIFF
--- a/balance_thresholds.yml
+++ b/balance_thresholds.yml
@@ -1,0 +1,25 @@
+matchups:
+  - player_class: Warrior
+    enemy_kind: Bandit
+    floor: 1
+    runs: 200
+    min: 0.25
+    max: 0.40
+  - player_class: Mage
+    enemy_kind: Bandit
+    floor: 1
+    runs: 200
+    min: 0.50
+    max: 0.65
+  - player_class: Rogue
+    enemy_kind: Bandit
+    floor: 1
+    runs: 200
+    min: 0.35
+    max: 0.55
+  - player_class: Cleric
+    enemy_kind: Bandit
+    floor: 1
+    runs: 200
+    min: 0.18
+    max: 0.35

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 pythonpath = .
+markers =
+    balance: balance matrix simulation tests

--- a/tests/test_balance_matrix.py
+++ b/tests/test_balance_matrix.py
@@ -1,5 +1,5 @@
-import yaml
 import pytest
+import yaml
 
 from dungeoncrawler.sim import simulate
 

--- a/tests/test_balance_matrix.py
+++ b/tests/test_balance_matrix.py
@@ -1,0 +1,19 @@
+import yaml
+import pytest
+
+from dungeoncrawler.sim import simulate
+
+with open("balance_thresholds.yml") as f:
+    CONFIG = yaml.safe_load(f)
+
+
+@pytest.mark.balance
+@pytest.mark.parametrize("case", CONFIG["matchups"])
+def test_balance_matrix(case):
+    result = simulate(
+        case["player_class"],
+        case["enemy_kind"],
+        case["floor"],
+        case.get("runs", 100),
+    )
+    assert case["min"] <= result.win_rate <= case["max"]


### PR DESCRIPTION
## Summary
- expose `simulate` in `dungeoncrawler.sim` returning a `SimulationResult` with `win_rate`
- add `balance_thresholds.yml` to configure class vs. enemy win-rate bounds
- test balance matrix using YAML config and mark tests with `balance`

## Testing
- `pytest tests/test_balance_matrix.py -q`
- `pytest` *(fails: test_floor_events.py::test_floor_progression_unlocks_features, test_floor_events.py::test_unlocks_persist_between_runs, test_map.py::test_render_map_snapshot, test_shop.py::test_shop_inventory_deterministic)*

------
https://chatgpt.com/codex/tasks/task_e_68a14269d82c8326af277f0253b125c9