### PR TITLE
Add snapshot tests for intro and map legend text

### DIFF
--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -21,6 +21,16 @@ from .i18n import set_language
 logger = logging.getLogger(__name__)
 
 
+def get_intro_text() -> str:
+    """Return the introductory blurb shown when launching the game."""
+
+    return _(
+        "Welcome to Dungeon Crawler!\n"
+        "Guide your hero through procedurally generated floors filled with monsters,\n"
+        "treasure, and meaningful character choices."
+    )
+
+
 def _load_unlocks():
     unlocks = {"class": False, "guild": False, "race": False}
     max_floor = 0

--- a/dungeoncrawler/map_text.py
+++ b/dungeoncrawler/map_text.py
@@ -1,0 +1,21 @@
+"""Utility functions returning static map-related text."""
+
+from gettext import gettext as _
+
+
+def get_legend_text() -> str:
+    """Return the map legend text shown with the in-game map."""
+
+    return "\n".join(
+        [
+            _("Legend:"),
+            _(" @ - You"),
+            _(" E - Exit"),
+            _(" . - Floor"),
+            _(" · - Discovered"),
+            _("   - Unexplored"),
+        ]
+    )
+
+
+__all__ = ["get_legend_text"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dev = [
   "pytest==8.4.1",
   "jsonschema==4.23.0",
   "hypothesis==6.112.0",
+  "pytest-regressions==2.8.2",
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ isort==5.13.2
 flake8==7.1.1
 pytest==8.4.1
 hypothesis==6.112.0
+pytest-regressions==2.8.2

--- a/tests/test_text_snapshots.py
+++ b/tests/test_text_snapshots.py
@@ -1,0 +1,11 @@
+from dungeoncrawler import main, map_text
+
+
+def test_intro_text_snapshot(file_regression):
+    text = main.get_intro_text()
+    file_regression.check(text, extension=".txt")
+
+
+def test_map_legend_snapshot(file_regression):
+    text = map_text.get_legend_text()
+    file_regression.check(text, extension=".txt")

--- a/tests/test_text_snapshots/test_intro_text_snapshot.txt
+++ b/tests/test_text_snapshots/test_intro_text_snapshot.txt
@@ -1,0 +1,3 @@
+Welcome to Dungeon Crawler!
+Guide your hero through procedurally generated floors filled with monsters,
+treasure, and meaningful character choices.

--- a/tests/test_text_snapshots/test_map_legend_snapshot.txt
+++ b/tests/test_text_snapshots/test_map_legend_snapshot.txt
@@ -1,0 +1,6 @@
+Legend:
+ @ - You
+ E - Exit
+ . - Floor
+ · - Discovered
+   - Unexplored


### PR DESCRIPTION
## Summary
- add `pytest-regressions` to dev dependencies
- expose `get_intro_text` and new `map_text.get_legend_text`
- add snapshot tests and baseline files for intro and map legend text

## Testing
- `pytest tests/test_text_snapshots.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a14fd06ba083269cd90f1490c57b12