### PR TITLE
Add Godot project skeleton with data and mods

### DIFF
--- a/DungeonCrawlerCarl/data/bosses.json
+++ b/DungeonCrawlerCarl/data/bosses.json
@@ -1,0 +1,401 @@
+[ 
+  {
+    "name": "Rat King",
+    "stats": [
+      150,
+      20,
+      8,
+      50
+    ],
+    "ai": {"aggressive": 2, "defensive": 1},
+    "traits": [],
+    "ability": "poison",
+    "loot": [
+      {
+        "name": "Royal Rat Spear",
+        "description": "A spear fashioned from gnawed bones.",
+        "min_damage": 10,
+        "max_damage": 14,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Bone Tyrant",
+    "stats": [
+      250,
+      30,
+      12,
+      120
+    ],
+    "ai": {"aggressive": 3, "defensive": 1, "unpredictable": 1},
+    "traits": ["armored"],
+    "ability": "lifesteal",
+    "loot": [
+      {
+        "name": "Skullcrusher",
+        "description": "A mace adorned with bone fragments.",
+        "min_damage": 24,
+        "max_damage": 32,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Doom Bringer",
+    "stats": [
+      300,
+      38,
+      16,
+      160
+    ],
+    "ai": {"aggressive": 4, "defensive": 1, "unpredictable": 1},
+    "traits": ["berserker"],
+    "ability": "double_strike",
+    "loot": [
+      {
+        "name": "Cataclysm",
+        "description": "Heavy axe with devastating power.",
+        "min_damage": 28,
+        "max_damage": 36,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Ember Lord",
+    "stats": [
+      295,
+      37,
+      16,
+      158
+    ],
+    "ai": {"aggressive": 3, "defensive": 1, "unpredictable": 2},
+    "traits": ["regenerator"],
+    "ability": "burn",
+    "loot": [
+      {
+        "name": "Flame Lash",
+        "description": "Whip of living fire.",
+        "min_damage": 25,
+        "max_damage": 33,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Frost Warden",
+    "stats": [
+      260,
+      28,
+      13,
+      130
+    ],
+    "ai": {"aggressive": 1, "defensive": 3, "unpredictable": 1},
+    "traits": ["armored"],
+    "ability": "freeze",
+    "loot": [
+      {
+        "name": "Glacier Edge",
+        "description": "Chilling blade that slows enemies.",
+        "min_damage": 23,
+        "max_damage": 31,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Glacier Fiend",
+    "stats": [
+      265,
+      29,
+      14,
+      133
+    ],
+    "ai": {"aggressive": 2, "defensive": 2, "unpredictable": 1},
+    "traits": ["regenerator"],
+    "ability": "freeze",
+    "loot": [
+      {
+        "name": "Frozen Talon",
+        "description": "Ice-forged claw that freezes.",
+        "min_damage": 24,
+        "max_damage": 32,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Grave Monarch",
+    "stats": [
+      275,
+      32,
+      15,
+      138
+    ],
+    "ai": {"aggressive": 2, "defensive": 3, "unpredictable": 1},
+    "traits": ["armored"],
+    "ability": "lifesteal",
+    "loot": [
+      {
+        "name": "Cryptblade",
+        "description": "Blade of necrotic energy.",
+        "min_damage": 26,
+        "max_damage": 34,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Inferno Golem",
+    "stats": [
+      270,
+      35,
+      14,
+      140
+    ],
+    "ai": {"aggressive": 3, "defensive": 2, "unpredictable": 1},
+    "traits": ["armored"],
+    "ability": "burn",
+    "loot": [
+      {
+        "name": "Molten Blade",
+        "description": "Red-hot sword that scorches foes.",
+        "min_damage": 26,
+        "max_damage": 34,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Shadow Reaver",
+    "stats": [
+      280,
+      33,
+      15,
+      150
+    ],
+    "ai": {"aggressive": 3, "defensive": 1, "unpredictable": 2},
+    "traits": ["berserker"],
+    "ability": "poison",
+    "loot": [
+      {
+        "name": "Nightfang",
+        "description": "A dagger that thrives in shadows.",
+        "min_damage": 22,
+        "max_damage": 30,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Storm Reaper",
+    "stats": [
+      285,
+      34,
+      15,
+      145
+    ],
+    "ai": {"aggressive": 3, "defensive": 1, "unpredictable": 2},
+    "traits": ["berserker"],
+    "ability": "double_strike",
+    "loot": [
+      {
+        "name": "Thunder Cleaver",
+        "description": "Sword crackling with lightning.",
+        "min_damage": 27,
+        "max_damage": 35,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Void Serpent",
+    "stats": [
+      290,
+      36,
+      17,
+      155
+    ],
+    "ai": {"aggressive": 2, "defensive": 1, "unpredictable": 3},
+    "traits": ["regenerator"],
+    "ability": "poison",
+    "loot": [
+      {
+        "name": "Venom Spire",
+        "description": "Spear coated in lethal toxins.",
+        "min_damage": 24,
+        "max_damage": 32,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Arcane Sentinel",
+    "stats": [
+      300,
+      40,
+      18,
+      170
+    ],
+    "ai": {"aggressive": 3, "defensive": 2, "unpredictable": 1},
+    "traits": ["armored"],
+    "ability": "burn",
+    "loot": [
+      {
+        "name": "Arcblade",
+        "description": "Sword humming with arcane energy.",
+        "min_damage": 27,
+        "max_damage": 35,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Blight Matron",
+    "stats": [
+      305,
+      39,
+      18,
+      172
+    ],
+    "ai": {"aggressive": 2, "defensive": 2, "unpredictable": 2},
+    "traits": ["regenerator"],
+    "ability": "poison",
+    "loot": [
+      {
+        "name": "Toxic Scepter",
+        "description": "Staff dripping with virulent slime.",
+        "min_damage": 25,
+        "max_damage": 33,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Chaos Djinn",
+    "stats": [
+      310,
+      41,
+      19,
+      175
+    ],
+    "ai": {"aggressive": 3, "defensive": 1, "unpredictable": 3},
+    "traits": ["berserker"],
+    "ability": "double_strike",
+    "loot": [
+      {
+        "name": "Chaotic Censer",
+        "description": "Incense burner that spills volatile magic.",
+        "min_damage": 26,
+        "max_damage": 34,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Dread Colossus",
+    "stats": [
+      315,
+      42,
+      20,
+      180
+    ],
+    "ai": {"aggressive": 2, "defensive": 3, "unpredictable": 1},
+    "traits": ["armored"],
+    "ability": "lifesteal",
+    "loot": [
+      {
+        "name": "Colossal Hammer",
+        "description": "Hammer that shakes the earth with each swing.",
+        "min_damage": 28,
+        "max_damage": 36,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Ethereal Harvester",
+    "stats": [
+      320,
+      43,
+      20,
+      185
+    ],
+    "ai": {"aggressive": 3, "defensive": 2, "unpredictable": 2},
+    "traits": ["regenerator"],
+    "ability": "burn",
+    "loot": [
+      {
+        "name": "Soul Reap Scythe",
+        "description": "Scythe that harvests the essence of foes.",
+        "min_damage": 27,
+        "max_damage": 35,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Feral Juggernaut",
+    "stats": [
+      325,
+      44,
+      21,
+      190
+    ],
+    "ai": {"aggressive": 4, "defensive": 1, "unpredictable": 2},
+    "traits": ["berserker"],
+    "ability": "double_strike",
+    "loot": [
+      {
+        "name": "Savage Maul",
+        "description": "Brutal maul that rends armor with ease.",
+        "min_damage": 29,
+        "max_damage": 37,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Gloom Shade",
+    "stats": [
+      330,
+      45,
+      21,
+      195
+    ],
+    "ai": {"aggressive": 2, "defensive": 1, "unpredictable": 4},
+    "traits": ["armored"],
+    "ability": "poison",
+    "loot": [
+      {
+        "name": "Night Veil",
+        "description": "Cloak woven from solid darkness.",
+        "min_damage": 25,
+        "max_damage": 33,
+        "price": 0
+      }
+    ]
+  },
+  {
+    "name": "Hex King",
+    "stats": [
+      335,
+      46,
+      22,
+      200
+    ],
+    "ai": {"aggressive": 3, "defensive": 2, "unpredictable": 3},
+    "traits": ["regenerator"],
+    "ability": "freeze",
+    "loot": [
+      {
+        "name": "Cursed Scepter",
+        "description": "Scepter pulsing with hexed power.",
+        "min_damage": 28,
+        "max_damage": 36,
+        "price": 0
+      }
+    ]
+  }
+]

--- a/DungeonCrawlerCarl/data/companions.json
+++ b/DungeonCrawlerCarl/data/companions.json
@@ -1,0 +1,4 @@
+[
+  {"name": "Battle Priest", "effect": "heal", "heal_amount": 5},
+  {"name": "Hired Blade", "effect": "attack", "attack_power": 5}
+]

--- a/DungeonCrawlerCarl/data/core_enemies.json
+++ b/DungeonCrawlerCarl/data/core_enemies.json
@@ -1,0 +1,37 @@
+{
+  "enemies": [
+    {
+      "name": "Goblin Skirm",
+      "rarity": "common",
+      "stats": {"health": 6, "attack": 3, "defense": 1, "speed": 4},
+      "intents": [
+        {"action": "attack", "message": "Goblin darts forward with a rusty blade."}
+      ]
+    },
+    {
+      "name": "Guard Beetle",
+      "rarity": "common",
+      "stats": {"health": 12, "attack": 2, "defense": 4, "speed": 2},
+      "intents": [
+        {"action": "defend", "message": "Beetle curls into its shell."},
+        {"action": "attack", "message": "Beetle snaps out with its mandibles."}
+      ]
+    },
+    {
+      "name": "Rabid Bat",
+      "rarity": "common",
+      "stats": {"health": 5, "attack": 2, "defense": 0, "speed": 6},
+      "intents": [
+        {"action": "attack", "message": "Bat screeches and dives."}
+      ]
+    },
+    {
+      "name": "Cult Acolyte",
+      "rarity": "rare",
+      "stats": {"health": 8, "attack": 4, "defense": 1, "speed": 3},
+      "intents": [
+        {"action": "attack", "message": "Acolyte begins channeling dark energy."}
+      ]
+    }
+  ]
+}

--- a/DungeonCrawlerCarl/data/core_events.json
+++ b/DungeonCrawlerCarl/data/core_events.json
@@ -1,0 +1,13 @@
+{
+  "fountain": {
+    "rarity": "common",
+    "uses": 2,
+    "bless_chance": 0.3,
+    "curse_chance": 0.1
+  },
+  "locked_cache": {
+    "rarity": "rare",
+    "loot": "credits",
+    "key_name": "cache_key"
+  }
+}

--- a/DungeonCrawlerCarl/data/core_items.json
+++ b/DungeonCrawlerCarl/data/core_items.json
@@ -1,0 +1,14 @@
+{
+  "items": [
+    {
+      "name": "potion",
+      "rarity": "common",
+      "potion_heal": 20
+    },
+    {
+      "name": "elixir",
+      "rarity": "rare",
+      "potion_heal": 50
+    }
+  ]
+}

--- a/DungeonCrawlerCarl/data/enemies.json
+++ b/DungeonCrawlerCarl/data/enemies.json
@@ -1,0 +1,401 @@
+[
+  {
+    "name": "Astral Dragon",
+    "stats": [
+      230,
+      270,
+      32,
+      42,
+      15
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Bandit",
+    "stats": [
+      60,
+      90,
+      8,
+      16,
+      3
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Basilisk",
+    "stats": [
+      130,
+      170,
+      16,
+      26,
+      7
+    ],
+    "ai": {},
+    "traits": [],
+    "ability": "freeze"
+  },
+  {
+    "name": "Beholder",
+    "stats": [
+      210,
+      250,
+      28,
+      38,
+      13
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Cultist",
+    "stats": [
+      75,
+      105,
+      11,
+      18,
+      3
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Cyclops",
+    "stats": [
+      200,
+      240,
+      26,
+      36,
+      12
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Dark Knight",
+    "stats": [
+      180,
+      220,
+      23,
+      31,
+      10
+    ],
+    "ai": {},
+    "traits": [],
+    "ability": "double_strike"
+  },
+  {
+    "name": "Demon",
+    "stats": [
+      130,
+      170,
+      17,
+      28,
+      8
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Gargoyle",
+    "stats": [
+      100,
+      140,
+      12,
+      24,
+      6
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Ghoul",
+    "stats": [
+      80,
+      110,
+      10,
+      17,
+      4
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Giant Spider",
+    "stats": [
+      80,
+      120,
+      11,
+      19,
+      4
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Goblin",
+    "stats": [
+      50,
+      80,
+      7,
+      14,
+      2
+    ],
+    "ai": {
+      "aggressive": 3,
+      "defensive": 1,
+      "unpredictable": 1
+    },
+    "traits": []
+  },
+  {
+    "name": "Harpy",
+    "stats": [
+      80,
+      120,
+      12,
+      20,
+      4
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Hydra",
+    "stats": [
+      190,
+      230,
+      24,
+      34,
+      11
+    ],
+    "ai": {},
+    "traits": [],
+    "ability": "poison"
+  },
+  {
+    "name": "Lich",
+    "stats": [
+      140,
+      180,
+      16,
+      28,
+      7
+    ],
+    "ai": {},
+    "traits": [],
+    "ability": "lifesteal"
+  },
+  {
+    "name": "Minotaur",
+    "stats": [
+      150,
+      190,
+      18,
+      30,
+      8
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Orc",
+    "stats": [
+      90,
+      120,
+      12,
+      20,
+      4
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Phoenix",
+    "stats": [
+      170,
+      210,
+      22,
+      32,
+      10
+    ],
+    "ai": {},
+    "traits": [],
+    "ability": "burn"
+  },
+  {
+    "name": "Revenant",
+    "stats": [
+      160,
+      200,
+      20,
+      30,
+      9
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Shade",
+    "stats": [
+      90,
+      130,
+      13,
+      21,
+      4
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Skeleton",
+    "stats": [
+      70,
+      100,
+      9,
+      16,
+      3
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Slime King",
+    "stats": [
+      140,
+      180,
+      15,
+      23,
+      6
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Troll",
+    "stats": [
+      120,
+      160,
+      15,
+      25,
+      6
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Vampire",
+    "stats": [
+      100,
+      140,
+      12,
+      22,
+      5
+    ],
+    "ai": {},
+    "traits": [],
+    "ability": "lifesteal"
+  },
+  {
+    "name": "Warlock",
+    "stats": [
+      120,
+      160,
+      17,
+      27,
+      6
+    ],
+    "ai": {},
+    "traits": [],
+    "ability": "burn"
+  },
+  {
+    "name": "Werewolf",
+    "stats": [
+      110,
+      150,
+      14,
+      22,
+      5
+    ],
+    "ai": {},
+    "traits": [],
+    "ability": "double_strike"
+  },
+  {
+    "name": "Wraith",
+    "stats": [
+      110,
+      150,
+      14,
+      24,
+      6
+    ],
+    "ai": {},
+    "traits": [],
+    "ability": "poison"
+  },
+  {
+    "name": "Zombie",
+    "stats": [
+      70,
+      110,
+      8,
+      16,
+      3
+    ],
+    "ai": {},
+    "traits": []
+  },
+  {
+    "name": "Spectral Rat",
+    "stats": [
+      40,
+      60,
+      5,
+      12,
+      2
+    ],
+    "ai": {},
+    "traits": ["ethereal"],
+    "ability": "phase"
+  },
+  {
+    "name": "Clockwork Guard",
+    "stats": [
+      120,
+      160,
+      14,
+      24,
+      8
+    ],
+    "ai": {"aggressive": 2, "defensive": 2},
+    "traits": ["mechanical"],
+    "ability": "stun"
+  },
+  {
+    "name": "Fungal Brute",
+    "stats": [
+      150,
+      190,
+      18,
+      26,
+      7
+    ],
+    "ai": {},
+    "traits": ["poisonous"]
+  },
+  {
+    "name": "Broodling",
+    "stats": [
+      20,
+      30,
+      5,
+      10,
+      1
+    ],
+    "ai": {},
+    "traits": ["fire_vulnerable"]
+  }
+]

--- a/DungeonCrawlerCarl/data/events.json
+++ b/DungeonCrawlerCarl/data/events.json
@@ -1,0 +1,15 @@
+{
+  "fountain": {
+    "uses": 2,
+    "bless_chance": 0.3,
+    "curse_chance": 0.1
+  },
+  "shrine": {
+    "prayer_boon_chance": 0.6
+  },
+  "trap": {
+    "detect_base": 0.3,
+    "disarm_cost": 15,
+    "bleed_chance": 0.3
+  }
+}

--- a/DungeonCrawlerCarl/data/events_extended.json
+++ b/DungeonCrawlerCarl/data/events_extended.json
@@ -1,0 +1,25 @@
+{
+  "random": {
+    "MerchantEvent": 1.0,
+    "PuzzleEvent": 1.0,
+    "TrapEvent": 1.0,
+    "FountainEvent": 1.0,
+    "CacheEvent": 1.0,
+    "LoreNoteEvent": 1.0,
+    "ShrineEvent": 1.0,
+    "MiniQuestHookEvent": 1.0,
+    "HazardEvent": 1.0
+  },
+  "dungeon": {
+    "Trap": 3,
+    "Treasure": 3,
+    "Enchantment": 2,
+    "Sanctuary": 2,
+    "Blacksmith": 1
+  },
+  "signature": [
+    "ShrineGauntletEvent",
+    "PuzzleChamberEvent",
+    "EscortMissionEvent"
+  ]
+}

--- a/DungeonCrawlerCarl/data/floors.json
+++ b/DungeonCrawlerCarl/data/floors.json
@@ -1,0 +1,412 @@
+{
+  "1": {
+    "size": [
+      8,
+      8
+    ],
+    "enemies": [
+      "Goblin",
+      "Skeleton",
+      "Bandit"
+    ],
+    "bosses": [
+      "Rat King"
+    ],
+    "places": {
+      "Trap": 2,
+      "Treasure": 2,
+      "Enchantment": 1,
+      "Sanctuary": 1,
+      "Blacksmith": 1
+    },
+    "fountain_rate": 1.0,
+    "cache_rate": 1.0
+  },
+  "2": {
+    "size": [
+      9,
+      9
+    ],
+    "enemies": [
+      "Orc",
+      "Cultist",
+      "Ghoul",
+      "Bandit"
+    ],
+    "bosses": [
+      "Inferno Golem"
+    ],
+    "places": {
+      "Trap": 3,
+      "Treasure": 3,
+      "Enchantment": 1,
+      "Sanctuary": 1,
+      "Blacksmith": 1
+    }
+  },
+  "3": {
+    "size": [
+      10,
+      10
+    ],
+    "enemies": [
+      "Vampire",
+      "Warlock",
+      "Wraith",
+      "Werewolf"
+    ],
+    "bosses": [
+      "Shadow Reaver"
+    ],
+    "places": {
+      "Trap": 3,
+      "Treasure": 4,
+      "Enchantment": 2,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "4": {
+    "size": [
+      11,
+      11
+    ],
+    "enemies": [
+      "Basilisk",
+      "Gargoyle",
+      "Troll",
+      "Lich"
+    ],
+    "bosses": [
+      "Void Serpent"
+    ],
+    "places": {
+      "Trap": 4,
+      "Treasure": 4,
+      "Enchantment": 2,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "5": {
+    "size": [
+      12,
+      12
+    ],
+    "enemies": [
+      "Phoenix",
+      "Hydra",
+      "Revenant",
+      "Beholder"
+    ],
+    "bosses": [
+      "Grave Monarch"
+    ],
+    "places": {
+      "Trap": 4,
+      "Treasure": 5,
+      "Enchantment": 2,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "6": {
+    "size": [
+      13,
+      13
+    ],
+    "enemies": [
+      "Minotaur",
+      "Demon",
+      "Harpy",
+      "Shade"
+    ],
+    "bosses": [
+      "Frost Warden"
+    ],
+    "places": {
+      "Trap": 5,
+      "Treasure": 5,
+      "Enchantment": 2,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "7": {
+    "size": [
+      14,
+      14
+    ],
+    "enemies": [
+      "Giant Spider",
+      "Slime King",
+      "Zombie",
+      "Gargoyle"
+    ],
+    "bosses": [
+      "Ember Lord"
+    ],
+    "places": {
+      "Trap": 5,
+      "Treasure": 6,
+      "Enchantment": 2,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "8": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Dark Knight",
+      "Cyclops",
+      "Basilisk",
+      "Werewolf"
+    ],
+    "bosses": [
+      "Glacier Fiend"
+    ],
+    "places": {
+      "Trap": 5,
+      "Treasure": 6,
+      "Enchantment": 3,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "9": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Hydra",
+      "Beholder",
+      "Revenant",
+      "Warlock"
+    ],
+    "bosses": [
+      "Storm Reaper"
+    ],
+    "places": {
+      "Trap": 6,
+      "Treasure": 6,
+      "Enchantment": 3,
+      "Sanctuary": 2,
+      "Blacksmith": 1
+    }
+  },
+  "10": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Phoenix",
+      "Dark Knight",
+      "Cyclops",
+      "Minotaur"
+    ],
+    "bosses": [
+      "Doom Bringer"
+    ],
+    "places": {
+      "Trap": 6,
+      "Treasure": 7,
+      "Enchantment": 3,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "11": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Astral Dragon",
+      "Demon",
+      "Harpy",
+      "Shade"
+    ],
+    "bosses": [
+      "Arcane Sentinel"
+    ],
+    "places": {
+      "Trap": 7,
+      "Treasure": 7,
+      "Enchantment": 3,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "12": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Giant Spider",
+      "Slime King",
+      "Zombie",
+      "Warlock"
+    ],
+    "bosses": [
+      "Blight Matron"
+    ],
+    "places": {
+      "Trap": 7,
+      "Treasure": 8,
+      "Enchantment": 4,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "13": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Basilisk",
+      "Gargoyle",
+      "Troll",
+      "Lich"
+    ],
+    "bosses": [
+      "Chaos Djinn"
+    ],
+    "places": {
+      "Trap": 8,
+      "Treasure": 8,
+      "Enchantment": 4,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "14": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Hydra",
+      "Beholder",
+      "Revenant",
+      "Dark Knight"
+    ],
+    "bosses": [
+      "Dread Colossus"
+    ],
+    "places": {
+      "Trap": 8,
+      "Treasure": 9,
+      "Enchantment": 4,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "15": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Cyclops",
+      "Astral Dragon",
+      "Phoenix",
+      "Minotaur"
+    ],
+    "bosses": [
+      "Ethereal Harvester"
+    ],
+    "places": {
+      "Trap": 9,
+      "Treasure": 9,
+      "Enchantment": 5,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "16": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Demon",
+      "Harpy",
+      "Shade",
+      "Giant Spider"
+    ],
+    "enemy_pool": [
+      "Harpy",
+      "Harpy",
+      "Shade",
+      "Shade",
+      "Giant Spider",
+      "Giant Spider",
+      "Demon"
+    ],
+    "bosses": [
+      "Feral Juggernaut"
+    ],
+    "places": {
+      "Trap": 9,
+      "Treasure": 10,
+      "Enchantment": 5,
+      "Sanctuary": 3,
+      "Blacksmith": 1
+    }
+  },
+  "17": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Slime King",
+      "Zombie",
+      "Gargoyle",
+      "Warlock"
+    ],
+    "bosses": [
+      "Rat King",
+      "Bone Tyrant",
+      "Gloom Shade"
+    ],
+    "boss_slots": 3,
+    "places": {
+      "Trap": 9,
+      "Treasure": 10,
+      "Enchantment": 5,
+      "Sanctuary": 4,
+      "Blacksmith": 1
+    }
+  },
+  "18": {
+    "size": [
+      15,
+      15
+    ],
+    "enemies": [
+      "Hydra",
+      "Beholder",
+      "Astral Dragon",
+      "Dark Knight"
+    ],
+    "bosses": [
+      "Hex King"
+    ],
+    "boss_slots": 5,
+    "places": {
+      "Trap": 10,
+      "Treasure": 10,
+      "Enchantment": 6,
+      "Sanctuary": 4,
+      "Blacksmith": 1
+    }
+  }
+}

--- a/DungeonCrawlerCarl/data/floors/01_intro.json
+++ b/DungeonCrawlerCarl/data/floors/01_intro.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "01",
+  "name": "Intro",
+  "map": [],
+  "rule_mods": {
+    "water": {"speed_penalty": 0.5, "breath_turns": 3},
+    "moving_walls": true,
+    "merchant_hub": true,
+    "mirror_shadows": true,
+    "noise_meter": {"threshold": 5},
+    "faction_choice": {"options": ["Guild", "Order", "League"]}
+  },
+  "objective": {
+    "type": "boss",
+    "target": "Rat King"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.rat_king",
+    "dungeoncrawler.hooks.water",
+    "dungeoncrawler.hooks.moving_walls",
+    "dungeoncrawler.hooks.merchant_hub",
+    "dungeoncrawler.hooks.mirror_shadows",
+    "dungeoncrawler.hooks.noise_meter",
+    "dungeoncrawler.hooks.faction_choice"
+  ]
+}

--- a/DungeonCrawlerCarl/data/floors/02_floor.json
+++ b/DungeonCrawlerCarl/data/floors/02_floor.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "02",
+  "name": "Floor",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": []
+}

--- a/DungeonCrawlerCarl/data/floors/03_floor.json
+++ b/DungeonCrawlerCarl/data/floors/03_floor.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "03",
+  "name": "Floor",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": []
+}

--- a/DungeonCrawlerCarl/data/floors/04_floor.json
+++ b/DungeonCrawlerCarl/data/floors/04_floor.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "04",
+  "name": "Floor",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": []
+}

--- a/DungeonCrawlerCarl/data/floors/05_floor.json
+++ b/DungeonCrawlerCarl/data/floors/05_floor.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "05",
+  "name": "Floor",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": []
+}

--- a/DungeonCrawlerCarl/data/floors/06_floor.json
+++ b/DungeonCrawlerCarl/data/floors/06_floor.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "06",
+  "name": "Floor",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": []
+}

--- a/DungeonCrawlerCarl/data/floors/07_floor.json
+++ b/DungeonCrawlerCarl/data/floors/07_floor.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "07",
+  "name": "Floor",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": []
+}

--- a/DungeonCrawlerCarl/data/floors/08_floor.json
+++ b/DungeonCrawlerCarl/data/floors/08_floor.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "08",
+  "name": "Floor",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": []
+}

--- a/DungeonCrawlerCarl/data/floors/09_floor.json
+++ b/DungeonCrawlerCarl/data/floors/09_floor.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "09",
+  "name": "Floor",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": []
+}

--- a/DungeonCrawlerCarl/data/floors/10_floor.json
+++ b/DungeonCrawlerCarl/data/floors/10_floor.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "10",
+  "name": "Floor",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": []
+}

--- a/DungeonCrawlerCarl/data/floors/11_floor.json
+++ b/DungeonCrawlerCarl/data/floors/11_floor.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "11",
+  "name": "Floor",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": []
+}

--- a/DungeonCrawlerCarl/data/floors/12_floor.json
+++ b/DungeonCrawlerCarl/data/floors/12_floor.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "12",
+  "name": "Hunted",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor12"
+  ]
+}

--- a/DungeonCrawlerCarl/data/floors/13_floor.json
+++ b/DungeonCrawlerCarl/data/floors/13_floor.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "13",
+  "name": "Anti-Magic",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor13"
+  ]
+}

--- a/DungeonCrawlerCarl/data/floors/14_floor.json
+++ b/DungeonCrawlerCarl/data/floors/14_floor.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "14",
+  "name": "Entropy",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor14"
+  ]
+}

--- a/DungeonCrawlerCarl/data/floors/15_floor.json
+++ b/DungeonCrawlerCarl/data/floors/15_floor.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "15",
+  "name": "Pestilence",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor15"
+  ]
+}

--- a/DungeonCrawlerCarl/data/floors/16_floor.json
+++ b/DungeonCrawlerCarl/data/floors/16_floor.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "16",
+  "name": "Time Weirdness",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor16"
+  ]
+}

--- a/DungeonCrawlerCarl/data/floors/17_floor.json
+++ b/DungeonCrawlerCarl/data/floors/17_floor.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "17",
+  "name": "Oaths & Curses",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor17"
+  ]
+}

--- a/DungeonCrawlerCarl/data/floors/18_final.json
+++ b/DungeonCrawlerCarl/data/floors/18_final.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../schemas/floor.json",
+  "id": "18",
+  "name": "Broadcast Finale",
+  "map": [],
+  "rule_mods": {},
+  "objective": {
+    "type": "none"
+  },
+  "spawns": [],
+  "ui": {},
+  "hooks": [
+    "dungeoncrawler.hooks.floor18"
+  ]
+}

--- a/DungeonCrawlerCarl/data/items.json
+++ b/DungeonCrawlerCarl/data/items.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../schemas/items.json",
+  "shop": [
+    {"type": "Item", "name": "Health Potion", "description": "Restores 20 health", "price": 10, "rarity": "common"},
+    {"type": "Weapon", "name": "Sword", "description": "A sharp sword", "min_damage": 10, "max_damage": 15, "price": 40, "rarity": "common"},
+    {"type": "Weapon", "name": "Axe", "description": "A heavy axe", "min_damage": 12, "max_damage": 18, "price": 65, "rarity": "uncommon"},
+    {"type": "Weapon", "name": "Dagger", "description": "A quick dagger", "min_damage": 8, "max_damage": 12, "price": 35, "rarity": "common"},
+    {"type": "Weapon", "name": "Warhammer", "description": "Crushes armor and bone", "min_damage": 14, "max_damage": 22, "price": 85, "rarity": "rare"},
+    {"type": "Weapon", "name": "Rapier", "description": "A slender, piercing blade", "min_damage": 9, "max_damage": 17, "price": 50, "rarity": "uncommon"},
+    {"type": "Weapon", "name": "Flame Blade", "description": "Glows with searing heat", "min_damage": 13, "max_damage": 20, "price": 95, "rarity": "rare"},
+    {"type": "Weapon", "name": "Crossbow", "description": "Ranged attack with bolts", "min_damage": 11, "max_damage": 19, "price": 60, "rarity": "uncommon"},
+    {"type": "Armor", "name": "Leather Armor", "description": "Basic protection", "defense": 2, "price": 30, "rarity": "common"},
+    {"type": "Trinket", "name": "Lucky Charm", "description": "A charm that brings luck", "effect": "blessed", "price": 25, "rarity": "rare"},
+    {"type": "Item", "name": "Scent-mask Spray", "description": "Masks blood scent, clearing Blood Torrent", "price": 15, "rarity": "common"},
+    {"type": "Item", "name": "Absorbent Gel", "description": "Soaks and removes Blood Torrent", "price": 20, "rarity": "uncommon"},
+    {"type": "Item", "name": "Anti-Nausea Draught", "description": "Removes Compression Sickness", "price": 15, "rarity": "common"},
+    {"type": "Item", "name": "Entropy Vent Stone", "description": "Vents Entropic Debt stacks", "price": 25, "rarity": "uncommon"},
+    {"type": "Item", "name": "Filter Mask", "description": "Negates one Miasma aura", "price": 20, "rarity": "common"},
+    {"type": "Item", "name": "Air Filter", "description": "Blocks one Miasma aura", "price": 30, "rarity": "uncommon"},
+    {"type": "Item", "name": "Anchor", "description": "Clears Temporal Lag", "price": 30, "rarity": "uncommon"},
+    {"type": "Item", "name": "Signal Jammer", "description": "Scrambles Spotlight pings", "price": 30, "rarity": "uncommon"},
+    {"type": "Item", "name": "Smoke Bomb", "description": "Briefly hides you from the Spotlight", "price": 35, "rarity": "uncommon"},
+    {"type": "Item", "name": "Rewrite", "description": "Clears Audience Fatigue stacks", "price": 25, "rarity": "common"},
+    {"type": "Trinket", "name": "Suppression Ring", "description": "Negates Mana Lock but may overheat", "price": 50, "rarity": "rare"},
+    {"type": "Augment", "name": "Battle Stim", "description": "Gain +2 attack, lose 5 max health", "attack_bonus": 2, "health_penalty": 5, "max_stacks": 2, "price": 40, "rarity": "uncommon", "combos_with": ["Bleed", "Poison"]}
+  ],
+  "rare": [
+    {"type": "Weapon", "name": "Elven Longbow", "description": "Bow of unmatched accuracy.", "min_damage": 15, "max_damage": 25, "price": 0, "rarity": "epic"},
+    {"type": "Item", "name": "Blessed Charm", "description": "Said to bring good fortune.", "rarity": "rare"},
+    {"type": "Weapon", "name": "Dwarven Waraxe", "description": "Forged in the deep halls.", "min_damage": 12, "max_damage": 20, "price": 0, "rarity": "epic"},
+    {"type": "Item", "name": "Shadow Cloak", "description": "Grants an air of mystery", "rarity": "rare"}
+  ]
+}

--- a/DungeonCrawlerCarl/data/riddles.json
+++ b/DungeonCrawlerCarl/data/riddles.json
@@ -1,0 +1,42 @@
+[
+  {
+    "question": "What walks on four legs in the morning, two legs at noon, and three legs in the evening?",
+    "answer": "human"
+  },
+  {
+    "question": "I speak without a mouth and hear without ears. I have nobody, but I come alive with wind. What am I?",
+    "answer": "echo"
+  },
+  {
+    "question": "What has keys but can't open locks?",
+    "answer": "piano"
+  },
+  {
+    "question": "What has hands but cannot clap?",
+    "answer": "clock"
+  },
+  {
+    "question": "What has a heart that doesn't beat?",
+    "answer": "artichoke"
+  },
+  {
+    "question": "What can travel around the world while staying in a corner?",
+    "answer": "stamp"
+  },
+  {
+    "question": "What has one eye but cannot see?",
+    "answer": "needle"
+  },
+  {
+    "question": "The more of this there is, the less you see. What is it?",
+    "answer": "darkness"
+  },
+  {
+    "question": "What gets wetter the more it dries?",
+    "answer": "towel"
+  },
+  {
+    "question": "What building has the most stories?",
+    "answer": "library"
+  }
+]

--- a/DungeonCrawlerCarl/data/skills.json
+++ b/DungeonCrawlerCarl/data/skills.json
@@ -1,0 +1,23 @@
+[
+  {
+    "key": "1",
+    "name": "Power Strike",
+    "cost": 30,
+    "base_cooldown": 3,
+    "func": "power_strike"
+  },
+  {
+    "key": "2",
+    "name": "Feint",
+    "cost": 20,
+    "base_cooldown": 4,
+    "func": "feint"
+  },
+  {
+    "key": "3",
+    "name": "Bandage",
+    "cost": 25,
+    "base_cooldown": 5,
+    "func": "bandage"
+  }
+]

--- a/DungeonCrawlerCarl/mods/__init__.py
+++ b/DungeonCrawlerCarl/mods/__init__.py
@@ -1,0 +1,5 @@
+"""Package containing user-created mods.
+
+Mods are discovered at runtime by :mod:`dungeoncrawler.plugins`.
+Each submodule can contribute additional content to the game.
+"""

--- a/DungeonCrawlerCarl/project.godot
+++ b/DungeonCrawlerCarl/project.godot
@@ -1,0 +1,5 @@
+[gd_resource type="ConfigFile" version=5]
+
+[application]
+config/name="DungeonCrawlerCarl"
+


### PR DESCRIPTION
## Summary
- scaffold Godot 4 project `DungeonCrawlerCarl`
- add directories for scenes, scripts, ui, art, data, and mods
- copy existing `data` and `mods` content into the new project

## Testing
- `pre-commit run --files DungeonCrawlerCarl/project.godot DungeonCrawlerCarl/mods/__init__.py $(find DungeonCrawlerCarl/data -type f)`

------
https://chatgpt.com/codex/tasks/task_e_68a39ba9987c83269f9ea1d637cbbd19