### PR TITLE
Ensure union annotations work on older Python

### DIFF
--- a/dungeoncrawler/dungeon.py
+++ b/dungeoncrawler/dungeon.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import importlib
 import json

--- a/dungeoncrawler/i18n.py
+++ b/dungeoncrawler/i18n.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gettext
 import locale
 from pathlib import Path

--- a/dungeoncrawler/main.py
+++ b/dungeoncrawler/main.py
@@ -6,6 +6,8 @@ remembered across runs. Classes unlock on floor 1, guilds on floor 2 and
 races on floor 3.
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging


### PR DESCRIPTION
## Summary
- postpone evaluation of type annotations in dungeon, i18n, and main modules
- avoid runtime TypeErrors in Python < 3.10 when using `int | None`

## Testing
- `pytest -q`
- `pre-commit run --files dungeoncrawler/dungeon.py dungeoncrawler/i18n.py dungeoncrawler/main.py` *(fails: "None" has no attribute ... errors from mypy)*

------
https://chatgpt.com/codex/tasks/task_e_68a2357ebe18832680e632dcd70a297c