### PR TITLE
Handle missing or corrupt items data

### DIFF
--- a/dungeoncrawler/data.py
+++ b/dungeoncrawler/data.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -29,6 +30,8 @@ from .items import Armor, Augment, Item, Trinket, Weapon
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 
+logger = logging.getLogger(__name__)
+
 EVENT_CLASS_MAP = {
     cls.__name__: cls
     for cls in [
@@ -53,8 +56,12 @@ EVENT_CLASS_MAP = {
 def load_items() -> Tuple[List[Item], List[Item]]:
     """Load shop and rare loot items from ``items.json``."""
     path = DATA_DIR / "items.json"
-    with open(path, encoding="utf-8") as f:
-        data = json.load(f)
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to load %s: %s", path, exc)
+        return [], []
 
     def make(cfg: Dict) -> Item:
         t = cfg.get("type")

--- a/tests/test_load_items_errors.py
+++ b/tests/test_load_items_errors.py
@@ -1,0 +1,27 @@
+"""Tests for graceful degradation of :func:`load_items`."""
+
+import dungeoncrawler.data as data_module
+
+
+def test_load_items_missing_file(monkeypatch, tmp_path):
+    """``load_items`` should return empty lists if ``items.json`` is absent."""
+
+    monkeypatch.setattr(data_module, "DATA_DIR", tmp_path)
+    data_module.load_items.cache_clear()
+    try:
+        assert data_module.load_items() == ([], [])
+    finally:
+        data_module.load_items.cache_clear()
+
+
+def test_load_items_invalid_json(monkeypatch, tmp_path):
+    """``load_items`` should return empty lists if ``items.json`` is malformed."""
+
+    items_path = tmp_path / "items.json"
+    items_path.write_text("not valid json", encoding="utf-8")
+    monkeypatch.setattr(data_module, "DATA_DIR", tmp_path)
+    data_module.load_items.cache_clear()
+    try:
+        assert data_module.load_items() == ([], [])
+    finally:
+        data_module.load_items.cache_clear()


### PR DESCRIPTION
## Summary
- guard item loading against missing or malformed JSON and log failures
- add regression tests for missing and invalid `items.json`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a22fa14244832681995014318c09b2