### PR TITLE
Log warning when telegraph data missing or invalid

### DIFF
--- a/dungeoncrawler/ai.py
+++ b/dungeoncrawler/ai.py
@@ -1,6 +1,9 @@
 import json
+import logging
 import random
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class AggressiveAI:
@@ -133,8 +136,8 @@ try:
                     "unpredictable": f"{_name} shifts unpredictably.",
                 },
             )
-except FileNotFoundError:
-    pass
+except (FileNotFoundError, json.JSONDecodeError) as _exc:
+    logger.warning("Telegraph data could not be loaded from %s: %s", _floors_path, _exc)
 
 
 # Default archetype weights for enemies that use IntentAI


### PR DESCRIPTION
## Summary
- log warning if telegraph telegraph data file is missing or invalid JSON
- support JSON decoding failures while loading floor telegraphs

## Testing
- `python -m pytest`
- `python dungeon_crawler.py --skip-tutorial` (with `data/floors.json` temporarily removed)

------
https://chatgpt.com/codex/tasks/task_e_68a22ca100648326b174157fe415e339